### PR TITLE
feat: marker-content multi-dst + yui list overview

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand};
 
 use crate::cmd;
+use crate::config::IconsMode;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -55,6 +56,19 @@ pub enum Command {
     /// Show drift status (link-broken / replaced / template-drift)
     Status,
 
+    /// List all src→dst link mappings (mount entries + .yuilink overrides)
+    List {
+        /// Include entries whose `when` evaluates false on the current host
+        #[arg(long)]
+        all: bool,
+        /// Override [ui] icons mode for this invocation
+        #[arg(long, value_name = "MODE")]
+        icons: Option<IconsMode>,
+        /// Disable color output (also respected via NO_COLOR env)
+        #[arg(long)]
+        no_color: bool,
+    },
+
     /// Manually absorb a target into source (when auto-absorb skipped)
     Absorb {
         target: Utf8PathBuf,
@@ -83,6 +97,11 @@ impl Cli {
             Command::Link { dry_run } => cmd::link(source, dry_run),
             Command::Unlink { paths } => cmd::unlink(source, paths),
             Command::Status => cmd::status(source),
+            Command::List {
+                all,
+                icons,
+                no_color,
+            } => cmd::list(source, all, icons, no_color),
             Command::Absorb { target, dry_run } => cmd::absorb(source, target, dry_run),
             Command::Doctor => cmd::doctor(source),
             Command::GcBackup { older_than } => cmd::gc_backup(source, older_than),

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -3,18 +3,28 @@
 //! Each `Command` variant in `cli.rs` calls one of these. Currently
 //! implemented: `apply`, `init`, `doctor`. The rest are `todo!()`.
 
+use std::fmt::Write as _;
+
 use anyhow::{Context as _, Result};
 use camino::{Utf8Path, Utf8PathBuf};
+use tera::Context as TeraContext;
 use tracing::{info, warn};
 
-use crate::config::{self, Config, MountStrategy};
+use crate::config::{self, Config, IconsMode, MountStrategy};
+use crate::icons::Icons;
 use crate::link::{self, EffectiveDirMode, EffectiveFileMode, resolve_dir_mode, resolve_file_mode};
-use crate::marker;
+use crate::marker::{self, MarkerSpec};
 use crate::mount::{self, ResolvedMount};
 use crate::render::{self, RenderReport};
 use crate::template;
 use crate::vars::YuiVars;
 use crate::{backup, paths};
+
+// NOTE: `owo_colors::OwoColorize` is intentionally NOT imported at module
+// scope — its blanket impl shadows inherent methods of unrelated types
+// (e.g. `ignore::WalkBuilder::hidden(bool)` collides with
+// `OwoColorize::hidden(&self)`). Each print function imports the trait
+// locally with `use owo_colors::OwoColorize as _;`.
 
 pub fn init(source: Option<Utf8PathBuf>, _git_hooks: bool) -> Result<()> {
     let dir = match source {
@@ -54,7 +64,7 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
 
     // 2. Resolve mounts and link.
     let mut engine = template::Engine::new();
-    let tera_ctx = template::config_context(&yui);
+    let tera_ctx = template::template_context(&yui, &config.vars);
     let mounts = mount::resolve(
         &config.mount.entry,
         config.mount.default_strategy,
@@ -79,7 +89,7 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
 
     for m in &mounts {
         info!("mount: {} → {}", m.src, m.dst);
-        process_mount(&source, m, &ctx)?;
+        process_mount(&source, m, &ctx, &mut engine, &tera_ctx)?;
     }
     Ok(())
 }
@@ -109,6 +119,282 @@ struct ApplyCtx<'a> {
     dir_mode: EffectiveDirMode,
     backup_root: &'a Utf8Path,
     dry_run: bool,
+}
+
+/// Show the resolved src→dst mappings for the current source repo.
+///
+/// By default only entries whose `when` matches the current host are shown
+/// (`active`). With `--all`, inactive entries are included with a dim row
+/// and the `when` condition that excluded them.
+pub fn list(
+    source: Option<Utf8PathBuf>,
+    all: bool,
+    icons_override: Option<IconsMode>,
+    no_color: bool,
+) -> Result<()> {
+    let source = resolve_source(source)?;
+    let yui = YuiVars::detect(&source);
+    let config = config::load(&source, &yui)?;
+
+    let icons_mode = icons_override.unwrap_or(config.ui.icons);
+    let icons = Icons::for_mode(icons_mode);
+    let color = !no_color && supports_color_stdout();
+
+    let items = collect_list_items(&source, &config, &yui)?;
+    let displayed: Vec<&ListItem> = if all {
+        items.iter().collect()
+    } else {
+        items.iter().filter(|i| i.active).collect()
+    };
+
+    print_list_table(&displayed, icons, color);
+
+    let total = items.len();
+    let active = items.iter().filter(|i| i.active).count();
+    let inactive = total - active;
+    println!();
+    if all {
+        println!("  {total} entries · {active} active · {inactive} inactive");
+    } else {
+        println!(
+            "  {} of {} entries shown ({} inactive hidden — use --all)",
+            active, total, inactive
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ListItem {
+    src: Utf8PathBuf,
+    dst: String,
+    when: Option<String>,
+    active: bool,
+}
+
+fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Result<Vec<ListItem>> {
+    let mut engine = template::Engine::new();
+    let tera_ctx = template::template_context(yui, &config.vars);
+    let mut items = Vec::new();
+
+    // 1. config.toml [[mount.entry]] entries
+    for entry in &config.mount.entry {
+        let active = match &entry.when {
+            None => true,
+            Some(w) => template::eval_truthy(w, &mut engine, &tera_ctx)?,
+        };
+        let dst = engine
+            .render(&entry.dst, &tera_ctx)
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|_| entry.dst.clone());
+        items.push(ListItem {
+            src: entry.src.clone(),
+            dst,
+            when: entry.when.clone(),
+            active,
+        });
+    }
+
+    // 2. .yuilink overrides under source
+    let walker = ignore::WalkBuilder::new(source)
+        .hidden(false)
+        .git_ignore(false)
+        .ignore(false)
+        .build();
+    let marker_filename = &config.mount.marker_filename;
+    for entry in walker {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            continue;
+        }
+        if entry.path().file_name().and_then(|n| n.to_str()) != Some(marker_filename.as_str()) {
+            continue;
+        }
+        let dir = match entry.path().parent() {
+            Some(d) => d,
+            None => continue,
+        };
+        let dir_utf8 = match Utf8PathBuf::from_path_buf(dir.to_path_buf()) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let spec = match marker::read_spec(&dir_utf8, marker_filename)? {
+            Some(s) => s,
+            None => continue,
+        };
+        let MarkerSpec::Override { links } = spec else {
+            continue; // PassThrough markers are already implied by mount entry
+        };
+        let rel = dir_utf8
+            .strip_prefix(source)
+            .map(Utf8PathBuf::from)
+            .unwrap_or(dir_utf8);
+        for link in &links {
+            let active = match &link.when {
+                None => true,
+                Some(w) => template::eval_truthy(w, &mut engine, &tera_ctx)?,
+            };
+            let dst = engine
+                .render(&link.dst, &tera_ctx)
+                .map(|s| s.trim().to_string())
+                .unwrap_or_else(|_| link.dst.clone());
+            items.push(ListItem {
+                src: rel.clone(),
+                dst,
+                when: link.when.clone(),
+                active,
+            });
+        }
+    }
+
+    items.sort_by(|a, b| a.src.cmp(&b.src).then_with(|| a.dst.cmp(&b.dst)));
+    Ok(items)
+}
+
+fn supports_color_stdout() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none()
+}
+
+fn print_list_table(items: &[&ListItem], icons: Icons, color: bool) {
+    let src_w = items
+        .iter()
+        .map(|i| i.src.as_str().chars().count())
+        .max()
+        .unwrap_or(0)
+        .max("SRC".len());
+    let dst_w = items
+        .iter()
+        .map(|i| i.dst.chars().count())
+        .max()
+        .unwrap_or(0)
+        .max("DST".len());
+
+    let status_w = "STATUS".len();
+    let arrow_w = icons.arrow.chars().count();
+
+    // Header
+    print_header(status_w, src_w, arrow_w, dst_w, color);
+
+    // Separator
+    let sep = render_separator(icons.sep, status_w, src_w, arrow_w, dst_w);
+    if color {
+        use owo_colors::OwoColorize as _;
+        println!("{}", sep.dimmed());
+    } else {
+        println!("{sep}");
+    }
+
+    // Rows
+    for item in items {
+        print_row(item, icons, status_w, src_w, arrow_w, dst_w, color);
+    }
+}
+
+fn print_header(status_w: usize, src_w: usize, arrow_w: usize, dst_w: usize, color: bool) {
+    use owo_colors::OwoColorize as _;
+    let mut line = String::new();
+    let _ = write!(
+        &mut line,
+        "  {:<status_w$}  {:<src_w$}  {:<arrow_w$}  {:<dst_w$}  WHEN",
+        "STATUS", "SRC", "", "DST"
+    );
+    if color {
+        println!("{}", line.bold());
+    } else {
+        println!("{line}");
+    }
+}
+
+fn render_separator(
+    sep_ch: char,
+    status_w: usize,
+    src_w: usize,
+    arrow_w: usize,
+    dst_w: usize,
+) -> String {
+    let bar = |n: usize| sep_ch.to_string().repeat(n);
+    format!(
+        "  {}  {}  {}  {}  {}",
+        bar(status_w),
+        bar(src_w),
+        bar(arrow_w),
+        bar(dst_w),
+        bar("WHEN".len())
+    )
+}
+
+fn print_row(
+    item: &ListItem,
+    icons: Icons,
+    status_w: usize,
+    src_w: usize,
+    arrow_w: usize,
+    dst_w: usize,
+    color: bool,
+) {
+    use owo_colors::OwoColorize as _;
+    let status = if item.active {
+        icons.active
+    } else {
+        icons.inactive
+    };
+    let when_str = item
+        .when
+        .as_deref()
+        .map(strip_braces)
+        .unwrap_or_else(|| "(always)".to_string());
+
+    // Normalize backslashes to forward slashes for cross-platform display.
+    let src_display = item.src.as_str().replace('\\', "/");
+    let src = src_display.as_str();
+    let dst = &item.dst;
+    let arrow = icons.arrow;
+
+    if !color {
+        println!(
+            "  {:<status_w$}  {:<src_w$}  {:<arrow_w$}  {:<dst_w$}  {when_str}",
+            status, src, arrow, dst
+        );
+        return;
+    }
+
+    if item.active {
+        println!(
+            "  {:<status_w$}  {:<src_w$}  {:<arrow_w$}  {:<dst_w$}  {}",
+            status.green().to_string(),
+            src.cyan().to_string(),
+            arrow.dimmed().to_string(),
+            dst.green().to_string(),
+            when_str.dimmed()
+        );
+    } else {
+        println!(
+            "  {:<status_w$}  {:<src_w$}  {:<arrow_w$}  {:<dst_w$}  {}",
+            status.red().dimmed().to_string(),
+            src.dimmed().to_string(),
+            arrow.dimmed().to_string(),
+            dst.dimmed().to_string(),
+            when_str.dimmed()
+        );
+    }
+}
+
+/// Strip the outer `{{ ... }}` Tera braces from a `when` expression for
+/// display purposes (shorter line, easier to read at a glance).
+fn strip_braces(expr: &str) -> String {
+    let trimmed = expr.trim();
+    if let Some(inner) = trimmed
+        .strip_prefix("{{")
+        .and_then(|s| s.strip_suffix("}}"))
+    {
+        inner.trim().to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 pub fn render(source: Option<Utf8PathBuf>, check: bool, dry_run: bool) -> Result<()> {
@@ -193,13 +479,19 @@ pub fn gc_backup(_source: Option<Utf8PathBuf>, _older_than: Option<String>) -> R
 // internals
 // ---------------------------------------------------------------------------
 
-fn process_mount(source: &Utf8Path, m: &ResolvedMount, ctx: &ApplyCtx<'_>) -> Result<()> {
+fn process_mount(
+    source: &Utf8Path,
+    m: &ResolvedMount,
+    ctx: &ApplyCtx<'_>,
+    engine: &mut template::Engine,
+    tera_ctx: &TeraContext,
+) -> Result<()> {
     let src_root = source.join(&m.src);
     if !src_root.is_dir() {
         warn!("mount src missing: {src_root}");
         return Ok(());
     }
-    walk_and_link(&src_root, &m.dst, ctx, m.strategy)
+    walk_and_link(&src_root, &m.dst, ctx, m.strategy, engine, tera_ctx)
 }
 
 fn walk_and_link(
@@ -207,12 +499,37 @@ fn walk_and_link(
     dst_dir: &Utf8Path,
     ctx: &ApplyCtx<'_>,
     strategy: MountStrategy,
+    engine: &mut template::Engine,
+    tera_ctx: &TeraContext,
 ) -> Result<()> {
     let marker_filename = &ctx.config.mount.marker_filename;
 
-    if strategy == MountStrategy::Marker && marker::is_marker_dir(src_dir, marker_filename) {
-        link_dir_with_backup(src_dir, dst_dir, ctx)?;
-        return Ok(());
+    if strategy == MountStrategy::Marker {
+        match marker::read_spec(src_dir, marker_filename)? {
+            None => {} // no marker — fall through to recursive walk
+            Some(MarkerSpec::PassThrough) => {
+                link_dir_with_backup(src_dir, dst_dir, ctx)?;
+                return Ok(());
+            }
+            Some(MarkerSpec::Override { links }) => {
+                let mut linked_any = false;
+                for link in &links {
+                    if let Some(when) = &link.when
+                        && !template::eval_truthy(when, engine, tera_ctx)?
+                    {
+                        continue;
+                    }
+                    let dst_str = engine.render(&link.dst, tera_ctx)?;
+                    let dst = Utf8PathBuf::from(dst_str.trim());
+                    link_dir_with_backup(src_dir, &dst, ctx)?;
+                    linked_any = true;
+                }
+                if !linked_any {
+                    info!("marker override at {src_dir} had no active links — skipping");
+                }
+                return Ok(());
+            }
+        }
     }
 
     for entry in std::fs::read_dir(src_dir)? {
@@ -225,7 +542,7 @@ fn walk_and_link(
             continue;
         }
         if name.ends_with(".tera") {
-            // Templates handled by render flow (not implemented yet).
+            // Templates are handled by the render flow before linking.
             continue;
         }
 
@@ -234,7 +551,7 @@ fn walk_and_link(
         let ft = entry.file_type()?;
 
         if ft.is_dir() {
-            walk_and_link(&src_path, &dst_path, ctx, strategy)?;
+            walk_and_link(&src_path, &dst_path, ctx, strategy, engine, tera_ctx)?;
         } else if ft.is_file() {
             link_file_with_backup(&src_path, &dst_path, ctx)?;
         }
@@ -346,7 +663,9 @@ dst = "{{ env(name='HOME') | default(value=env(name='USERPROFILE')) }}"
 # [[mount.entry]]
 # src  = "appdata"
 # dst  = "{{ env(name='APPDATA') }}"
-# when = "{{ yui.os == 'windows' }}"
+# # NOTE: write `when` as a *bare* expression (no `{{ … }}`) so it survives
+# # config.toml's whole-file Tera render and shows up cleanly in `yui list`.
+# when = "yui.os == 'windows'"
 "#;
 
 const SKELETON_GITIGNORE: &str = r#"# yui internals (regenerable, do not commit)
@@ -494,6 +813,151 @@ dst = "{}"
         // Rendered file content carries the yui.os substitution.
         let linked = std::fs::read_to_string(target.join(".gitconfig")).unwrap();
         assert!(linked.contains("os = "));
+    }
+
+    #[test]
+    fn apply_marker_override_links_to_custom_dst() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        let target_a = utf8(tmp.path().join("target_a"));
+        let target_b = utf8(tmp.path().join("target_b"));
+        std::fs::create_dir_all(source.join("home/.config/nvim")).unwrap();
+        std::fs::create_dir_all(&target_a).unwrap();
+        std::fs::create_dir_all(&target_b).unwrap();
+        std::fs::write(
+            source.join("home/.config/nvim/init.lua"),
+            "-- nvim config\n",
+        )
+        .unwrap();
+
+        // Marker tells yui to ignore the parent mount's dst for this dir
+        // and link it to two custom places (the second only if condition matches).
+        std::fs::write(
+            source.join("home/.config/nvim/.yuilink"),
+            format!(
+                r#"
+[[link]]
+dst = "{}/nvim"
+
+[[link]]
+dst = "{}/nvim"
+when = "{{{{ yui.os == '{}' }}}}"
+"#,
+                toml_path(&target_a),
+                toml_path(&target_b),
+                std::env::consts::OS
+            ),
+        )
+        .unwrap();
+
+        let parent_target = utf8(tmp.path().join("parent_target"));
+        std::fs::create_dir_all(&parent_target).unwrap();
+        let cfg = format!(
+            r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+            toml_path(&parent_target)
+        );
+        std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+        apply(Some(source.clone()), false).unwrap();
+
+        // Both override targets received the link (the second's when matches OS).
+        assert!(
+            target_a.join("nvim/init.lua").exists(),
+            "target_a/nvim/init.lua should be reachable through the link"
+        );
+        assert!(
+            target_b.join("nvim/init.lua").exists(),
+            "target_b/nvim/init.lua should be reachable through the link"
+        );
+        // Parent mount did NOT also link this dir (it would have appeared at
+        // parent_target/.config/nvim — the marker claims the dir).
+        assert!(
+            !parent_target.join(".config/nvim").exists(),
+            "parent mount should have skipped the marker-claimed sub-dir"
+        );
+    }
+
+    #[test]
+    fn apply_marker_override_skips_inactive_link() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        let target_inactive = utf8(tmp.path().join("inactive"));
+        let parent_target = utf8(tmp.path().join("parent"));
+        std::fs::create_dir_all(source.join("home/.config/nvim")).unwrap();
+        std::fs::create_dir_all(&parent_target).unwrap();
+        std::fs::write(source.join("home/.config/nvim/init.lua"), "x").unwrap();
+
+        // when=false on every link → marker has no active links.
+        std::fs::write(
+            source.join("home/.config/nvim/.yuilink"),
+            format!(
+                r#"
+[[link]]
+dst = "{}/nvim"
+when = "{{{{ yui.os == 'no-such-os' }}}}"
+"#,
+                toml_path(&target_inactive)
+            ),
+        )
+        .unwrap();
+
+        let cfg = format!(
+            r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+            toml_path(&parent_target)
+        );
+        std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+        apply(Some(source.clone()), false).unwrap();
+
+        // Inactive target untouched.
+        assert!(!target_inactive.join("nvim").exists());
+        // Parent mount also skipped the dir (marker claims it even when
+        // all links are inactive — the user's intent was per-dir override).
+        assert!(!parent_target.join(".config/nvim").exists());
+    }
+
+    #[test]
+    fn list_shows_mount_entries_and_marker_overrides() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        std::fs::create_dir_all(source.join("home/.config/nvim")).unwrap();
+        std::fs::write(source.join("home/.config/nvim/init.lua"), "x").unwrap();
+        std::fs::write(
+            source.join("home/.config/nvim/.yuilink"),
+            r#"
+[[link]]
+dst = "/custom/nvim"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            source.join("config.toml"),
+            r#"
+[[mount.entry]]
+src = "home"
+dst = "/h"
+"#,
+        )
+        .unwrap();
+
+        // Just verify it runs without error — output format is covered by
+        // unit-level helpers below.
+        list(Some(source), false, None, true).unwrap();
+    }
+
+    #[test]
+    fn strip_braces_removes_outer_template_braces() {
+        assert_eq!(strip_braces("{{ yui.os == 'linux' }}"), "yui.os == 'linux'");
+        assert_eq!(strip_braces("yui.os == 'linux'"), "yui.os == 'linux'");
+        assert_eq!(strip_braces("  {{x}}  "), "x");
     }
 
     #[test]

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -354,30 +354,36 @@ fn print_row(
     let dst = &item.dst;
     let arrow = icons.arrow;
 
+    // Pad each cell to its column width FIRST, then apply color. Doing it
+    // the other way round lets ANSI escape codes count as printable chars
+    // in `format!("{:<w$}")`, which silently breaks alignment when colors
+    // are enabled (caught in PR #11 review).
+    let cell_status = format!("{:<status_w$}", status);
+    let cell_src = format!("{:<src_w$}", src);
+    let cell_arrow = format!("{:<arrow_w$}", arrow);
+    let cell_dst = format!("{:<dst_w$}", dst);
+
     if !color {
-        println!(
-            "  {:<status_w$}  {:<src_w$}  {:<arrow_w$}  {:<dst_w$}  {when_str}",
-            status, src, arrow, dst
-        );
+        println!("  {cell_status}  {cell_src}  {cell_arrow}  {cell_dst}  {when_str}");
         return;
     }
 
     if item.active {
         println!(
-            "  {:<status_w$}  {:<src_w$}  {:<arrow_w$}  {:<dst_w$}  {}",
-            status.green().to_string(),
-            src.cyan().to_string(),
-            arrow.dimmed().to_string(),
-            dst.green().to_string(),
+            "  {}  {}  {}  {}  {}",
+            cell_status.green(),
+            cell_src.cyan(),
+            cell_arrow.dimmed(),
+            cell_dst.green(),
             when_str.dimmed()
         );
     } else {
         println!(
-            "  {:<status_w$}  {:<src_w$}  {:<arrow_w$}  {:<dst_w$}  {}",
-            status.red().dimmed().to_string(),
-            src.dimmed().to_string(),
-            arrow.dimmed().to_string(),
-            dst.dimmed().to_string(),
+            "  {}  {}  {}  {}  {}",
+            cell_status.red().dimmed(),
+            cell_src.dimmed(),
+            cell_arrow.dimmed(),
+            cell_dst.dimmed(),
             when_str.dimmed()
         );
     }
@@ -514,10 +520,13 @@ fn walk_and_link(
             Some(MarkerSpec::Override { links }) => {
                 let mut linked_any = false;
                 for link in &links {
-                    if let Some(when) = &link.when
-                        && !template::eval_truthy(when, engine, tera_ctx)?
-                    {
-                        continue;
+                    // Nested ifs (not let-chains) so the crate's MSRV
+                    // (rust-version = "1.85") stays buildable; let-chains
+                    // were stabilized in 1.88.
+                    if let Some(when) = &link.when {
+                        if !template::eval_truthy(when, engine, tera_ctx)? {
+                            continue;
+                        }
                     }
                     let dst_str = engine.render(&link.dst, tera_ctx)?;
                     let dst = Utf8PathBuf::from(dst_str.trim());

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,27 @@ pub struct Config {
 
     #[serde(default)]
     pub backup: BackupConfig,
+
+    #[serde(default)]
+    pub ui: UiConfig,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct UiConfig {
+    #[serde(default)]
+    pub icons: IconsMode,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum IconsMode {
+    /// `✓ ✗ → ─` — works on any terminal that renders basic Unicode (default).
+    #[default]
+    Unicode,
+    /// Nerd Font glyphs (`  →`) — requires a Nerd-Font-patched terminal font.
+    Nerd,
+    /// `[+] [-] -> -` — pure ASCII, for CI logs / SSH-into-legacy-tty.
+    Ascii,
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,0 +1,45 @@
+//! Icon character sets for terminal output.
+//!
+//! Three modes (see [`crate::config::IconsMode`]):
+//!   - `Unicode` (default): `✓ ✗ → ─` — universally renderable
+//!   - `Nerd`: Nerd-Font glyphs — requires a patched font
+//!   - `Ascii`: `[+] [-] -> -` — pure ASCII fallback for CI logs
+
+use crate::config::IconsMode;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Icons {
+    pub active: &'static str,
+    pub inactive: &'static str,
+    pub arrow: &'static str,
+    pub sep: char,
+}
+
+impl Icons {
+    pub const UNICODE: Self = Self {
+        active: "\u{2713}",   // ✓
+        inactive: "\u{2717}", // ✗
+        arrow: "\u{2192}",    // →
+        sep: '\u{2500}',      // ─
+    };
+    pub const NERD: Self = Self {
+        active: "\u{f058}",   //   nf-fa-check_circle
+        inactive: "\u{f057}", //   nf-fa-times_circle
+        arrow: "\u{2192}",    // → (no need for a special arrow glyph)
+        sep: '\u{2500}',      // ─
+    };
+    pub const ASCII: Self = Self {
+        active: "[+]",
+        inactive: "[-]",
+        arrow: "->",
+        sep: '-',
+    };
+
+    pub const fn for_mode(mode: IconsMode) -> Self {
+        match mode {
+            IconsMode::Unicode => Self::UNICODE,
+            IconsMode::Nerd => Self::NERD,
+            IconsMode::Ascii => Self::ASCII,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod cmd;
 pub mod config;
 pub mod error;
+pub mod icons;
 pub mod link;
 pub mod marker;
 pub mod mount;

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -1,11 +1,159 @@
-//! `.yuilink` marker file detection.
+//! `.yuilink` marker file detection + parsing.
 //!
-//! Under `marker` strategy, a directory containing the configured marker file
-//! (default `.yuilink`) is the link point — `yui` creates a single
-//! junction/symlink for that directory and stops recursing.
+//! Two forms are accepted:
+//!   - **empty file** → "junction this dir at the parent mount's dst"
+//!     (the original presence-only marker semantics)
+//!   - **TOML with `[[link]]` entries** → "junction this dir at each
+//!     entry's `dst`, when filtered" — overrides the parent mount's dst.
+//!
+//! ```toml
+//! # $DOTFILES/home/.config/nvim/.yuilink
+//! [[link]]
+//! dst = "{{ env(name='HOME') }}/.config/nvim"
+//!
+//! [[link]]
+//! dst = "{{ env(name='LOCALAPPDATA') }}/nvim"
+//! when = "{{ yui.os == 'windows' }}"
+//! ```
 
 use camino::Utf8Path;
+use serde::Deserialize;
 
+use crate::{Error, Result};
+
+#[derive(Debug, Clone)]
+pub enum MarkerSpec {
+    /// Empty marker — link this dir using the parent mount's dst.
+    PassThrough,
+    /// Per-dir override; each entry produces a link (after `when` filter).
+    /// The parent mount's dst is bypassed for this directory.
+    Override { links: Vec<MarkerLink> },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MarkerLink {
+    pub dst: String,
+    #[serde(default)]
+    pub when: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct MarkerFile {
+    #[serde(default)]
+    link: Vec<MarkerLink>,
+}
+
+/// Read and parse a `.yuilink` from `dir`.
+///
+/// Returns:
+///   - `Ok(None)` — no marker file present
+///   - `Ok(Some(PassThrough))` — present and empty / whitespace-only / no `[[link]]`
+///   - `Ok(Some(Override { ... }))` — present with `[[link]]` entries
+///   - `Err(_)` — present but malformed TOML, or other IO error
+pub fn read_spec(dir: &Utf8Path, marker_filename: &str) -> Result<Option<MarkerSpec>> {
+    let path = dir.join(marker_filename);
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(Error::Io(e)),
+    };
+    if raw.trim().is_empty() {
+        return Ok(Some(MarkerSpec::PassThrough));
+    }
+    let parsed: MarkerFile =
+        toml::from_str(&raw).map_err(|e| Error::Config(format!("parse {path}: {e}")))?;
+    if parsed.link.is_empty() {
+        return Ok(Some(MarkerSpec::PassThrough));
+    }
+    Ok(Some(MarkerSpec::Override { links: parsed.link }))
+}
+
+/// Presence-only check: any `.yuilink` file (empty or with content) counts.
+/// Kept for callers that don't need the spec contents.
 pub fn is_marker_dir(dir: &Utf8Path, marker_filename: &str) -> bool {
     dir.join(marker_filename).is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+
+    fn root(tmp: &TempDir) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap()
+    }
+
+    #[test]
+    fn no_marker_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        assert!(read_spec(&root(&tmp), ".yuilink").unwrap().is_none());
+    }
+
+    #[test]
+    fn empty_marker_is_passthrough() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".yuilink"), "").unwrap();
+        assert!(matches!(
+            read_spec(&root(&tmp), ".yuilink").unwrap(),
+            Some(MarkerSpec::PassThrough)
+        ));
+    }
+
+    #[test]
+    fn whitespace_only_marker_is_passthrough() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".yuilink"), "  \n\n").unwrap();
+        assert!(matches!(
+            read_spec(&root(&tmp), ".yuilink").unwrap(),
+            Some(MarkerSpec::PassThrough)
+        ));
+    }
+
+    #[test]
+    fn marker_with_links_is_override() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join(".yuilink"),
+            r#"
+[[link]]
+dst = "/a"
+
+[[link]]
+dst = "/b"
+when = "{{ yui.os == 'windows' }}"
+"#,
+        )
+        .unwrap();
+        let spec = read_spec(&root(&tmp), ".yuilink").unwrap().unwrap();
+        match spec {
+            MarkerSpec::Override { links } => {
+                assert_eq!(links.len(), 2);
+                assert_eq!(links[0].dst, "/a");
+                assert!(links[0].when.is_none());
+                assert_eq!(links[1].dst, "/b");
+                assert_eq!(links[1].when.as_deref(), Some("{{ yui.os == 'windows' }}"));
+            }
+            _ => panic!("expected Override"),
+        }
+    }
+
+    #[test]
+    fn marker_with_invalid_toml_errors() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".yuilink"), "this is not toml ===").unwrap();
+        let err = read_spec(&root(&tmp), ".yuilink").unwrap_err();
+        assert!(format!("{err}").contains("parse"));
+    }
+
+    #[test]
+    fn empty_link_array_is_passthrough() {
+        // Has a [[link]] header but no entries (rare but valid TOML).
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".yuilink"), "# no links\n").unwrap();
+        assert!(matches!(
+            read_spec(&root(&tmp), ".yuilink").unwrap(),
+            Some(MarkerSpec::PassThrough)
+        ));
+    }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -229,21 +229,9 @@ fn split_yui_when(raw: &str) -> Option<(&str, &str)> {
     Some((expr, &raw[body_start..]))
 }
 
-/// Evaluate a Tera expression as a truthy/falsy boolean. Accepts either a
-/// bare expression (`yui.os == 'linux'`) or a pre-wrapped one
-/// (`{{ yui.os == 'linux' }}`); used for both file-header `yui:when` and
-/// config `[[render.rule]] when` to keep the user-facing forms consistent
-/// with `[[mount.entry]] when` (which the user writes wrapped).
+/// Local alias for [`template::eval_truthy`] to keep call sites short.
 fn eval_when(expr: &str, engine: &mut Engine, ctx: &TeraContext) -> Result<bool> {
-    let trimmed = expr.trim_start();
-    let to_render = if trimmed.starts_with("{{") || trimmed.starts_with("{%") {
-        expr.to_string()
-    } else {
-        format!("{{{{ {expr} }}}}")
-    };
-    let out = engine.render(&to_render, ctx)?;
-    let s = out.trim();
-    Ok(s.eq_ignore_ascii_case("true") || s == "1")
+    template::eval_truthy(expr, engine, ctx)
 }
 
 fn template_target(template_path: &Utf8Path) -> Utf8PathBuf {

--- a/src/template.rs
+++ b/src/template.rs
@@ -66,6 +66,22 @@ pub fn template_context<V: Serialize>(yui: &YuiVars, vars: &V) -> Context {
     ctx
 }
 
+/// Evaluate a Tera expression as a truthy/falsy boolean. Accepts either a
+/// bare expression (`yui.os == 'linux'`) or a pre-wrapped one
+/// (`{{ yui.os == 'linux' }}`); used wherever the user writes a `when`
+/// condition (mount entry, render rule, marker link, file-header).
+pub fn eval_truthy(expr: &str, engine: &mut Engine, ctx: &Context) -> Result<bool> {
+    let trimmed = expr.trim_start();
+    let to_render = if trimmed.starts_with("{{") || trimmed.starts_with("{%") {
+        expr.to_string()
+    } else {
+        format!("{{{{ {expr} }}}}")
+    };
+    let out = engine.render(&to_render, ctx)?;
+    let s = out.trim();
+    Ok(s.eq_ignore_ascii_case("true") || s == "1")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Adds the *one src → many dst* feature requested by the user (same source
dir linking to different targets on different OSes — e.g. nvim config
landing at `~/.config/nvim` on Unix and `%LOCALAPPDATA%/nvim` on
Windows) **and** a `yui list` overview so the resulting fan-out stays
discoverable.

### `.yuilink` gets content

```toml
# $DOTFILES/home/.config/nvim/.yuilink
[[link]]
dst = "{{ env(name='HOME') }}/.config/nvim"

[[link]]
dst = "{{ env(name='LOCALAPPDATA') }}/nvim"
when = "yui.os == 'windows'"
```

- Empty `.yuilink` keeps the existing presence-only semantics (junction
  at parent mount's dst).
- `[[link]]` entries override the parent mount — each matching `dst` is
  a junction target; parent walk skips the dir.
- Malformed TOML fails loudly with the path included.

### `yui list`

```
  STATUS  SRC                   DST                            WHEN
  ──────  ─────────────────  ─  ─────────────────────────────  ────
  ✓       appdata            →  C:/Users/u/AppData/Roaming     yui.os == 'windows'
  ✓       home/.config/nvim  →  /home/u/.config/nvim           (always)
  ✓       home/.config/nvim  →  C:/Users/u/AppData/Local/nvim  yui.os == 'windows'

  3 of 4 entries shown (1 inactive hidden — use --all)
```

- Lists every mount entry + `.yuilink` override with active/inactive
  status.
- 3 icon modes: `unicode` (default), `nerd`, `ascii`. Settable in
  `[ui] icons` or per invocation via `--icons`.
- Color via `owo-colors`, TTY-detected, honours `NO_COLOR`, has
  `--no-color`.
- Default shows only links that would activate on this host;
  `--all` reveals inactive ones with their `when` reason.

### Other

- `template::eval_truthy` extracted from `render::eval_when` so mount,
  render, marker, and list share one bare-or-wrapped truthy convention.
- mount/marker `dst` Tera ctx now includes `vars.*` (uniform with
  template render).
- `init` skeleton recommends bare `when = "yui.os == 'windows'"` so the
  expression survives whole-file Tera render and shows usefully in
  `list` (wrapped form pre-evaluates to `"true"`/`"false"` and loses
  the original meaning — separate issue, fixable with schema-aware
  rendering later).
- src paths normalized to `/` in `list` output for cross-platform
  consistency.

## Test plan

- [x] `cargo make check` clean (fmt / clippy / test / locked build)
- [x] 65 unit tests passing (7 new: 5 marker, 2 cmd marker behaviour,
      list smoke test, strip_braces)
- [x] Manual demo of `yui list` in all 3 icon modes + active/inactive
      filter
- [ ] CI on `feat/0.2-marker-multidst-list` (waiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `list` CLI subcommand displaying all link mappings with active/inactive status indicators.
  * Supports `--all` (include inactive links), `--icons` (override icon style), and `--no-color` (plain text) options.
  * Introduced `[ui]` configuration section to customize terminal icon style: unicode (default), nerd, or ascii.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->