### PR TITLE
feat(paths): tilde expansion for cross-platform home

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,13 @@ git_email = "you@example.com"
 
 [[mount.entry]]
 src = "home"
-dst = "{{ env(name='HOME') | default(value=env(name='USERPROFILE')) }}"
+# `~` expands to $HOME on Unix and $USERPROFILE on Windows — use it freely.
+dst = "~"
 
 [[mount.entry]]
 src  = "appdata"
 dst  = "{{ env(name='APPDATA') }}"
-when = "{{ yui.os == 'windows' }}"
+when = "yui.os == 'windows'"
 ```
 
 `config.local.toml` (gitignored) is for machine-local overrides:
@@ -77,7 +78,10 @@ git_email = "you@work.example"
 
 Built-in variables exposed to Tera: `yui.os`, `yui.host`, `yui.user`,
 `yui.arch`, `yui.source`. Environment variables are read with
-`{{ env(name='HOME') }}` (Tera's standard function).
+`{{ env(name='HOME') }}`. Path values (in `dst`, `--source`, `YUI_SOURCE`,
+`.yuilink` `[[link]] dst`, etc.) accept a leading `~` / `~/...` which
+expands to `$HOME` (or `$USERPROFILE` on Windows) at apply time —
+`dst = "~/.config/foo"` Just Works™ across platforms.
 
 ## Status
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -185,7 +185,7 @@ fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Resu
         };
         let dst = engine
             .render(&entry.dst, &tera_ctx)
-            .map(|s| s.trim().to_string())
+            .map(|s| paths::expand_tilde(s.trim()).to_string())
             .unwrap_or_else(|_| entry.dst.clone());
         items.push(ListItem {
             src: entry.src.clone(),
@@ -239,7 +239,7 @@ fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Resu
             };
             let dst = engine
                 .render(&link.dst, &tera_ctx)
-                .map(|s| s.trim().to_string())
+                .map(|s| paths::expand_tilde(s.trim()).to_string())
                 .unwrap_or_else(|_| link.dst.clone());
             items.push(ListItem {
                 src: rel.clone(),
@@ -529,7 +529,7 @@ fn walk_and_link(
                         }
                     }
                     let dst_str = engine.render(&link.dst, tera_ctx)?;
-                    let dst = Utf8PathBuf::from(dst_str.trim());
+                    let dst = paths::expand_tilde(dst_str.trim());
                     link_dir_with_backup(src_dir, &dst, ctx)?;
                     linked_any = true;
                 }
@@ -622,7 +622,7 @@ fn resolve_source(source: Option<Utf8PathBuf>) -> Result<Utf8PathBuf> {
             return Ok(ancestor.to_path_buf());
         }
     }
-    if let Some(home) = home_dir() {
+    if let Some(home) = paths::home_dir() {
         for c in ["dotfiles", ".dotfiles", "src/dotfiles"] {
             let p = home.join(c);
             if p.join("config.toml").is_file() {
@@ -634,11 +634,13 @@ fn resolve_source(source: Option<Utf8PathBuf>) -> Result<Utf8PathBuf> {
 }
 
 fn absolutize(p: &Utf8Path) -> Result<Utf8PathBuf> {
-    if p.is_absolute() {
-        return Ok(p.to_path_buf());
+    // Expand `~` first so callers can pass `--source ~/dotfiles` directly.
+    let expanded = paths::expand_tilde(p.as_str());
+    if expanded.is_absolute() {
+        return Ok(expanded);
     }
     let cwd = current_dir_utf8()?;
-    Ok(cwd.join(p))
+    Ok(cwd.join(expanded))
 }
 
 fn current_dir_utf8() -> Result<Utf8PathBuf> {
@@ -646,12 +648,8 @@ fn current_dir_utf8() -> Result<Utf8PathBuf> {
     Utf8PathBuf::from_path_buf(cwd).map_err(|p| anyhow::anyhow!("non-UTF8 cwd: {}", p.display()))
 }
 
-fn home_dir() -> Option<Utf8PathBuf> {
-    std::env::var("HOME")
-        .ok()
-        .or_else(|| std::env::var("USERPROFILE").ok())
-        .map(Utf8PathBuf::from)
-}
+// Note: `home_dir()` lives in `paths.rs` so the tilde-expansion helper and
+// `resolve_source` share one HOME/USERPROFILE lookup.
 
 const SKELETON_CONFIG: &str = r#"# yui config — see https://github.com/yukimemi/yui
 
@@ -667,7 +665,8 @@ default_strategy = "marker"
 
 [[mount.entry]]
 src = "home"
-dst = "{{ env(name='HOME') | default(value=env(name='USERPROFILE')) }}"
+# `~` expands to $HOME / $USERPROFILE per OS at apply time, no Tera needed.
+dst = "~"
 
 # [[mount.entry]]
 # src  = "appdata"

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -7,7 +7,7 @@ use tera::Context;
 use crate::Result;
 use crate::config::{MountEntry, MountStrategy};
 use crate::paths;
-use crate::template::Engine;
+use crate::template::{self, Engine};
 
 /// A mount entry after Tera rendering of `dst` and `when`-filtering.
 #[derive(Debug, Clone)]
@@ -26,8 +26,13 @@ pub fn resolve(
     let mut out = Vec::with_capacity(entries.len());
     for e in entries {
         if let Some(when) = &e.when {
-            let rendered = engine.render(when, ctx)?;
-            if !is_truthy(rendered.trim()) {
+            // `template::eval_truthy` accepts both bare (`yui.os == 'linux'`)
+            // and pre-wrapped (`{{ … }}`) forms — same convention used by
+            // marker links and render rules. Without it, a bare expression
+            // would be silently filtered out (the literal expression string
+            // doesn't equal "true" / "1" so the row drops). The README and
+            // `init` skeleton recommend bare form, so this MUST agree.
+            if !template::eval_truthy(when, engine, ctx)? {
                 continue;
             }
         }
@@ -40,14 +45,6 @@ pub fn resolve(
         });
     }
     Ok(out)
-}
-
-/// `when` rendered output is treated as truthy when literally `"true"` (case
-/// insensitive) or `"1"`. Anything else (including `"false"`, `""`, etc.)
-/// disables the entry.
-fn is_truthy(s: &str) -> bool {
-    let s = s.trim();
-    s.eq_ignore_ascii_case("true") || s == "1"
 }
 
 #[cfg(test)]
@@ -106,6 +103,38 @@ mod tests {
     }
 
     #[test]
+    fn bare_when_form_works() {
+        // Regression: README and `init` skeleton recommend bare-form `when`,
+        // so this MUST resolve via `template::eval_truthy`. Earlier this
+        // function used a direct `engine.render(when)` which only handled
+        // the wrapped form — caught in PR #12 review (gemini-code-assist).
+        let entries = vec![MountEntry {
+            src: "home".into(),
+            dst: "/h".into(),
+            when: Some("yui.os == 'linux'".into()),
+            strategy: None,
+        }];
+        let mut e = Engine::new();
+        let ctx = template::config_context(&vars());
+        let resolved = resolve(&entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
+        assert_eq!(resolved.len(), 1);
+    }
+
+    #[test]
+    fn bare_when_form_filters_when_false() {
+        let entries = vec![MountEntry {
+            src: "home".into(),
+            dst: "/h".into(),
+            when: Some("yui.os == 'no-such-os'".into()),
+            strategy: None,
+        }];
+        let mut e = Engine::new();
+        let ctx = template::config_context(&vars());
+        let resolved = resolve(&entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
+        assert!(resolved.is_empty());
+    }
+
+    #[test]
     fn per_entry_strategy_overrides_default() {
         let entries = vec![MountEntry {
             src: "home".into(),
@@ -117,15 +146,5 @@ mod tests {
         let ctx = template::config_context(&vars());
         let resolved = resolve(&entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
         assert_eq!(resolved[0].strategy, MountStrategy::PerFile);
-    }
-
-    #[test]
-    fn truthy_recognizes_true_and_one() {
-        assert!(is_truthy("true"));
-        assert!(is_truthy("TRUE"));
-        assert!(is_truthy(" 1 "));
-        assert!(!is_truthy("false"));
-        assert!(!is_truthy(""));
-        assert!(!is_truthy("yes"));
     }
 }

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -6,6 +6,7 @@ use tera::Context;
 
 use crate::Result;
 use crate::config::{MountEntry, MountStrategy};
+use crate::paths;
 use crate::template::Engine;
 
 /// A mount entry after Tera rendering of `dst` and `when`-filtering.
@@ -31,7 +32,7 @@ pub fn resolve(
             }
         }
         let dst_str = engine.render(&e.dst, ctx)?;
-        let dst = Utf8PathBuf::from(dst_str.trim());
+        let dst = paths::expand_tilde(dst_str.trim());
         out.push(ResolvedMount {
             src: e.src.clone(),
             dst,

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,6 +1,44 @@
-//! Path utilities for backup-mirroring and timestamp suffixing.
+//! Path utilities for backup-mirroring, timestamp suffixing, and
+//! cross-platform tilde expansion.
 
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
+
+/// Expand a leading `~` or `~/...` to the user's home directory.
+///
+/// Smooths over the `$HOME` (Unix) vs `$USERPROFILE` (Windows) split so
+/// `dst = "~/.config"` works on every platform without writing a Tera
+/// `env(...)` call. Home is resolved via [`home_dir`].
+///
+/// `~user` (other-user homes) is left untouched — we don't support that
+/// form. If `$HOME` / `$USERPROFILE` are both unset the input is also
+/// returned verbatim (better to surface a "no such path" error later than
+/// silently substitute an empty string).
+pub fn expand_tilde(s: &str) -> Utf8PathBuf {
+    match home_dir() {
+        Some(home) => expand_tilde_with(s, &home),
+        None => Utf8PathBuf::from(s),
+    }
+}
+
+/// Same as [`expand_tilde`] but with an explicit home path — used in tests
+/// to avoid touching the process-wide `HOME` env var.
+pub fn expand_tilde_with(s: &str, home: &Utf8Path) -> Utf8PathBuf {
+    if let Some(rest) = s.strip_prefix("~/").or_else(|| s.strip_prefix("~\\")) {
+        home.join(rest)
+    } else if s == "~" {
+        home.to_path_buf()
+    } else {
+        Utf8PathBuf::from(s)
+    }
+}
+
+/// `$HOME` (Unix) or `$USERPROFILE` (Windows), or `None` if neither is set.
+pub fn home_dir() -> Option<Utf8PathBuf> {
+    std::env::var("HOME")
+        .ok()
+        .or_else(|| std::env::var("USERPROFILE").ok())
+        .map(Utf8PathBuf::from)
+}
 
 /// Mirror an absolute target path into a backup directory, dropping the drive
 /// colon on Windows so the path is filesystem-safe.
@@ -84,5 +122,63 @@ mod tests {
     fn append_dotfile() {
         let r = append_timestamp(Utf8Path::new(".gitconfig"), "20260429_143022123");
         assert_eq!(r, Utf8PathBuf::from(".gitconfig_20260429_143022123"));
+    }
+
+    #[test]
+    fn tilde_slash_expands() {
+        let home = Utf8Path::new("/h/u");
+        assert_eq!(
+            expand_tilde_with("~/foo", home),
+            Utf8PathBuf::from("/h/u/foo")
+        );
+        assert_eq!(
+            expand_tilde_with("~/.config/nvim", home),
+            Utf8PathBuf::from("/h/u/.config/nvim")
+        );
+    }
+
+    #[test]
+    fn tilde_backslash_expands_for_windows_input() {
+        // Tera renders may emit Windows-style separators; accept both.
+        let home = Utf8Path::new("C:/Users/u");
+        assert_eq!(
+            expand_tilde_with("~\\foo", home),
+            Utf8PathBuf::from("C:/Users/u/foo")
+        );
+    }
+
+    #[test]
+    fn lone_tilde_is_home() {
+        let home = Utf8Path::new("/h/u");
+        assert_eq!(expand_tilde_with("~", home), Utf8PathBuf::from("/h/u"));
+    }
+
+    #[test]
+    fn tilde_user_form_is_untouched() {
+        let home = Utf8Path::new("/h/u");
+        // We don't support `~root/...` style; leave it for the caller to
+        // see a useful error (file not found) rather than silently lying.
+        assert_eq!(
+            expand_tilde_with("~root/foo", home),
+            Utf8PathBuf::from("~root/foo")
+        );
+    }
+
+    #[test]
+    fn no_tilde_unchanged() {
+        let home = Utf8Path::new("/h/u");
+        assert_eq!(
+            expand_tilde_with("/abs/path", home),
+            Utf8PathBuf::from("/abs/path")
+        );
+        assert_eq!(
+            expand_tilde_with("rel/path", home),
+            Utf8PathBuf::from("rel/path")
+        );
+        // Mid-string `~` is not a home reference (matches POSIX/bash behaviour).
+        assert_eq!(
+            expand_tilde_with("/foo/~/bar", home),
+            Utf8PathBuf::from("/foo/~/bar")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds `paths::expand_tilde` and threads it through every user-facing
path surface so `~` Just Works™ across platforms — `$HOME` on Unix,
`$USERPROFILE` on Windows. Cuts \`{{ env(name='HOME') | default(...) }}\`
out of the common case:

\`\`\`toml
[[mount.entry]]
src = "home"
dst = "~"
\`\`\`

Applied at:
- \`[[mount.entry]] dst\` (after Tera render)
- \`.yuilink\` \`[[link]] dst\` (after Tera render)
- \`--source\` / \`\$YUI_SOURCE\`
- \`yui list\` display column
- \`init\` skeleton + README example switched to the new form

\`~\foo\` (Windows-separator form, since Tera may emit it) is also
accepted. \`~user\` is intentionally left untouched.

\`home_dir()\` consolidated into \`paths.rs\` (was duplicated in cmd).

## Test plan

- [x] \`cargo make check\` clean
- [x] 70 unit tests passing (5 new in paths::tests)
- [ ] CI on \`feat/tilde-expansion\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)