### PR TITLE
feat: drift classifier + yui status command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,6 +1839,7 @@ dependencies = [
  "junction",
  "owo-colors",
  "predicates",
+ "same-file",
  "serde",
  "similar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ ignore = "0.4"
 indicatif = "0.17"
 jiff = { version = "0.2", features = ["serde"] }
 owo-colors = "4"
+same-file = "1"
 serde = { version = "1", features = ["derive"] }
 similar = "2"
 tera = "1"

--- a/src/absorb.rs
+++ b/src/absorb.rs
@@ -71,11 +71,13 @@ pub fn classify(source: &Utf8Path, target: &Utf8Path) -> Result<AbsorbDecision> 
         return Ok(AbsorbDecision::NeedsConfirm);
     }
 
-    // File vs file: compare content + mtime to choose the action.
+    // File vs file: compare content + mtime to choose the action. Fast
+    // path: compare sizes first to avoid loading two arbitrary blobs into
+    // memory whenever the answer is obviously "different".
     if target_meta.file_type().is_file() && source_meta.file_type().is_file() {
-        let src_content = std::fs::read(source)?;
-        let dst_content = std::fs::read(target)?;
-        if src_content == dst_content {
+        let identical = source_meta.len() == target_meta.len()
+            && std::fs::read(source)? == std::fs::read(target)?;
+        if identical {
             return Ok(AbsorbDecision::RelinkOnly);
         }
         let src_mtime = source_meta.modified()?;

--- a/src/absorb.rs
+++ b/src/absorb.rs
@@ -1,27 +1,177 @@
-//! Drift detection + auto-absorb decision logic.
+//! Drift detection — classify the relationship between a source file/dir
+//! and its target counterpart.
 //!
-//! When a target was once linked but is now a separate inode (e.g. an editor
-//! atomic-saved over the hardlink), classify the situation and decide how to
-//! recover. See design doc for the truth table.
+//! Used by:
+//!   - `yui status` (display the classification)
+//!   - `yui apply` (decide what to do: skip / relink / auto-absorb / ask)
+//!
+//! ## Decision matrix
+//!
+//! | target state                                          | classify result |
+//! |-------------------------------------------------------|-----------------|
+//! | resolves to the same inode/file-id as source          | `InSync`        |
+//! | different inode but **identical content**             | `RelinkOnly`    |
+//! | different + content differs + target.mtime > source's | `AutoAbsorb`    |
+//! | different + content differs + source.mtime ≥ target's | `NeedsConfirm`  |
+//! | target missing                                        | `Restore`       |
+//!
+//! "Same inode" is computed via the `same-file` crate, which transparently
+//! follows symlinks, hardlinks, and junctions on Windows.
 
 use camino::Utf8Path;
+use same_file::Handle;
 
 use crate::Result;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AbsorbDecision {
-    /// Inode broken but contents identical — relink only.
-    RelinkOnly,
-    /// target.mtime > source.mtime, contents differ → backup source, copy target → source, relink.
-    AutoAbsorb,
-    /// source.mtime ≥ target.mtime, contents differ → diff + ask (anomaly).
-    NeedsConfirm,
-    /// target equals source via current link mode — nothing to do.
+    /// `target` resolves to `source` already — link is intact.
     InSync,
-    /// target missing → re-link from source.
+    /// Inode broken but contents identical — `apply` can relink without
+    /// touching source.
+    RelinkOnly,
+    /// `target.mtime > source.mtime` and content differs — `apply` should
+    /// back up source, copy target → source, then relink. The user
+    /// edited the live copy and we honor that.
+    AutoAbsorb,
+    /// `source.mtime ≥ target.mtime` and content differs — anomaly
+    /// (source updated since last apply but target was also touched);
+    /// `apply` defers to `[absorb] on_anomaly` policy.
+    NeedsConfirm,
+    /// `target` is missing — `apply` simply links from source.
     Restore,
 }
 
-pub fn classify(_source: &Utf8Path, _target: &Utf8Path) -> Result<AbsorbDecision> {
-    todo!("absorb::classify")
+pub fn classify(source: &Utf8Path, target: &Utf8Path) -> Result<AbsorbDecision> {
+    // Target gone? — restore from source.
+    let target_meta = match std::fs::symlink_metadata(target) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(AbsorbDecision::Restore);
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    // Inode/file-id comparison (follows symlinks and junctions). If both
+    // resolve to the same backing file, the link is intact regardless of
+    // which mechanism made it (hardlink, symlink, junction).
+    if let (Ok(src_h), Ok(dst_h)) = (
+        Handle::from_path(source.as_std_path()),
+        Handle::from_path(target.as_std_path()),
+    ) {
+        if src_h == dst_h {
+            return Ok(AbsorbDecision::InSync);
+        }
+    }
+
+    // Directories: we don't deep-compare contents — drift on a junction'd
+    // directory is unusual enough to warrant a manual look.
+    let source_meta = std::fs::metadata(source)?;
+    if target_meta.file_type().is_dir() && source_meta.file_type().is_dir() {
+        return Ok(AbsorbDecision::NeedsConfirm);
+    }
+
+    // File vs file: compare content + mtime to choose the action.
+    if target_meta.file_type().is_file() && source_meta.file_type().is_file() {
+        let src_content = std::fs::read(source)?;
+        let dst_content = std::fs::read(target)?;
+        if src_content == dst_content {
+            return Ok(AbsorbDecision::RelinkOnly);
+        }
+        let src_mtime = source_meta.modified()?;
+        let dst_mtime = target_meta.modified()?;
+        if dst_mtime > src_mtime {
+            return Ok(AbsorbDecision::AutoAbsorb);
+        }
+        return Ok(AbsorbDecision::NeedsConfirm);
+    }
+
+    // Type mismatch (file vs dir, or one is a broken/odd link) — anomaly.
+    Ok(AbsorbDecision::NeedsConfirm)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use camino::Utf8PathBuf;
+    use std::time::{Duration, SystemTime};
+    use tempfile::TempDir;
+
+    fn utf8(p: std::path::PathBuf) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(p).unwrap()
+    }
+
+    /// Set a file's mtime to a specific instant. `set_modified` requires a
+    /// writable file handle, which `File::open` doesn't grant on Windows.
+    fn backdate(path: &Utf8Path, when: SystemTime) {
+        let f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .expect("open writable for set_modified");
+        f.set_modified(when).expect("set_modified");
+    }
+
+    #[test]
+    fn missing_target_is_restore() {
+        let tmp = TempDir::new().unwrap();
+        let src = utf8(tmp.path().join("src.txt"));
+        std::fs::write(&src, "x").unwrap();
+        let dst = utf8(tmp.path().join("dst.txt"));
+        assert_eq!(classify(&src, &dst).unwrap(), AbsorbDecision::Restore);
+    }
+
+    #[test]
+    fn hardlink_is_in_sync() {
+        let tmp = TempDir::new().unwrap();
+        let src = utf8(tmp.path().join("src.txt"));
+        std::fs::write(&src, "x").unwrap();
+        let dst = utf8(tmp.path().join("dst.txt"));
+        std::fs::hard_link(&src, &dst).unwrap();
+        assert_eq!(classify(&src, &dst).unwrap(), AbsorbDecision::InSync);
+    }
+
+    #[test]
+    fn separate_files_same_content_is_relink_only() {
+        let tmp = TempDir::new().unwrap();
+        let src = utf8(tmp.path().join("src.txt"));
+        let dst = utf8(tmp.path().join("dst.txt"));
+        std::fs::write(&src, "same body").unwrap();
+        std::fs::write(&dst, "same body").unwrap();
+        assert_eq!(classify(&src, &dst).unwrap(), AbsorbDecision::RelinkOnly);
+    }
+
+    #[test]
+    fn target_newer_with_diff_is_auto_absorb() {
+        let tmp = TempDir::new().unwrap();
+        let src = utf8(tmp.path().join("src.txt"));
+        let dst = utf8(tmp.path().join("dst.txt"));
+        std::fs::write(&src, "old source").unwrap();
+        // Make sure mtimes are clearly ordered: backdate source, then write dst fresh.
+        let past = SystemTime::now() - Duration::from_secs(60);
+        backdate(&src, past);
+        std::fs::write(&dst, "edited target").unwrap();
+        assert_eq!(classify(&src, &dst).unwrap(), AbsorbDecision::AutoAbsorb);
+    }
+
+    #[test]
+    fn source_newer_with_diff_is_needs_confirm() {
+        let tmp = TempDir::new().unwrap();
+        let src = utf8(tmp.path().join("src.txt"));
+        let dst = utf8(tmp.path().join("dst.txt"));
+        std::fs::write(&dst, "old target").unwrap();
+        let past = SystemTime::now() - Duration::from_secs(60);
+        backdate(&dst, past);
+        std::fs::write(&src, "fresh source").unwrap();
+        assert_eq!(classify(&src, &dst).unwrap(), AbsorbDecision::NeedsConfirm);
+    }
+
+    #[test]
+    fn separate_dirs_are_needs_confirm() {
+        let tmp = TempDir::new().unwrap();
+        let src = utf8(tmp.path().join("src_dir"));
+        let dst = utf8(tmp.path().join("dst_dir"));
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::create_dir_all(&dst).unwrap();
+        assert_eq!(classify(&src, &dst).unwrap(), AbsorbDecision::NeedsConfirm);
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,7 +54,14 @@ pub enum Command {
     Unlink { paths: Vec<Utf8PathBuf> },
 
     /// Show drift status (link-broken / replaced / template-drift)
-    Status,
+    Status {
+        /// Override [ui] icons mode for this invocation
+        #[arg(long, value_name = "MODE")]
+        icons: Option<IconsMode>,
+        /// Disable color output (also respected via NO_COLOR env)
+        #[arg(long)]
+        no_color: bool,
+    },
 
     /// List all src→dst link mappings (mount entries + .yuilink overrides)
     List {
@@ -96,7 +103,7 @@ impl Cli {
             Command::Render { check, dry_run } => cmd::render(source, check, dry_run),
             Command::Link { dry_run } => cmd::link(source, dry_run),
             Command::Unlink { paths } => cmd::unlink(source, paths),
-            Command::Status => cmd::status(source),
+            Command::Status { icons, no_color } => cmd::status(source, icons, no_color),
             Command::List {
                 all,
                 icons,

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -438,7 +438,11 @@ pub fn unlink(source: Option<Utf8PathBuf>, paths_arg: Vec<Utf8PathBuf>) -> Resul
 ///
 /// Walks each `[[mount.entry]]`'s source tree, honoring `.yuilink`
 /// markers (PassThrough = single dir-level link, Override = one or more
-/// custom dsts), and classifies each pair via [`crate::absorb::classify`].
+/// custom dsts), classifies each pair via [`crate::absorb::classify`],
+/// and additionally surfaces any **render drift** — rendered files
+/// whose content has diverged from what the matching `.tera` template
+/// would produce now (i.e. the user edited the rendered file in place
+/// without reflecting the change back into the template).
 ///
 /// Exits non-zero (via `anyhow::bail!`) when anything diverges, so
 /// `yui status && …` can gate workflows on a clean tree.
@@ -465,6 +469,23 @@ pub fn status(
     let color = !no_color && supports_color_stdout();
 
     let mut report: Vec<StatusItem> = Vec::new();
+
+    // 1. Template drift — render in dry-run mode and surface anything
+    //    whose rendered counterpart on disk no longer matches.
+    let render_report = render::render_all(&source, &config, &yui, /* dry_run */ true)?;
+    for rendered in &render_report.diverged {
+        // `diverged` holds the rendered path; the template lives at
+        // `<rendered>.tera`. Show the .tera as src so it's clear which
+        // file the user needs to update.
+        let tera_path = Utf8PathBuf::from(format!("{rendered}.tera"));
+        report.push(StatusItem {
+            src: relative_for_display(&source, &tera_path),
+            dst: rendered.clone(),
+            state: StatusState::RenderDrift,
+        });
+    }
+
+    // 2. Link drift — classify each src→dst pair under every mount.
     for m in &mounts {
         let src_root = source.join(&m.src);
         if !src_root.is_dir() {
@@ -487,10 +508,7 @@ pub fn status(
 
     print_status_table(&report, icons, color);
 
-    let drift = report
-        .iter()
-        .filter(|r| !matches!(r.decision, absorb::AbsorbDecision::InSync))
-        .count();
+    let drift = report.iter().filter(|r| !r.state.is_in_sync()).count();
 
     println!();
     let total = report.len();
@@ -508,9 +526,23 @@ pub fn status(
 struct StatusItem {
     /// Path under the source tree (display only).
     src: Utf8PathBuf,
-    /// Resolved target path.
+    /// Resolved target path (or rendered output path for `RenderDrift`).
     dst: Utf8PathBuf,
-    decision: absorb::AbsorbDecision,
+    state: StatusState,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum StatusState {
+    Link(absorb::AbsorbDecision),
+    /// Rendered output diverges from current `.tera` template — user
+    /// edited the rendered file directly without updating the template.
+    RenderDrift,
+}
+
+impl StatusState {
+    fn is_in_sync(self) -> bool {
+        matches!(self, Self::Link(absorb::AbsorbDecision::InSync))
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -534,7 +566,7 @@ fn classify_walk(
                 report.push(StatusItem {
                     src: relative_for_display(source_root, src_dir),
                     dst: dst_dir.to_path_buf(),
-                    decision,
+                    state: StatusState::Link(decision),
                 });
                 return Ok(());
             }
@@ -551,7 +583,7 @@ fn classify_walk(
                     report.push(StatusItem {
                         src: relative_for_display(source_root, src_dir),
                         dst,
-                        decision,
+                        state: StatusState::Link(decision),
                     });
                 }
                 return Ok(());
@@ -587,7 +619,7 @@ fn classify_walk(
             report.push(StatusItem {
                 src: relative_for_display(source_root, &src_path),
                 dst: dst_path,
-                decision,
+                state: StatusState::Link(decision),
             });
         }
     }
@@ -616,7 +648,7 @@ fn print_status_table(items: &[StatusItem], icons: Icons, color: bool) {
     // STATE column = icon (1ch) + space + longest label
     let state_label_w = items
         .iter()
-        .map(|i| state_label(i.decision).len())
+        .map(|i| state_label(i.state).len())
         .max()
         .unwrap_or(0)
         .max("STATE".len() - 2); // "STATE" header takes 5 chars; the icon prefix accounts for 2
@@ -635,25 +667,27 @@ fn print_status_table(items: &[StatusItem], icons: Icons, color: bool) {
     }
 }
 
-fn state_label(d: absorb::AbsorbDecision) -> &'static str {
+fn state_label(s: StatusState) -> &'static str {
     use absorb::AbsorbDecision::*;
-    match d {
-        InSync => "in-sync",
-        RelinkOnly => "relink",
-        AutoAbsorb => "drift (auto)",
-        NeedsConfirm => "drift (anomaly)",
-        Restore => "missing",
+    match s {
+        StatusState::Link(InSync) => "in-sync",
+        StatusState::Link(RelinkOnly) => "relink",
+        StatusState::Link(AutoAbsorb) => "drift (auto)",
+        StatusState::Link(NeedsConfirm) => "drift (anomaly)",
+        StatusState::Link(Restore) => "missing",
+        StatusState::RenderDrift => "render drift",
     }
 }
 
-fn state_icon(d: absorb::AbsorbDecision, icons: Icons) -> &'static str {
+fn state_icon(s: StatusState, icons: Icons) -> &'static str {
     use absorb::AbsorbDecision::*;
-    match d {
-        InSync => icons.ok,
-        RelinkOnly => icons.warn,
-        AutoAbsorb => icons.warn,
-        NeedsConfirm => icons.error,
-        Restore => icons.info,
+    match s {
+        StatusState::Link(InSync) => icons.ok,
+        StatusState::Link(RelinkOnly) => icons.warn,
+        StatusState::Link(AutoAbsorb) => icons.warn,
+        StatusState::Link(NeedsConfirm) => icons.error,
+        StatusState::Link(Restore) => icons.info,
+        StatusState::RenderDrift => icons.error,
     }
 }
 
@@ -698,8 +732,8 @@ fn print_status_row(
     color: bool,
 ) {
     use owo_colors::OwoColorize as _;
-    let icon = state_icon(item.decision, icons);
-    let label = state_label(item.decision);
+    let icon = state_icon(item.state, icons);
+    let label = state_label(item.state);
     let state_text = format!("{icon} {label}");
     let src_display = item.src.as_str().replace('\\', "/");
     let dst_display = item.dst.as_str().replace('\\', "/");
@@ -715,11 +749,14 @@ fn print_status_row(
     }
 
     use absorb::AbsorbDecision::*;
-    let state_colored = match item.decision {
-        InSync => cell_state.green().to_string(),
-        RelinkOnly | AutoAbsorb => cell_state.yellow().to_string(),
-        NeedsConfirm => cell_state.red().to_string(),
-        Restore => cell_state.cyan().to_string(),
+    let state_colored = match item.state {
+        StatusState::Link(InSync) => cell_state.green().to_string(),
+        StatusState::Link(RelinkOnly) | StatusState::Link(AutoAbsorb) => {
+            cell_state.yellow().to_string()
+        }
+        StatusState::Link(NeedsConfirm) => cell_state.red().to_string(),
+        StatusState::Link(Restore) => cell_state.cyan().to_string(),
+        StatusState::RenderDrift => cell_state.red().to_string(),
     };
     let src_colored = cell_src.cyan().to_string();
     let arrow_colored = arrow.dimmed().to_string();
@@ -1271,6 +1308,32 @@ dst = "{}"
         apply(Some(source.clone()), false).unwrap();
         // status should succeed (everything in-sync).
         status(Some(source), None, true).unwrap();
+    }
+
+    #[test]
+    fn status_reports_template_drift() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        let target = utf8(tmp.path().join("target"));
+        std::fs::create_dir_all(source.join("home")).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        // Template would render to "fresh" but the rendered file on disk
+        // says "stale" — simulating a manual edit not reflected back.
+        std::fs::write(source.join("home/.gitconfig.tera"), "fresh").unwrap();
+        std::fs::write(source.join("home/.gitconfig"), "stale").unwrap();
+
+        let cfg = format!(
+            r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+            toml_path(&target)
+        );
+        std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+        let err = status(Some(source), None, true).unwrap_err();
+        assert!(format!("{err}").contains("diverged"));
     }
 
     #[test]

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -18,7 +18,7 @@ use crate::mount::{self, ResolvedMount};
 use crate::render::{self, RenderReport};
 use crate::template;
 use crate::vars::YuiVars;
-use crate::{backup, paths};
+use crate::{absorb, backup, paths};
 
 // NOTE: `owo_colors::OwoColorize` is intentionally NOT imported at module
 // scope — its blanket impl shadows inherent methods of unrelated types
@@ -434,8 +434,297 @@ pub fn unlink(source: Option<Utf8PathBuf>, paths_arg: Vec<Utf8PathBuf>) -> Resul
     Ok(())
 }
 
-pub fn status(_source: Option<Utf8PathBuf>) -> Result<()> {
-    todo!("yui status — drift detection (needs absorb classifier)")
+/// Show every src→dst pair's drift state against the current host.
+///
+/// Walks each `[[mount.entry]]`'s source tree, honoring `.yuilink`
+/// markers (PassThrough = single dir-level link, Override = one or more
+/// custom dsts), and classifies each pair via [`crate::absorb::classify`].
+///
+/// Exits non-zero (via `anyhow::bail!`) when anything diverges, so
+/// `yui status && …` can gate workflows on a clean tree.
+pub fn status(
+    source: Option<Utf8PathBuf>,
+    icons_override: Option<IconsMode>,
+    no_color: bool,
+) -> Result<()> {
+    let source = resolve_source(source)?;
+    let yui = YuiVars::detect(&source);
+    let config = config::load(&source, &yui)?;
+
+    let mut engine = template::Engine::new();
+    let tera_ctx = template::template_context(&yui, &config.vars);
+    let mounts = mount::resolve(
+        &config.mount.entry,
+        config.mount.default_strategy,
+        &mut engine,
+        &tera_ctx,
+    )?;
+
+    let icons_mode = icons_override.unwrap_or(config.ui.icons);
+    let icons = Icons::for_mode(icons_mode);
+    let color = !no_color && supports_color_stdout();
+
+    let mut report: Vec<StatusItem> = Vec::new();
+    for m in &mounts {
+        let src_root = source.join(&m.src);
+        if !src_root.is_dir() {
+            warn!("mount src missing: {src_root}");
+            continue;
+        }
+        classify_walk(
+            &src_root,
+            &m.dst,
+            &config,
+            m.strategy,
+            &mut engine,
+            &tera_ctx,
+            &source,
+            &mut report,
+        )?;
+    }
+
+    report.sort_by(|a, b| a.src.cmp(&b.src).then_with(|| a.dst.cmp(&b.dst)));
+
+    print_status_table(&report, icons, color);
+
+    let drift = report
+        .iter()
+        .filter(|r| !matches!(r.decision, absorb::AbsorbDecision::InSync))
+        .count();
+
+    println!();
+    let total = report.len();
+    let in_sync = total - drift;
+    if drift == 0 {
+        println!("  {total} entries · all in sync");
+        Ok(())
+    } else {
+        println!("  {total} entries · {in_sync} in sync · {drift} diverged");
+        anyhow::bail!("status: {drift} entries diverged from source")
+    }
+}
+
+#[derive(Debug)]
+struct StatusItem {
+    /// Path under the source tree (display only).
+    src: Utf8PathBuf,
+    /// Resolved target path.
+    dst: Utf8PathBuf,
+    decision: absorb::AbsorbDecision,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn classify_walk(
+    src_dir: &Utf8Path,
+    dst_dir: &Utf8Path,
+    config: &Config,
+    strategy: MountStrategy,
+    engine: &mut template::Engine,
+    tera_ctx: &TeraContext,
+    source_root: &Utf8Path,
+    report: &mut Vec<StatusItem>,
+) -> Result<()> {
+    let marker_filename = &config.mount.marker_filename;
+
+    if strategy == MountStrategy::Marker {
+        match marker::read_spec(src_dir, marker_filename)? {
+            None => {} // no marker — fall through to recursive walk
+            Some(MarkerSpec::PassThrough) => {
+                let decision = absorb::classify(src_dir, dst_dir)?;
+                report.push(StatusItem {
+                    src: relative_for_display(source_root, src_dir),
+                    dst: dst_dir.to_path_buf(),
+                    decision,
+                });
+                return Ok(());
+            }
+            Some(MarkerSpec::Override { links }) => {
+                for link in &links {
+                    if let Some(when) = &link.when {
+                        if !template::eval_truthy(when, engine, tera_ctx)? {
+                            continue;
+                        }
+                    }
+                    let dst_str = engine.render(&link.dst, tera_ctx)?;
+                    let dst = paths::expand_tilde(dst_str.trim());
+                    let decision = absorb::classify(src_dir, &dst)?;
+                    report.push(StatusItem {
+                        src: relative_for_display(source_root, src_dir),
+                        dst,
+                        decision,
+                    });
+                }
+                return Ok(());
+            }
+        }
+    }
+
+    for entry in std::fs::read_dir(src_dir)? {
+        let entry = entry?;
+        let name_os = entry.file_name();
+        let Some(name) = name_os.to_str() else {
+            continue;
+        };
+        if name == marker_filename || name.ends_with(".tera") {
+            continue;
+        }
+        let src_path = src_dir.join(name);
+        let dst_path = dst_dir.join(name);
+        let ft = entry.file_type()?;
+        if ft.is_dir() {
+            classify_walk(
+                &src_path,
+                &dst_path,
+                config,
+                strategy,
+                engine,
+                tera_ctx,
+                source_root,
+                report,
+            )?;
+        } else if ft.is_file() {
+            let decision = absorb::classify(&src_path, &dst_path)?;
+            report.push(StatusItem {
+                src: relative_for_display(source_root, &src_path),
+                dst: dst_path,
+                decision,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn relative_for_display(source_root: &Utf8Path, p: &Utf8Path) -> Utf8PathBuf {
+    p.strip_prefix(source_root)
+        .map(Utf8PathBuf::from)
+        .unwrap_or_else(|_| p.to_path_buf())
+}
+
+fn print_status_table(items: &[StatusItem], icons: Icons, color: bool) {
+    let src_w = items
+        .iter()
+        .map(|i| i.src.as_str().chars().count())
+        .max()
+        .unwrap_or(0)
+        .max("SRC".len());
+    let dst_w = items
+        .iter()
+        .map(|i| i.dst.as_str().chars().count())
+        .max()
+        .unwrap_or(0)
+        .max("DST".len());
+    // STATE column = icon (1ch) + space + longest label
+    let state_label_w = items
+        .iter()
+        .map(|i| state_label(i.decision).len())
+        .max()
+        .unwrap_or(0)
+        .max("STATE".len() - 2); // "STATE" header takes 5 chars; the icon prefix accounts for 2
+    let state_w = state_label_w + 2; // " " + label
+
+    print_status_header(state_w, src_w, dst_w, color);
+    let sep = render_status_separator(icons.sep, state_w, src_w, dst_w, icons.arrow);
+    if color {
+        use owo_colors::OwoColorize as _;
+        println!("{}", sep.dimmed());
+    } else {
+        println!("{sep}");
+    }
+    for item in items {
+        print_status_row(item, icons, state_w, src_w, dst_w, color);
+    }
+}
+
+fn state_label(d: absorb::AbsorbDecision) -> &'static str {
+    use absorb::AbsorbDecision::*;
+    match d {
+        InSync => "in-sync",
+        RelinkOnly => "relink",
+        AutoAbsorb => "drift (auto)",
+        NeedsConfirm => "drift (anomaly)",
+        Restore => "missing",
+    }
+}
+
+fn state_icon(d: absorb::AbsorbDecision, icons: Icons) -> &'static str {
+    use absorb::AbsorbDecision::*;
+    match d {
+        InSync => icons.ok,
+        RelinkOnly => icons.warn,
+        AutoAbsorb => icons.warn,
+        NeedsConfirm => icons.error,
+        Restore => icons.info,
+    }
+}
+
+fn print_status_header(state_w: usize, src_w: usize, dst_w: usize, color: bool) {
+    use owo_colors::OwoColorize as _;
+    // STATE is the only column with data above; "WHEN" intentionally omitted
+    // since status only shows mounts that are already active on this host.
+    let line = format!(
+        "  {:<state_w$}  {:<src_w$}     {:<dst_w$}",
+        "STATE", "SRC", "DST"
+    );
+    if color {
+        println!("{}", line.bold());
+    } else {
+        println!("{line}");
+    }
+}
+
+fn render_status_separator(
+    sep_ch: char,
+    state_w: usize,
+    src_w: usize,
+    dst_w: usize,
+    arrow: &str,
+) -> String {
+    let bar = |n: usize| sep_ch.to_string().repeat(n);
+    format!(
+        "  {}  {}  {}  {}",
+        bar(state_w),
+        bar(src_w),
+        bar(arrow.chars().count()),
+        bar(dst_w)
+    )
+}
+
+fn print_status_row(
+    item: &StatusItem,
+    icons: Icons,
+    state_w: usize,
+    src_w: usize,
+    dst_w: usize,
+    color: bool,
+) {
+    use owo_colors::OwoColorize as _;
+    let icon = state_icon(item.decision, icons);
+    let label = state_label(item.decision);
+    let state_text = format!("{icon} {label}");
+    let src_display = item.src.as_str().replace('\\', "/");
+    let dst_display = item.dst.as_str().replace('\\', "/");
+    let arrow = icons.arrow;
+
+    let cell_state = format!("{:<state_w$}", state_text);
+    let cell_src = format!("{:<src_w$}", src_display);
+    let cell_dst = format!("{:<dst_w$}", dst_display);
+
+    if !color {
+        println!("  {cell_state}  {cell_src}  {arrow}  {cell_dst}");
+        return;
+    }
+
+    use absorb::AbsorbDecision::*;
+    let state_colored = match item.decision {
+        InSync => cell_state.green().to_string(),
+        RelinkOnly | AutoAbsorb => cell_state.yellow().to_string(),
+        NeedsConfirm => cell_state.red().to_string(),
+        Restore => cell_state.cyan().to_string(),
+    };
+    let src_colored = cell_src.cyan().to_string();
+    let arrow_colored = arrow.dimmed().to_string();
+    let dst_colored = cell_dst.dimmed().to_string();
+    println!("  {state_colored}  {src_colored}  {arrow_colored}  {dst_colored}");
 }
 
 pub fn absorb(_source: Option<Utf8PathBuf>, _target: Utf8PathBuf, _dry_run: bool) -> Result<()> {
@@ -959,6 +1248,51 @@ dst = "/h"
         // Just verify it runs without error — output format is covered by
         // unit-level helpers below.
         list(Some(source), false, None, true).unwrap();
+    }
+
+    #[test]
+    fn status_reports_in_sync_after_apply() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        let target = utf8(tmp.path().join("target"));
+        std::fs::create_dir_all(source.join("home")).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(source.join("home/.bashrc"), "echo hi\n").unwrap();
+        let cfg = format!(
+            r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+            toml_path(&target)
+        );
+        std::fs::write(source.join("config.toml"), cfg).unwrap();
+        // First link the target so the link is intact.
+        apply(Some(source.clone()), false).unwrap();
+        // status should succeed (everything in-sync).
+        status(Some(source), None, true).unwrap();
+    }
+
+    #[test]
+    fn status_fails_when_target_missing() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        let target = utf8(tmp.path().join("target"));
+        std::fs::create_dir_all(source.join("home")).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(source.join("home/.bashrc"), "echo hi\n").unwrap();
+        let cfg = format!(
+            r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+            toml_path(&target)
+        );
+        std::fs::write(source.join("config.toml"), cfg).unwrap();
+        // No apply yet — target/.bashrc doesn't exist.
+        let err = status(Some(source), None, true).unwrap_err();
+        assert!(format!("{err}").contains("diverged"));
     }
 
     #[test]

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -13,6 +13,14 @@ pub struct Icons {
     pub inactive: &'static str,
     pub arrow: &'static str,
     pub sep: char,
+    /// `yui status` — link is intact (in-sync).
+    pub ok: &'static str,
+    /// `yui status` — informational (e.g. target missing, will be created).
+    pub info: &'static str,
+    /// `yui status` — drift detected, but auto-fixable.
+    pub warn: &'static str,
+    /// `yui status` — anomaly that needs user attention.
+    pub error: &'static str,
 }
 
 impl Icons {
@@ -21,18 +29,30 @@ impl Icons {
         inactive: "\u{2717}", // ✗
         arrow: "\u{2192}",    // →
         sep: '\u{2500}',      // ─
+        ok: "\u{2713}",       // ✓
+        info: "\u{25cb}",     // ○
+        warn: "\u{26a0}",     // ⚠
+        error: "\u{2717}",    // ✗
     };
     pub const NERD: Self = Self {
         active: "\u{f058}",   //   nf-fa-check_circle
         inactive: "\u{f057}", //   nf-fa-times_circle
         arrow: "\u{2192}",    // → (no need for a special arrow glyph)
         sep: '\u{2500}',      // ─
+        ok: "\u{f058}",       //   nf-fa-check_circle
+        info: "\u{f05a}",     //   nf-fa-info_circle
+        warn: "\u{f071}",     //   nf-fa-warning
+        error: "\u{f057}",    //   nf-fa-times_circle
     };
     pub const ASCII: Self = Self {
         active: "[+]",
         inactive: "[-]",
         arrow: "->",
         sep: '-',
+        ok: "[+]",
+        info: "[.]",
+        warn: "[!]",
+        error: "[-]",
     };
 
     pub const fn for_mode(mode: IconsMode) -> Self {


### PR DESCRIPTION
## Summary

Adds the absorb classifier and a read-only \`yui status\` command. The
*apply integration* (acting on the classifier's decisions) and the
manual \`yui absorb\` command are deferred to the next PR — keeping
this one focused on the foundation + display surface.

### \`absorb::classify\`

| target state | result |
|---|---|
| target's file-id matches source (link intact) | \`InSync\` |
| different inode, identical content | \`RelinkOnly\` |
| target.mtime > source + content differs | \`AutoAbsorb\` |
| source.mtime ≥ target + content differs | \`NeedsConfirm\` |
| target missing | \`Restore\` |

\"Same file-id\" via the \`same-file\` crate, so hardlink, junction and
symlink all qualify uniformly. Directories are classified by file-id
only (no deep content compare).

### \`yui status\`

\`\`\`
  STATE        SRC                  DST                                   
  ─────────  ─ ─────────────────  ─  ─────────────────────────────────────
  ✓ in-sync     home/.bashrc      →  /home/u/.bashrc
  ⚠ drift (auto) home/.gitconfig   →  /home/u/.gitconfig
  ✗ drift (anomaly) home/.tmux.conf →  /home/u/.tmux.conf
  ○ missing     home/.ssh/config  →  /home/u/.ssh/config

  4 entries · 1 in sync · 3 diverged
\`\`\`

- 4 state icons (\`ok\` / \`warn\` / \`error\` / \`info\`) added to the
  3 icon modes (\`unicode\` / \`nerd\` / \`ascii\`)
- Same color/TTY/NO_COLOR rules as \`yui list\`
- Exits non-zero when anything's diverged, so \`yui status && ...\` works

### Out-of-scope (next PR)

- \`apply\` consulting \`classify()\` instead of unconditional
  backup-and-replace
- \`cmd::absorb\` (manual single-target absorb)
- \`[absorb] on_anomaly\` policy enforcement

## Test plan

- [x] \`cargo make check\` clean (fmt / clippy / test / locked)
- [x] 79 unit tests passing (8 new: 6 absorb classifier arms +
      2 cmd::status smoke tests)
- [x] Manual demo of \`yui status\` (missing → after-apply → drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `status` command now displays a formatted table reporting link integrity and render drift anomalies.
  * Added `--icons <MODE>` flag to customize status output icon rendering mode per invocation.
  * Added `--no-color` flag to disable colored output in status reports (respects NO_COLOR environment variable).
  * Enhanced status reporting with status-specific icon indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->