### PR TITLE
docs+assets: 0.3.0 README rewrite, logo + diamond bind-point

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["dotfiles", "config", "symlink", "hardlink", "junction"]
 categories = ["command-line-utilities", "config"]
 include = [
     "src/**/*.rs",
+    "assets/icon.svg",
+    "assets/logo.svg",
+    "assets/logo-dark.svg",
     "Cargo.toml",
     "README.md",
     "LICENSE",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."

--- a/README.md
+++ b/README.md
@@ -1,36 +1,64 @@
-# yui
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.svg" />
+    <img src="assets/logo.svg" width="560" alt="yui — target-as-truth dotfiles manager" />
+  </picture>
+</p>
 
-> 結 — *target-as-truth* dotfiles manager
+<p align="center">
+  <b>結 — edit your live configs, the source repo updates itself.</b>
+</p>
 
-`yui` is a dotfiles manager that flips the chezmoi flow on its head: edit
-your live configs (the **target**), and the source repo updates
-automatically. Built to fix three chezmoi pain points:
+<p align="center">
+  <a href="https://crates.io/crates/yui-cli"><img src="https://img.shields.io/crates/v/yui-cli.svg" alt="crates.io"/></a>
+  <a href="https://github.com/yukimemi/yui/actions/workflows/ci.yml"><img src="https://github.com/yukimemi/yui/actions/workflows/ci.yml/badge.svg" alt="CI"/></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"/></a>
+</p>
 
-- having to edit the source first and `apply` afterwards is a constant tax
-- apps overwrite the target directly, so source and target drift
-- new files apps create aren't tracked, and you can't even notice them
+`yui` flips the chezmoi flow: instead of editing your source repo and
+running `apply` to push changes out to `~`, you edit `~` directly and
+the source follows automatically. The two sides share a backing inode
+(hardlink / junction / symlink), so an app's write to the target *is*
+a write to source.
+
+It exists to fix three chezmoi pain points the author hit running
+chezmoi for years:
+
+1. **The edit-source-then-apply tax** — every config tweak became a
+   two-step ceremony.
+2. **Source ↔ target drift** — apps overwrite the target directly,
+   and the user finds out at the next `chezmoi diff`.
+3. **Untracked new files** — apps that create new files inside a
+   managed directory aren't visible to chezmoi unless you remember
+   to `chezmoi add` them.
 
 ## How it works
 
-The actual files live in your dotfiles repo, and the targets are
-**hardlinks / junctions / symlinks** pointing at them. When an app writes
-to the target, the link routes the write straight through to source — no
-copy step, no drift.
+Your dotfiles repo is a normal directory tree. `yui apply` walks it
+and links each file/directory into its target location:
 
-| Platform | files | directories |
+| platform | files | directories |
 |----------|-------|-------------|
 | Linux / macOS | symlink | symlink |
-| Windows (default) | hardlink | junction |
-| Windows (opt-in) | symlink | symlink (requires Developer Mode / admin) |
+| Windows (default) | **hardlink** | **junction** |
+| Windows (opt-in) | symlink | symlink (Developer Mode / admin) |
 
-Drop a `.yuilink` marker file inside any directory in your source tree
-to make `yui` link that whole directory as a single unit — files an
-app creates inside it land directly in your source repo.
+The Windows defaults are deliberate: hardlinks and junctions both
+work without elevated permissions and survive most editors' "atomic
+save" rename trick. When that trick *does* break the hardlink, the
+**absorb classifier** notices on the next `apply` / `status`:
 
-When an editor's atomic-save breaks a hardlink, `yui` looks at mtimes,
-content, and git status to decide between **auto-absorb** (target →
-source, with backup), **relink only** (contents identical), or **ask**
-(anomaly).
+```
+target's file-id == source's file-id?            → InSync
+content identical, different file-id?            → RelinkOnly
+target newer + content differs?                  → AutoAbsorb (target wins)
+source newer + content differs?                  → NeedsConfirm (anomaly)
+target missing?                                  → Restore
+```
+
+`AutoAbsorb` backs source up under `$DOTFILES/.yui/backup/` and
+copies target's content into source before relinking — your local
+edit is preserved, even when an editor saved over the link.
 
 ## Install
 
@@ -38,30 +66,29 @@ source, with backup), **relink only** (contents identical), or **ask**
 cargo install yui-cli
 ```
 
-Binary lives at `~/.cargo/bin/yui`. Make sure that's on your `PATH`.
+Pre-built binaries for Linux x86_64, Windows x86_64, and macOS
+(Intel + Apple Silicon) are attached to every
+[GitHub Release](https://github.com/yukimemi/yui/releases).
 
 ## Quick start
 
 ```sh
-# Initialize a fresh source repo at $DOTFILES (and install git hooks).
+# Scaffold a source repo at the current directory and install git hooks.
 yui init --git-hooks
 
 # Edit $DOTFILES/config.toml to declare your mounts, then:
 yui apply        # render templates + link targets + auto-absorb drift
-yui status       # show drift across all mounts
-yui doctor       # diagnose your environment
+yui list         # see every src→dst mapping at a glance
+yui status       # check what drifted
+yui doctor       # environment sanity check
 ```
 
-Minimal `$DOTFILES/config.toml`:
+Smallest useful `$DOTFILES/config.toml`:
 
 ```toml
-[vars]
-git_email = "you@example.com"
-
 [[mount.entry]]
 src = "home"
-# `~` expands to $HOME on Unix and $USERPROFILE on Windows — use it freely.
-dst = "~"
+dst = "~"          # ~ expands to $HOME / $USERPROFILE per OS
 
 [[mount.entry]]
 src  = "appdata"
@@ -69,23 +96,103 @@ dst  = "{{ env(name='APPDATA') }}"
 when = "yui.os == 'windows'"
 ```
 
-`config.local.toml` (gitignored) is for machine-local overrides:
+Add files under `home/` and they'll link into `~`. Add a `.yuilink`
+file to a directory to junction the whole directory as one unit (so
+files an app creates inside that dir land back in source
+automatically).
 
-```toml
-[vars]
-git_email = "you@work.example"
+## Templates (`*.tera`)
+
+Files ending in `.tera` are rendered with [Tera] before linking; the
+output is a sibling file with the `.tera` suffix dropped. `yui` adds
+the rendered file to a managed `# >>> yui rendered (auto-managed) <<<`
+section of `.gitignore` so it doesn't get committed.
+
+```
+home/.gitconfig.tera   →  home/.gitconfig   →  ~/.gitconfig
 ```
 
-Built-in variables exposed to Tera: `yui.os`, `yui.host`, `yui.user`,
-`yui.arch`, `yui.source`. Environment variables are read with
-`{{ env(name='HOME') }}`. Path values (in `dst`, `--source`, `YUI_SOURCE`,
-`.yuilink` `[[link]] dst`, etc.) accept a leading `~` / `~/...` which
-expands to `$HOME` (or `$USERPROFILE` on Windows) at apply time —
-`dst = "~/.config/foo"` Just Works™ across platforms.
+Templates have access to `yui.os` / `yui.host` / `yui.user` /
+`yui.arch` / `yui.source` and your `[vars]` table. Per-host overrides
+go in `config.local.toml` (machine-local, gitignored), which `yui`
+loads after `config.*.toml` so its values win.
+
+[Tera]: https://keats.github.io/tera/
+
+## One source → many targets
+
+If you want the same source directory linked to different places on
+different OSes — common for editor configs (`~/.config/nvim` on Unix,
+`%LOCALAPPDATA%\nvim` on Windows) — drop a `.yuilink` with content:
+
+```toml
+# $DOTFILES/home/.config/nvim/.yuilink
+[[link]]
+dst = "~/.config/nvim"
+
+[[link]]
+dst = "{{ env(name='LOCALAPPDATA') }}/nvim"
+when = "yui.os == 'windows'"
+```
+
+`yui list` shows each link and which `when` would activate it.
+
+## Anomalies and the `[absorb]` policy
+
+When source AND target both diverge from each other, `yui` can't
+auto-merge. It defers to your `[absorb] on_anomaly` setting:
+
+```toml
+[absorb]
+auto              = true     # auto-absorb on any AutoAbsorb classification
+require_clean_git = true     # treat dirty source as anomaly
+on_anomaly        = "ask"    # "ask" | "skip" | "force"
+```
+
+- `ask` — on a TTY, render the diff and prompt y/N; off-TTY, skip
+- `skip` — log a warning and leave both sides untouched
+- `force` — treat the anomaly as auto-absorb anyway (target wins)
+
+Need to absorb a single file regardless of policy? `yui absorb
+<target-path>` does that — bypasses `auto`, `require_clean_git`, and
+`on_anomaly` for an explicit user-initiated pull.
+
+## Commands
+
+| | |
+|---|---|
+| `yui init [--git-hooks]` | scaffold `config.toml` + `.gitignore` in cwd |
+| `yui apply [--dry-run]` | render → link → auto-absorb |
+| `yui render [--check]` | template-only pass; `--check` fails on drift |
+| `yui link [--dry-run]` | alias for apply (kept for muscle memory) |
+| `yui list [--all] [--icons MODE] [--no-color]` | every src→dst mapping |
+| `yui status [--icons MODE] [--no-color]` | drift overview, exits non-zero on any divergence |
+| `yui absorb <target>` | manually pull a single target into source |
+| `yui unlink <path>...` | tear down a specific link |
+| `yui doctor` | environment sanity check |
+| `yui gc-backup --older-than DUR` | clean old backups (planned) |
+
+`--icons` accepts `unicode` (default), `nerd` (Nerd-Font glyphs),
+`ascii` (CI-log-safe). The `[ui] icons = "..."` config key sets it
+globally.
 
 ## Status
 
-Pre-release. MVP design complete; implementation in progress.
+`v0.3.0` ships the absorb story end-to-end — chezmoi-replacement
+ready for simple repos. Known gaps:
+
+- no `.yuiignore` (gitignore-style exclusion) yet
+- no hook-script support (chezmoi's `run_*` scripts)
+- no built-in encryption (use `pass` / `1password-cli` from a Tera
+  template instead)
+- chezmoi name-prefix translation (`dot_zshrc` → `.zshrc`,
+  `run_once_*.sh.tmpl`) is **not** implemented — bring-your-own
+  rename when migrating
+
+Migration from chezmoi: rename files (`dot_X` → `.X`), convert
+`*.tmpl` → `*.tera` (Go template → Tera syntax), and pull the
+`run_*` scripts into a separate runner you trigger yourself. yui has
+no opinion on what runs them.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -163,14 +163,14 @@ Need to absorb a single file regardless of policy? `yui absorb
 |---|---|
 | `yui init [--git-hooks]` | scaffold `config.toml` + `.gitignore` in cwd |
 | `yui apply [--dry-run]` | render → link → auto-absorb |
-| `yui render [--check]` | template-only pass; `--check` fails on drift |
+| `yui render [--check] [--dry-run]` | template-only pass; `--check` fails on drift |
 | `yui link [--dry-run]` | alias for apply (kept for muscle memory) |
 | `yui list [--all] [--icons MODE] [--no-color]` | every src→dst mapping |
 | `yui status [--icons MODE] [--no-color]` | drift overview, exits non-zero on any divergence |
-| `yui absorb <target>` | manually pull a single target into source |
+| `yui absorb <target> [--dry-run]` | manually pull a single target into source |
 | `yui unlink <path>...` | tear down a specific link |
 | `yui doctor` | environment sanity check |
-| `yui gc-backup --older-than DUR` | clean old backups (planned) |
+| `yui gc-backup [--older-than DUR]` | clean old backups (**not yet implemented** — calling it errors out) |
 
 `--icons` accepts `unicode` (default), `nerd` (Nerd-Font glyphs),
 `ascii` (CI-log-safe). The `[ui] icons = "..."` config key sets it
@@ -178,7 +178,7 @@ globally.
 
 ## Status
 
-`v0.3.0` ships the absorb story end-to-end — chezmoi-replacement
+`v0.4.0` ships the absorb story end-to-end — chezmoi-replacement
 ready for simple repos. Known gaps:
 
 - no `.yuiignore` (gitignore-style exclusion) yet

--- a/assets/alt/README.md
+++ b/assets/alt/README.md
@@ -1,7 +1,13 @@
 # Logo / icon alternatives
 
-Concept variants for `assets/icon.svg`. Pick whichever reads best at
-favicon size and ship it; the others stay here for reference.
+Concept variants explored for `assets/icon.svg`.
+
+**Selected**: rings + diamond — see `icon-rings-diamond.svg` (now also
+in `../icon.svg`). The rings carry "source ↔ target", the small gold
+diamond at the intersection marks 結 (the bind point) without reading
+as a literal eye the way a centered circle did.
+
+The other variants stay here as a record of the design exploration.
 
 | file | concept | tradeoffs |
 |---|---|---|

--- a/assets/alt/README.md
+++ b/assets/alt/README.md
@@ -1,0 +1,20 @@
+# Logo / icon alternatives
+
+Concept variants for `assets/icon.svg`. Pick whichever reads best at
+favicon size and ship it; the others stay here for reference.
+
+| file | concept | tradeoffs |
+|---|---|---|
+| `../icon.svg` | two interlocking rings | minimal, distinct at 16×16, abstract — "two things linked" |
+| `icon-infinity.svg` | two ovals as ∞ | dynamic, "endless cycle of source ↔ target" |
+| `icon-knot.svg` | mizuhiki crossing cords | most literal 結 (tie / knot) |
+| `icon-kanji.svg` | the 結 character itself | most direct; depends on a CJK font being installed |
+| `icon-rings-dot.svg` | rings + gold accent dot | rings concept with the binding point highlighted |
+
+Color palette (consistent across variants):
+- coral `#d96459` — source side
+- indigo `#225378` — target side
+- gold `#c9a227` — the bind / accent (where used)
+
+To preview a variant, swap the file in `../icon.svg` and re-render the
+banner via `../logo.svg`.

--- a/assets/alt/icon-infinity.svg
+++ b/assets/alt/icon-infinity.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="yui (infinity variant)">
+  <title>yui — infinity-shape variant</title>
+  <!--
+    Variant 2: two horizontal loops linked in ∞ form. Reads as "endless
+    cycle" / "永続的に結ぶ" — source ↔ target as a continuous round-trip.
+    Slightly more dynamic than the static circles.
+  -->
+  <g fill="none" stroke-width="22" stroke-linecap="round">
+    <ellipse cx="88"  cy="128" rx="44" ry="36" stroke="#d96459" />
+    <ellipse cx="168" cy="128" rx="44" ry="36" stroke="#225378" />
+  </g>
+</svg>

--- a/assets/alt/icon-kanji.svg
+++ b/assets/alt/icon-kanji.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="yui (kanji variant)">
+  <title>yui — 結 kanji variant</title>
+  <!--
+    Variant 4: the kanji 結 (yui, "tie / bind") rendered in a
+    serif-weight Japanese face. Most direct and the most "Japanese-tool"
+    feel. Trade-off: depends on the viewer having a CJK font installed
+    — most modern environments do, but stripped-down terminals or
+    minimal-Linux GUIs might fall back to a tofu □.
+  -->
+  <text x="128" y="200"
+        font-family="'Hiragino Mincho ProN', 'Yu Mincho', 'Noto Serif JP', 'MS Mincho', serif"
+        font-weight="700" font-size="220"
+        text-anchor="middle"
+        fill="#d96459">結</text>
+</svg>

--- a/assets/alt/icon-knot.svg
+++ b/assets/alt/icon-knot.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="yui (knot variant)">
+  <title>yui — mizuhiki knot variant</title>
+  <!--
+    Variant 1: stylized 水引-like cord knot — two ribbons crossing each
+    other. Most literal representation of 結 (knot/tie). Slightly busier
+    than the rings, more iconic at larger sizes.
+  -->
+  <g fill="none" stroke-width="18" stroke-linecap="round">
+    <!-- "Bottom" cord (drawn first; appears under the crossing) -->
+    <path d="M 56,176 C 56,80 200,80 200,176"
+          stroke="#d96459" />
+    <!-- "Top" cord crossing over — drawn second so it appears on top -->
+    <path d="M 56,80  C 56,176 200,176 200,80"
+          stroke="#225378" />
+    <!-- Knot center — small filled circle highlighting the link point -->
+    <circle cx="128" cy="128" r="14" fill="#c9a227" stroke="none" />
+  </g>
+</svg>

--- a/assets/alt/icon-rings-diamond.svg
+++ b/assets/alt/icon-rings-diamond.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="yui (rings + diamond variant)">
+  <title>yui — interlocking rings with a small gold diamond</title>
+  <!--
+    Variant 5b: same rings, but the bind-point is a small rotated square
+    (diamond) instead of a circle. Breaks the "iris" pattern that makes
+    a centered circle inside a vertical lens read as a literal eye, while
+    keeping the gold-accent-at-the-bind-point idea.
+  -->
+  <g fill="none" stroke-width="20" stroke-linecap="round">
+    <circle cx="96"  cy="128" r="56" stroke="#d96459" />
+    <circle cx="160" cy="128" r="56" stroke="#225378" />
+  </g>
+  <!-- Diamond (rotated square) at intersection center, side ≈ 12 -->
+  <rect x="120" y="120" width="16" height="16"
+        transform="rotate(45 128 128)"
+        fill="#c9a227" />
+</svg>

--- a/assets/alt/icon-rings-dot.svg
+++ b/assets/alt/icon-rings-dot.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="yui (rings+dot variant)">
+  <title>yui — interlocking rings with a gold "yui" dot</title>
+  <!--
+    Variant 5: same two interlocking rings as the main icon, but with
+    a small gold dot in the intersection. Reads as "the binding point
+    is highlighted" — closer to a literal 結 (tied at this point).
+  -->
+  <g fill="none" stroke-width="20" stroke-linecap="round">
+    <circle cx="96"  cy="128" r="56" stroke="#d96459" />
+    <circle cx="160" cy="128" r="56" stroke="#225378" />
+  </g>
+  <!-- Gold dot at the geometric center of the intersection. -->
+  <circle cx="128" cy="128" r="11" fill="#c9a227" />
+</svg>

--- a/assets/alt/icon-rings-dot.svg
+++ b/assets/alt/icon-rings-dot.svg
@@ -4,11 +4,12 @@
     Variant 5: same two interlocking rings as the main icon, but with
     a small gold dot in the intersection. Reads as "the binding point
     is highlighted" — closer to a literal 結 (tied at this point).
+    Dot radius 7 (was 11) for more breathing room — fewer "eye" vibes.
   -->
   <g fill="none" stroke-width="20" stroke-linecap="round">
     <circle cx="96"  cy="128" r="56" stroke="#d96459" />
     <circle cx="160" cy="128" r="56" stroke="#225378" />
   </g>
-  <!-- Gold dot at the geometric center of the intersection. -->
-  <circle cx="128" cy="128" r="11" fill="#c9a227" />
+  <!-- Gold "bind" dot at the geometric center of the intersection. -->
+  <circle cx="128" cy="128" r="7" fill="#c9a227" />
 </svg>

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -3,7 +3,6 @@
   <!--
     Two interlocking rings — coral (source) ↔ indigo (target) — with a
     small gold diamond at the intersection marking the bind point: 結.
-    See assets/alt/ for the design exploration that led here.
   -->
   <g fill="none" stroke-width="20" stroke-linecap="round">
     <circle cx="96"  cy="128" r="56" stroke="#d96459" />

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="yui">
+  <title>yui — target-as-truth dotfiles</title>
+  <!--
+    Two interlocking rings: source (warm coral) and target (deep indigo).
+    The visual overlap stands in for 結 (yui, "tie / bind") — the very
+    point of yui-cli is to keep source and target the same backing file.
+  -->
+  <g fill="none" stroke-width="20" stroke-linecap="round">
+    <circle cx="96"  cy="128" r="56" stroke="#d96459" />
+    <circle cx="160" cy="128" r="56" stroke="#225378" />
+  </g>
+</svg>

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,12 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="yui">
   <title>yui — target-as-truth dotfiles</title>
   <!--
-    Two interlocking rings: source (warm coral) and target (deep indigo).
-    The visual overlap stands in for 結 (yui, "tie / bind") — the very
-    point of yui-cli is to keep source and target the same backing file.
+    Two interlocking rings — coral (source) ↔ indigo (target) — with a
+    small gold diamond at the intersection marking the bind point: 結.
+    See assets/alt/ for the design exploration that led here.
   -->
   <g fill="none" stroke-width="20" stroke-linecap="round">
     <circle cx="96"  cy="128" r="56" stroke="#d96459" />
     <circle cx="160" cy="128" r="56" stroke="#225378" />
   </g>
+  <rect x="120" y="120" width="16" height="16"
+        transform="rotate(45 128 128)"
+        fill="#c9a227" />
 </svg>

--- a/assets/logo-dark.svg
+++ b/assets/logo-dark.svg
@@ -6,6 +6,9 @@
       <circle cx="96"  cy="128" r="56" stroke="#f08c80" />
       <circle cx="160" cy="128" r="56" stroke="#7eb3da" />
     </g>
+    <rect x="120" y="120" width="16" height="16"
+          transform="rotate(45 128 128)"
+          fill="#e9c14a" />
   </g>
   <text x="118" y="68"
         font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"

--- a/assets/logo-dark.svg
+++ b/assets/logo-dark.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 580 120" role="img" aria-label="yui — target-as-truth dotfiles">
+  <title>yui — target-as-truth dotfiles</title>
+  <!-- icon (slightly brighter strokes for dark backgrounds) -->
+  <g transform="translate(20, 18) scale(0.34)">
+    <g fill="none" stroke-width="20" stroke-linecap="round">
+      <circle cx="96"  cy="128" r="56" stroke="#f08c80" />
+      <circle cx="160" cy="128" r="56" stroke="#7eb3da" />
+    </g>
+  </g>
+  <text x="118" y="68"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+        font-weight="700" font-size="58" letter-spacing="-2"
+        fill="#f5f5f5">yui</text>
+  <text x="120" y="96"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+        font-style="italic" font-size="16"
+        fill="#b8b8b8">結 — target-as-truth dotfiles manager</text>
+</svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 580 120" role="img" aria-label="yui — target-as-truth dotfiles">
+  <title>yui — target-as-truth dotfiles</title>
+  <!-- icon (matches assets/icon.svg) -->
+  <g transform="translate(20, 18) scale(0.34)">
+    <g fill="none" stroke-width="20" stroke-linecap="round">
+      <circle cx="96"  cy="128" r="56" stroke="#d96459" />
+      <circle cx="160" cy="128" r="56" stroke="#225378" />
+    </g>
+  </g>
+  <!-- wordmark -->
+  <text x="118" y="68"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+        font-weight="700" font-size="58" letter-spacing="-2"
+        fill="#1a1a1a">yui</text>
+  <!-- tagline -->
+  <text x="120" y="96"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+        font-style="italic" font-size="16"
+        fill="#5a5a5a">結 — target-as-truth dotfiles manager</text>
+</svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -6,6 +6,9 @@
       <circle cx="96"  cy="128" r="56" stroke="#d96459" />
       <circle cx="160" cy="128" r="56" stroke="#225378" />
     </g>
+    <rect x="120" y="120" width="16" height="16"
+          transform="rotate(45 128 128)"
+          fill="#c9a227" />
   </g>
   <!-- wordmark -->
   <text x="118" y="68"


### PR DESCRIPTION
## Summary

Aligns the public-facing surface with where 0.3.0 actually landed.
The README had been frozen at 0.1.0 and didn't mention any of:
absorb classifier, \`yui list\`, \`yui status\`, multi-dst markers,
\`[absorb]\` policy, \`~\` expansion, icon modes, or the manual
\`yui absorb\`. It does now.

### Logo

Settled on **rings + diamond** after a side-by-side review of 5
concept variants under \`assets/alt/\` (rings, infinity, knot,
kanji, rings+dot). The diamond bind-point breaks the
\"iris-in-a-vesica\" pattern that made a centered circle inside the
intersection lens read as a literal eye, while keeping the
gold-accent-at-the-bind idea.

- \`assets/icon.svg\` — square 256×256
- \`assets/logo.svg\` — banner with wordmark + tagline (light theme)
- \`assets/logo-dark.svg\` — same, brighter strokes + light text for
  dark theme
- \`assets/alt/\` — design exploration archive (decision recorded in
  \`assets/alt/README.md\`)

README header uses \`<picture>\` + \`prefers-color-scheme\` so
GitHub picks the right variant automatically.

### README

Full rewrite reflecting 0.3.0:

- Quick start now shows the \`~\` form (\`dst = \"~\"\` works
  cross-platform without writing Tera \`env(...)\` chains).
- New "How it works" section walks through the 5-state classifier
  table.
- Multi-dst (\`.yuilink\` \`[[link]]\`) covered with the canonical
  nvim cross-OS example.
- \`[absorb]\` policy section with all three \`on_anomaly\` modes.
- Full command list with flags.
- Status section calls out known gaps (\`.yuiignore\`, hooks,
  encryption) and notes that chezmoi-style name prefixes (\`dot_\`,
  \`run_\`) are not translated — migration requires manual rename.

### Cargo.toml

\`include\` adds \`assets/icon.svg\`, \`assets/logo.svg\`,
\`assets/logo-dark.svg\` so the README renders on crates.io / docs.rs
without 404 image links.

## Test plan

- [x] \`cargo make check\` clean
- [x] \`cargo publish --dry-run --allow-dirty\` packages cleanly
      (27 files, 171.5 KiB)
- [ ] CI on \`feat/logo-assets\`
- [ ] Eyeballed rendered README via the GitHub diff before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with improved installation and configuration guidance
  * Added comprehensive examples for linking configurations
  * Documented new and refined commands (list, status, doctor)
  * Introduced design documentation for icon variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->