### PR TITLE
feat: .yuiignore (gitignore-style exclusion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,29 @@ when = "yui.os == 'windows'"
 
 `yui list` shows each link and which `when` would activate it.
 
+## `.yuiignore` — exclude paths from being linked
+
+A `$DOTFILES/.yuiignore` file (gitignore syntax) keeps matched paths
+out of every yui flow — render skips them, list omits them, and apply
+won't link them. Useful for editor lock-files, build artifacts, OS
+junk like `.DS_Store`, and anything else that lives next to your real
+config but shouldn't be propagated:
+
+```gitignore
+# $DOTFILES/.yuiignore
+**/.DS_Store
+**/lock.json
+home/.config/nvim/lazy-lock.json     # exact path also works
+
+# Exclude all of build/ except the one file we DO want linked
+build/
+!build/result.toml
+```
+
+Currently only the repo-root `.yuiignore` is honored — nested
+`.yuiignore` files inside subdirectories are not yet walked, so put
+all your rules at the top.
+
 ## Anomalies and the `[absorb]` policy
 
 When source AND target both diverge from each other, `yui` can't
@@ -181,7 +204,6 @@ globally.
 `v0.4.0` ships the absorb story end-to-end — chezmoi-replacement
 ready for simple repos. Known gaps:
 
-- no `.yuiignore` (gitignore-style exclusion) yet
 - no hook-script support (chezmoi's `run_*` scripts)
 - no built-in encryption (use `pass` / `1password-cli` from a Tera
   template instead)

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -51,9 +51,12 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
     let source = resolve_source(source)?;
     let yui = YuiVars::detect(&source);
     let config = config::load(&source, &yui)?;
+    // Load `.yuiignore` once and thread through render + walk so the
+    // matcher isn't re-built per-flow.
+    let yuiignore = paths::load_yuiignore(&source)?;
 
     // 1. Render templates first so the link walk picks up rendered files.
-    let render_report = render::render_all(&source, &config, &yui, dry_run)?;
+    let render_report = render::render_all(&source, &config, &yui, &yuiignore, dry_run)?;
     log_render_report(&render_report);
     if render_report.has_drift() {
         anyhow::bail!(
@@ -73,7 +76,6 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
     )?;
 
     let backup_root = source.join(&config.backup.dir);
-    let yuiignore = paths::load_yuiignore(&source)?;
     let ctx = ApplyCtx {
         config: &config,
         source: &source,
@@ -417,8 +419,9 @@ pub fn render(source: Option<Utf8PathBuf>, check: bool, dry_run: bool) -> Result
     let source = resolve_source(source)?;
     let yui = YuiVars::detect(&source);
     let config = config::load(&source, &yui)?;
+    let yuiignore = paths::load_yuiignore(&source)?;
     // --check is a stricter dry-run: never writes, exits non-zero on drift.
-    let report = render::render_all(&source, &config, &yui, dry_run || check)?;
+    let report = render::render_all(&source, &config, &yui, &yuiignore, dry_run || check)?;
     log_render_report(&report);
     if check && report.has_drift() {
         anyhow::bail!("render drift detected ({} file(s))", report.diverged.len());
@@ -479,10 +482,14 @@ pub fn status(
     let color = !no_color && supports_color_stdout();
 
     let mut report: Vec<StatusItem> = Vec::new();
+    // Load `.yuiignore` once and reuse for both render-drift detection
+    // and the link-drift walk below.
+    let yuiignore = paths::load_yuiignore(&source)?;
 
     // 1. Template drift — render in dry-run mode and surface anything
     //    whose rendered counterpart on disk no longer matches.
-    let render_report = render::render_all(&source, &config, &yui, /* dry_run */ true)?;
+    let render_report =
+        render::render_all(&source, &config, &yui, &yuiignore, /* dry_run */ true)?;
     for rendered in &render_report.diverged {
         // `diverged` holds the rendered path; the template lives at
         // `<rendered>.tera`. Show the .tera as src so it's clear which
@@ -496,7 +503,6 @@ pub fn status(
     }
 
     // 2. Link drift — classify each src→dst pair under every mount.
-    let yuiignore = paths::load_yuiignore(&source)?;
     for m in &mounts {
         let src_root = source.join(&m.src);
         if !src_root.is_dir() {
@@ -801,9 +807,18 @@ pub fn absorb(source: Option<Utf8PathBuf>, target: Utf8PathBuf, dry_run: bool) -
 
     let mut engine = template::Engine::new();
     let tera_ctx = template::template_context(&yui, &config.vars);
+    // Single load — the matcher is shared with both find_source_for_target
+    // and the eventual ApplyCtx below.
+    let yuiignore = paths::load_yuiignore(&source)?;
 
-    let src_path = match find_source_for_target(&source, &config, &target, &mut engine, &tera_ctx)?
-    {
+    let src_path = match find_source_for_target(
+        &source,
+        &config,
+        &target,
+        &mut engine,
+        &tera_ctx,
+        &yuiignore,
+    )? {
         Some(s) => s,
         None => anyhow::bail!(
             "no mount entry / .yuilink override claims target {target}; \
@@ -819,7 +834,6 @@ pub fn absorb(source: Option<Utf8PathBuf>, target: Utf8PathBuf, dry_run: bool) -
     }
 
     let backup_root = source.join(&config.backup.dir);
-    let yuiignore = paths::load_yuiignore(&source)?;
     let ctx = ApplyCtx {
         config: &config,
         source: &source,
@@ -844,9 +858,8 @@ fn find_source_for_target(
     target: &Utf8Path,
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
+    yuiignore: &ignore::gitignore::Gitignore,
 ) -> Result<Option<Utf8PathBuf>> {
-    let yuiignore = paths::load_yuiignore(source)?;
-
     // 1. Mount entries — render dst, see if target is inside it.
     for entry in &config.mount.entry {
         if let Some(when) = &entry.when {
@@ -861,7 +874,7 @@ fn find_source_for_target(
             // Honor `.yuiignore` even on manual absorb — if you've
             // ignored a path, you've explicitly opted out of yui's
             // managing it.
-            if paths::is_ignored(&yuiignore, source, &candidate, candidate.is_dir()) {
+            if paths::is_ignored(yuiignore, source, &candidate, candidate.is_dir()) {
                 continue;
             }
             return Ok(Some(candidate));
@@ -892,7 +905,7 @@ fn find_source_for_target(
             Ok(p) => p,
             Err(_) => continue,
         };
-        if paths::is_ignored(&yuiignore, source, &dir_utf8, true) {
+        if paths::is_ignored(yuiignore, source, &dir_utf8, true) {
             continue;
         }
         let spec = match marker::read_spec(&dir_utf8, marker_filename)? {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -73,9 +73,11 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
     )?;
 
     let backup_root = source.join(&config.backup.dir);
+    let yuiignore = paths::load_yuiignore(&source)?;
     let ctx = ApplyCtx {
         config: &config,
         source: &source,
+        yuiignore: &yuiignore,
         file_mode: resolve_file_mode(config.link.file_mode),
         dir_mode: resolve_dir_mode(config.link.dir_mode),
         backup_root: &backup_root,
@@ -116,8 +118,12 @@ fn log_render_report(r: &RenderReport) {
 /// Bundle of immutable settings threaded through the apply walk.
 struct ApplyCtx<'a> {
     config: &'a Config,
-    /// Source repo root — needed for git-clean checks during absorb.
+    /// Source repo root — needed for git-clean checks during absorb and
+    /// for resolving paths inside `is_ignored` against `.yuiignore`.
     source: &'a Utf8Path,
+    /// Patterns from `$source/.yuiignore`. Empty matcher when the file
+    /// is absent.
+    yuiignore: &'a ignore::gitignore::Gitignore,
     file_mode: EffectiveFileMode,
     dir_mode: EffectiveDirMode,
     backup_root: &'a Utf8Path,
@@ -178,6 +184,7 @@ struct ListItem {
 fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Result<Vec<ListItem>> {
     let mut engine = template::Engine::new();
     let tera_ctx = template::template_context(yui, &config.vars);
+    let yuiignore = paths::load_yuiignore(source)?;
     let mut items = Vec::new();
 
     // 1. config.toml [[mount.entry]] entries
@@ -220,6 +227,10 @@ fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Resu
             Ok(p) => p,
             Err(_) => continue,
         };
+        // .yuiignore filter — markers inside ignored subtrees are skipped.
+        if paths::is_ignored(&yuiignore, source, &dir_utf8, true) {
+            continue;
+        }
         let spec = match marker::read_spec(&dir_utf8, marker_filename)? {
             Some(s) => s,
             None => continue,
@@ -485,6 +496,7 @@ pub fn status(
     }
 
     // 2. Link drift — classify each src→dst pair under every mount.
+    let yuiignore = paths::load_yuiignore(&source)?;
     for m in &mounts {
         let src_root = source.join(&m.src);
         if !src_root.is_dir() {
@@ -499,6 +511,7 @@ pub fn status(
             &mut engine,
             &tera_ctx,
             &source,
+            &yuiignore,
             &mut report,
         )?;
     }
@@ -553,8 +566,13 @@ fn classify_walk(
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
     source_root: &Utf8Path,
+    yuiignore: &ignore::gitignore::Gitignore,
     report: &mut Vec<StatusItem>,
 ) -> Result<()> {
+    if paths::is_ignored(yuiignore, source_root, src_dir, /* is_dir */ true) {
+        return Ok(());
+    }
+
     let marker_filename = &config.mount.marker_filename;
 
     if strategy == MountStrategy::Marker {
@@ -602,6 +620,9 @@ fn classify_walk(
         let src_path = src_dir.join(name);
         let dst_path = dst_dir.join(name);
         let ft = entry.file_type()?;
+        if paths::is_ignored(yuiignore, source_root, &src_path, ft.is_dir()) {
+            continue;
+        }
         if ft.is_dir() {
             classify_walk(
                 &src_path,
@@ -611,6 +632,7 @@ fn classify_walk(
                 engine,
                 tera_ctx,
                 source_root,
+                yuiignore,
                 report,
             )?;
         } else if ft.is_file() {
@@ -797,9 +819,11 @@ pub fn absorb(source: Option<Utf8PathBuf>, target: Utf8PathBuf, dry_run: bool) -
     }
 
     let backup_root = source.join(&config.backup.dir);
+    let yuiignore = paths::load_yuiignore(&source)?;
     let ctx = ApplyCtx {
         config: &config,
         source: &source,
+        yuiignore: &yuiignore,
         file_mode: resolve_file_mode(config.link.file_mode),
         dir_mode: resolve_dir_mode(config.link.dir_mode),
         backup_root: &backup_root,
@@ -821,6 +845,8 @@ fn find_source_for_target(
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
 ) -> Result<Option<Utf8PathBuf>> {
+    let yuiignore = paths::load_yuiignore(source)?;
+
     // 1. Mount entries — render dst, see if target is inside it.
     for entry in &config.mount.entry {
         if let Some(when) = &entry.when {
@@ -831,7 +857,14 @@ fn find_source_for_target(
         let dst_str = engine.render(&entry.dst, tera_ctx)?;
         let dst_root = paths::expand_tilde(dst_str.trim());
         if let Ok(rel) = target.strip_prefix(&dst_root) {
-            return Ok(Some(source.join(&entry.src).join(rel)));
+            let candidate = source.join(&entry.src).join(rel);
+            // Honor `.yuiignore` even on manual absorb — if you've
+            // ignored a path, you've explicitly opted out of yui's
+            // managing it.
+            if paths::is_ignored(&yuiignore, source, &candidate, candidate.is_dir()) {
+                continue;
+            }
+            return Ok(Some(candidate));
         }
     }
 
@@ -859,6 +892,9 @@ fn find_source_for_target(
             Ok(p) => p,
             Err(_) => continue,
         };
+        if paths::is_ignored(&yuiignore, source, &dir_utf8, true) {
+            continue;
+        }
         let spec = match marker::read_spec(&dir_utf8, marker_filename)? {
             Some(s) => s,
             None => continue,
@@ -952,6 +988,12 @@ fn walk_and_link(
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
 ) -> Result<()> {
+    // `.yuiignore` short-circuit — entire subtrees that match are skipped
+    // without even reading their marker / iterating their children.
+    if paths::is_ignored(ctx.yuiignore, ctx.source, src_dir, /* is_dir */ true) {
+        return Ok(());
+    }
+
     let marker_filename = &ctx.config.mount.marker_filename;
 
     if strategy == MountStrategy::Marker {
@@ -998,10 +1040,13 @@ fn walk_and_link(
             // Templates are handled by the render flow before linking.
             continue;
         }
-
         let src_path = src_dir.join(name);
         let dst_path = dst_dir.join(name);
         let ft = entry.file_type()?;
+
+        if paths::is_ignored(ctx.yuiignore, ctx.source, &src_path, ft.is_dir()) {
+            continue;
+        }
 
         if ft.is_dir() {
             walk_and_link(&src_path, &dst_path, ctx, strategy, engine, tera_ctx)?;
@@ -1906,6 +1951,78 @@ dst = "{}"
         std::fs::write(&stranger, "not yui's").unwrap();
         let err = absorb(Some(source), stranger, false).unwrap_err();
         assert!(format!("{err}").contains("no mount entry"));
+    }
+
+    #[test]
+    fn yuiignore_excludes_file_from_linking() {
+        let tmp = TempDir::new().unwrap();
+        let (source, target) = setup_minimal_dotfiles(&tmp);
+        std::fs::write(source.join("home/.bashrc"), "kept").unwrap();
+        std::fs::write(source.join("home/lock.json"), "ignored").unwrap();
+        // Exclude `lock.json` files anywhere under source.
+        std::fs::write(source.join(".yuiignore"), "**/lock.json\n").unwrap();
+        apply(Some(source.clone()), false).unwrap();
+        assert!(target.join(".bashrc").exists());
+        assert!(
+            !target.join("lock.json").exists(),
+            "yuiignore should keep lock.json out of target"
+        );
+    }
+
+    #[test]
+    fn yuiignore_excludes_directory_subtree() {
+        let tmp = TempDir::new().unwrap();
+        let (source, target) = setup_minimal_dotfiles(&tmp);
+        std::fs::create_dir_all(source.join("home/cache")).unwrap();
+        std::fs::write(source.join("home/.bashrc"), "kept").unwrap();
+        std::fs::write(source.join("home/cache/a"), "ignored").unwrap();
+        std::fs::write(source.join("home/cache/b"), "also ignored").unwrap();
+        // Trailing slash → match dirs only; entire subtree skipped.
+        std::fs::write(source.join(".yuiignore"), "home/cache/\n").unwrap();
+        apply(Some(source.clone()), false).unwrap();
+        assert!(target.join(".bashrc").exists());
+        assert!(
+            !target.join("cache").exists(),
+            "yuiignore'd subtree should not appear in target"
+        );
+    }
+
+    #[test]
+    fn yuiignore_negation_re_includes_file() {
+        let tmp = TempDir::new().unwrap();
+        let (source, target) = setup_minimal_dotfiles(&tmp);
+        std::fs::write(source.join("home/keep.cache"), "kept by negation").unwrap();
+        std::fs::write(source.join("home/drop.cache"), "ignored").unwrap();
+        // Ignore all .cache files except keep.cache.
+        std::fs::write(source.join(".yuiignore"), "*.cache\n!keep.cache\n").unwrap();
+        apply(Some(source.clone()), false).unwrap();
+        assert!(target.join("keep.cache").exists());
+        assert!(!target.join("drop.cache").exists());
+    }
+
+    #[test]
+    fn yuiignore_skips_template_in_render() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        let target = utf8(tmp.path().join("target"));
+        std::fs::create_dir_all(source.join("home")).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(source.join("home/note.tera"), "{{ yui.os }}").unwrap();
+        std::fs::write(source.join(".yuiignore"), "home/note*\n").unwrap();
+        let cfg = format!(
+            r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+            toml_path(&target)
+        );
+        std::fs::write(source.join("config.toml"), cfg).unwrap();
+        apply(Some(source.clone()), false).unwrap();
+        // Neither the template nor the rendered output linked.
+        assert!(!source.join("home/note").exists());
+        assert!(!target.join("note").exists());
+        assert!(!target.join("note.tera").exists());
     }
 
     fn walkdir(root: &Utf8Path) -> Vec<Utf8PathBuf> {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -40,6 +40,48 @@ pub fn home_dir() -> Option<Utf8PathBuf> {
         .map(Utf8PathBuf::from)
 }
 
+/// Load `$source/.yuiignore` as a gitignore-style matcher.
+///
+/// Returns an empty matcher when the file is absent (so `is_ignored`
+/// becomes a no-op). Patterns use full gitignore syntax: glob (`*`,
+/// `**`), negation (`!`), trailing-slash dir-only matching, comments
+/// (`#`).
+///
+/// Currently only the repo-root `.yuiignore` is honored — nested
+/// `.yuiignore` files inside subdirectories are not yet walked. (The
+/// 95% case is "exclude `**/lock.json` once at the top".) If you need
+/// per-subtree rules, file an issue with the use case.
+pub fn load_yuiignore(source: &Utf8Path) -> crate::Result<ignore::gitignore::Gitignore> {
+    let path = source.join(".yuiignore");
+    if !path.is_file() {
+        return Ok(ignore::gitignore::Gitignore::empty());
+    }
+    let mut builder = ignore::gitignore::GitignoreBuilder::new(source);
+    if let Some(e) = builder.add(path.as_std_path()) {
+        return Err(crate::Error::Config(format!("parsing {path}: {e}")));
+    }
+    builder
+        .build()
+        .map_err(|e| crate::Error::Config(format!("building .yuiignore: {e}")))
+}
+
+/// Test a path against the loaded `.yuiignore` matcher. `path` may be
+/// absolute or relative to `source` — relative is computed automatically.
+/// Uses `matched_path_or_any_parents` so an ignored ancestor directory
+/// causes the descendant file to be ignored too.
+pub fn is_ignored(
+    gi: &ignore::gitignore::Gitignore,
+    source: &Utf8Path,
+    path: &Utf8Path,
+    is_dir: bool,
+) -> bool {
+    let rel = path.strip_prefix(source).unwrap_or(path);
+    matches!(
+        gi.matched_path_or_any_parents(rel.as_std_path(), is_dir),
+        ignore::Match::Ignore(_)
+    )
+}
+
 /// Build a source-tree walker that skips yui's internal `.yui/` directory.
 ///
 /// `.yui/backup/` can grow huge over time, and `.yui/rendered/` (future)

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -65,8 +65,16 @@ pub fn load_yuiignore(source: &Utf8Path) -> crate::Result<ignore::gitignore::Git
         .map_err(|e| crate::Error::Config(format!("building .yuiignore: {e}")))
 }
 
-/// Test a path against the loaded `.yuiignore` matcher. `path` may be
-/// absolute or relative to `source` — relative is computed automatically.
+/// Test a path against the loaded `.yuiignore` matcher.
+///
+/// `path` is treated relative to `source` (gitignore convention). Paths
+/// that don't live under `source` can't possibly match a source-rooted
+/// rule, so they short-circuit to `false`. Without this guard, an
+/// absolute path passed through `unwrap_or(path)` would land on the
+/// matcher as an absolute, which `Gitignore` would test using its
+/// rightmost component — leading to spurious matches for paths outside
+/// the repo. (Caught in PR #19 review.)
+///
 /// Uses `matched_path_or_any_parents` so an ignored ancestor directory
 /// causes the descendant file to be ignored too.
 pub fn is_ignored(
@@ -75,7 +83,9 @@ pub fn is_ignored(
     path: &Utf8Path,
     is_dir: bool,
 ) -> bool {
-    let rel = path.strip_prefix(source).unwrap_or(path);
+    let Ok(rel) = path.strip_prefix(source) else {
+        return false;
+    };
     matches!(
         gi.matched_path_or_any_parents(rel.as_std_path(), is_dir),
         ignore::Match::Ignore(_)

--- a/src/render.rs
+++ b/src/render.rs
@@ -59,12 +59,14 @@ pub fn render_all(
     let mut engine = Engine::new();
     let ctx = template::template_context(yui, &config.vars);
     let rules = compile_rules(&config.render.rule)?;
+    let yuiignore = paths::load_yuiignore(source)?;
     let mut report = RenderReport::default();
 
     // Walk every file under source. Filtering is centralized in
     // `paths::source_walker`: ignore-files OFF (so unrelated user rules
     // don't swallow `.tera`s) and `.yui/` skipped (backup mirrors etc.
-    // shouldn't be rendered).
+    // shouldn't be rendered). `.yuiignore` patterns are checked per
+    // entry below.
     let walker = paths::source_walker(source).build();
     for entry in walker {
         let entry = match entry {
@@ -85,6 +87,11 @@ pub fn render_all(
             Ok(p) => p,
             Err(_) => continue,
         };
+        // `.yuiignore` filter — also skip rendering the rendered counterpart
+        // (since that's what'd land in the user's tree).
+        if paths::is_ignored(&yuiignore, source, &template_path, false) {
+            continue;
+        }
         process_template(
             &template_path,
             source,

--- a/src/render.rs
+++ b/src/render.rs
@@ -54,12 +54,12 @@ pub fn render_all(
     source: &Utf8Path,
     config: &Config,
     yui: &YuiVars,
+    yuiignore: &ignore::gitignore::Gitignore,
     dry_run: bool,
 ) -> Result<RenderReport> {
     let mut engine = Engine::new();
     let ctx = template::template_context(yui, &config.vars);
     let rules = compile_rules(&config.render.rule)?;
-    let yuiignore = paths::load_yuiignore(source)?;
     let mut report = RenderReport::default();
 
     // Walk every file under source. Filtering is centralized in
@@ -89,7 +89,7 @@ pub fn render_all(
         };
         // `.yuiignore` filter — also skip rendering the rendered counterpart
         // (since that's what'd land in the user's tree).
-        if paths::is_ignored(&yuiignore, source, &template_path, false) {
+        if paths::is_ignored(yuiignore, source, &template_path, false) {
             continue;
         }
         process_template(
@@ -404,7 +404,14 @@ mod tests {
             &r.join("home/.gitconfig.tera"),
             "[user]\n  os = {{ yui.os }}\n",
         );
-        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        let report = render_all(
+            &r,
+            &empty_config(),
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         assert_eq!(report.written.len(), 1);
         assert_eq!(
             std::fs::read_to_string(r.join("home/.gitconfig")).unwrap(),
@@ -420,7 +427,14 @@ mod tests {
         let mut cfg = empty_config();
         cfg.vars
             .insert("greet".into(), toml::Value::String("hello".into()));
-        let _ = render_all(&r, &cfg, &yui_vars(&r), false).unwrap();
+        let _ = render_all(
+            &r,
+            &cfg,
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         assert_eq!(
             std::fs::read_to_string(r.join("home/foo")).unwrap(),
             "hello"
@@ -435,7 +449,14 @@ mod tests {
             &r.join("home/foo.tera"),
             "{# yui:when yui.os == 'windows' #}\nbody",
         );
-        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        let report = render_all(
+            &r,
+            &empty_config(),
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         assert!(report.written.is_empty());
         assert_eq!(report.skipped_when_false.len(), 1);
         assert!(!r.join("home/foo").exists());
@@ -449,7 +470,14 @@ mod tests {
             &r.join("home/foo.tera"),
             "{# yui:when yui.os == 'linux' #}\nbody",
         );
-        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        let report = render_all(
+            &r,
+            &empty_config(),
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         assert_eq!(report.written.len(), 1);
         assert_eq!(std::fs::read_to_string(r.join("home/foo")).unwrap(), "body");
     }
@@ -464,7 +492,14 @@ mod tests {
             r#match: "home/win/**".into(),
             when: Some("{{ yui.os == 'windows' }}".into()),
         });
-        let report = render_all(&r, &cfg, &yui_vars(&r), false).unwrap();
+        let report = render_all(
+            &r,
+            &cfg,
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         assert_eq!(report.skipped_when_false.len(), 1);
         assert!(report.written.is_empty());
     }
@@ -480,7 +515,14 @@ mod tests {
             r#match: "home/win/**".into(),
             when: Some("{{ yui.os == 'windows' }}".into()),
         });
-        let report = render_all(&r, &cfg, &yui_vars(&r), false).unwrap();
+        let report = render_all(
+            &r,
+            &cfg,
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         assert_eq!(report.written.len(), 1);
     }
 
@@ -490,7 +532,14 @@ mod tests {
         let r = root(&tmp);
         write(&r.join("home/foo.tera"), "body");
         write(&r.join("home/foo"), "body"); // already in sync
-        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        let report = render_all(
+            &r,
+            &empty_config(),
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         assert!(report.written.is_empty());
         assert_eq!(report.unchanged.len(), 1);
     }
@@ -501,7 +550,14 @@ mod tests {
         let r = root(&tmp);
         write(&r.join("home/foo.tera"), "fresh body");
         write(&r.join("home/foo"), "manually edited");
-        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        let report = render_all(
+            &r,
+            &empty_config(),
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         assert!(report.has_drift());
         assert_eq!(report.diverged.len(), 1);
         // existing content NOT overwritten
@@ -516,7 +572,14 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let r = root(&tmp);
         write(&r.join("home/foo.tera"), "body");
-        let _ = render_all(&r, &empty_config(), &yui_vars(&r), true).unwrap();
+        let _ = render_all(
+            &r,
+            &empty_config(),
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            true,
+        )
+        .unwrap();
         assert!(!r.join("home/foo").exists());
         assert!(!r.join(".gitignore").exists());
     }
@@ -527,7 +590,14 @@ mod tests {
         let r = root(&tmp);
         write(&r.join("home/foo.tera"), "body");
         write(&r.join("home/bar.tera"), "body2");
-        let _ = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        let _ = render_all(
+            &r,
+            &empty_config(),
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
         assert!(gi.contains(GITIGNORE_BEGIN));
         assert!(gi.contains(GITIGNORE_END));
@@ -545,7 +615,14 @@ mod tests {
         let r = root(&tmp);
         write(&r.join(".gitignore"), "node_modules/\ntarget/\n");
         write(&r.join("home/foo.tera"), "body");
-        let _ = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        let _ = render_all(
+            &r,
+            &empty_config(),
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
         assert!(gi.contains("node_modules/"));
         assert!(gi.contains("target/"));
@@ -562,7 +639,14 @@ mod tests {
             &format!("node_modules/\n\n{GITIGNORE_BEGIN}\nstale/path\n{GITIGNORE_END}\n\nfoo\n"),
         );
         write(&r.join("home/foo.tera"), "body");
-        let _ = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        let _ = render_all(
+            &r,
+            &empty_config(),
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
         assert!(gi.contains("node_modules/"));
         assert!(gi.contains("home/foo"));
@@ -578,7 +662,14 @@ mod tests {
         // Pre-existing .gitignore that would normally hide `node_modules/`.
         write(&r.join(".gitignore"), "node_modules/\n");
         write(&r.join("node_modules/foo.tera"), "body");
-        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        let report = render_all(
+            &r,
+            &empty_config(),
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         // Template under a gitignored dir is still discovered + rendered.
         assert_eq!(report.written.len(), 1);
         assert!(r.join("node_modules/foo").exists());
@@ -594,7 +685,14 @@ mod tests {
             "{# yui:when yui.os == 'windows' #}\nbody",
         );
         write(&r.join("home/foo"), "old rendered output");
-        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        let report = render_all(
+            &r,
+            &empty_config(),
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         assert_eq!(report.skipped_when_false.len(), 1);
         // Stale sibling was cleaned up so apply won't link it.
         assert!(!r.join("home/foo").exists());
@@ -611,7 +709,14 @@ mod tests {
             r#match: "home/win/**".into(),
             when: Some("{{ yui.os == 'windows' }}".into()),
         });
-        let report = render_all(&r, &cfg, &yui_vars(&r), false).unwrap();
+        let report = render_all(
+            &r,
+            &cfg,
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         assert_eq!(report.skipped_when_false.len(), 1);
         assert!(!r.join("home/win/settings").exists());
     }
@@ -622,7 +727,14 @@ mod tests {
         let r = root(&tmp);
         write(&r.join("home/foo.tera"), "{# yui:when false #}\nbody");
         write(&r.join("home/foo"), "old rendered output");
-        let _ = render_all(&r, &empty_config(), &yui_vars(&r), true).unwrap();
+        let _ = render_all(
+            &r,
+            &empty_config(),
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            true,
+        )
+        .unwrap();
         // Dry-run leaves the on-disk file alone.
         assert_eq!(
             std::fs::read_to_string(r.join("home/foo")).unwrap(),
@@ -637,7 +749,14 @@ mod tests {
         write(&r.join("home/foo.tera"), "body");
         let mut cfg = empty_config();
         cfg.render.manage_gitignore = false;
-        let _ = render_all(&r, &cfg, &yui_vars(&r), false).unwrap();
+        let _ = render_all(
+            &r,
+            &cfg,
+            &yui_vars(&r),
+            &ignore::gitignore::Gitignore::empty(),
+            false,
+        )
+        .unwrap();
         assert!(r.join("home/foo").exists());
         assert!(!r.join(".gitignore").exists());
     }


### PR DESCRIPTION
## Summary

Closes the last "known gap" called out in the 0.4.0 README: yui now
honors a \`\$DOTFILES/.yuiignore\` file with gitignore-style patterns.
Matched paths are dropped from every yui flow — render won't render
them, list / status won't show them, apply won't link them, manual
absorb refuses to claim them.

\`\`\`gitignore
# \$DOTFILES/.yuiignore
**/.DS_Store
**/lock.json
build/
!build/result.toml
\`\`\`

Threaded through all 5 walks (render, list, status, find_source,
apply). For directories \`apply\` returns early on a match so an
ignored subtree never gets read or recursed into.

**Scope limitation**: only the repo-root \`.yuiignore\` is honored.
Nested \`.yuiignore\` files in subdirectories are not yet walked. The
common "exclude \`**/lock.json\` once at the top" case is covered;
nested support can come later if a real use case shows up. README
documents the limitation.

## Test plan

- [x] \`cargo make check\` clean
- [x] 89 unit tests passing (4 new: file exclusion, dir-subtree
      exclusion, \`!\`-negation re-include, template-render skip)
- [ ] CI on \`feat/yuiignore\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)