### PR TITLE
feat: hook system — run user scripts around apply

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,6 +1841,8 @@ dependencies = [
  "predicates",
  "same-file",
  "serde",
+ "serde_json",
+ "sha2",
  "similar",
  "tempfile",
  "tera",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ jiff = { version = "0.2", features = ["serde"] }
 owo-colors = "4"
 same-file = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
 similar = "2"
 tera = "1"
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -160,6 +160,65 @@ Currently only the repo-root `.yuiignore` is honored — nested
 `.yuiignore` files inside subdirectories are not yet walked, so put
 all your rules at the top.
 
+## Hooks — run scripts around `apply`
+
+Drop a script under `$DOTFILES/.yui/bin/` and reference it with a
+`[[hook]]` entry. The script stays a normal executable (you can run
+it directly without yui); yui just decides *when* to invoke it.
+
+```toml
+[[hook]]
+name   = "brew-bundle"
+script = ".yui/bin/brew-bundle.sh"
+# Defaults: command="bash", args=["{{ script_path }}"], when_run="onchange", phase="post"
+when   = "yui.os == 'macos'"
+```
+
+Schema:
+
+| field | required? | default | meaning |
+|---|---|---|---|
+| `name` | ✓ | — | unique identifier (state-tracking key, `yui hooks run <name>`) |
+| `script` | ✓ | — | path to script, relative to `$DOTFILES` |
+| `command` | | `"bash"` | Tera-templated interpreter |
+| `args` | | `["{{ script_path }}"]` | Tera-templated each |
+| `when_run` | | `"onchange"` | `once` \| `onchange` \| `every` |
+| `phase` | | `"post"` | `pre` \| `post` (around `apply`) |
+| `when` | | _always_ | optional Tera bool predicate |
+
+`onchange` re-runs whenever the script's SHA-256 differs from the
+last successful run. State is tracked in `$DOTFILES/.yui/state.json`
+(gitignored — it's per-machine).
+
+`command` and each `args` element are Tera-rendered with the standard
+`yui.*` / `vars.*` / `env(...)` plus these extras for the script:
+`script_path`, `script_dir`, `script_name`, `script_stem`,
+`script_ext`. Example with a Deno script:
+
+```toml
+[[hook]]
+name = "denops-build"
+script = ".yui/bin/build.ts"
+command = "deno"
+args = ["run", "-A", "{{ script_path }}"]
+when_run = "onchange"
+phase = "post"
+when = "yui.os != 'windows'"
+```
+
+Manual control:
+
+```sh
+yui hooks list                    # what's configured + last-run state
+yui hooks run                     # run all hooks per their rules
+yui hooks run brew-bundle         # run just this one (still honors `when`)
+yui hooks run brew-bundle --force # bypass when_run state check
+```
+
+`apply` runs `pre` hooks before render/link and `post` hooks after
+all linking. A failing hook stops `apply` immediately — fix the
+script, then re-run.
+
 ## Anomalies and the `[absorb]` policy
 
 When source AND target both diverge from each other, `yui` can't
@@ -194,6 +253,8 @@ Need to absorb a single file regardless of policy? `yui absorb
 | `yui unlink <path>...` | tear down a specific link |
 | `yui doctor` | environment sanity check |
 | `yui gc-backup [--older-than DUR]` | clean old backups (**not yet implemented** — calling it errors out) |
+| `yui hooks list` | show configured `[[hook]]` entries + last-run state |
+| `yui hooks run [<name>] [--force]` | run hooks on demand (bypassing `when_run` with `--force`) |
 
 `--icons` accepts `unicode` (default), `nerd` (Nerd-Font glyphs),
 `ascii` (CI-log-safe). The `[ui] icons = "..."` config key sets it
@@ -204,7 +265,6 @@ globally.
 `v0.4.0` ships the absorb story end-to-end — chezmoi-replacement
 ready for simple repos. Known gaps:
 
-- no hook-script support (chezmoi's `run_*` scripts)
 - no built-in encryption (use `pass` / `1password-cli` from a Tera
   template instead)
 - chezmoi name-prefix translation (`dot_zshrc` → `.zshrc`,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,6 +92,29 @@ pub enum Command {
         #[arg(long)]
         older_than: Option<String>,
     },
+
+    /// Manage `[[hook]]` scripts
+    Hooks {
+        #[command(subcommand)]
+        action: HookAction,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum HookAction {
+    /// List configured hooks with their last-run state
+    List,
+    /// Run a hook (or every hook). The `when` filter is always honored;
+    /// `--force` bypasses the `when_run` state check (so a `once` hook
+    /// can be re-run, an `onchange` hook re-runs even with matching
+    /// hash).
+    Run {
+        /// Hook name (omit to run every hook per its `when_run` rule)
+        name: Option<String>,
+        /// Bypass the `when_run` state check
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 impl Cli {
@@ -112,6 +135,10 @@ impl Cli {
             Command::Absorb { target, dry_run } => cmd::absorb(source, target, dry_run),
             Command::Doctor => cmd::doctor(source),
             Command::GcBackup { older_than } => cmd::gc_backup(source, older_than),
+            Command::Hooks { action } => match action {
+                HookAction::List => cmd::hooks_list(source),
+                HookAction::Run { name, force } => cmd::hooks_run(source, name, force),
+            },
         }
     }
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -10,7 +10,8 @@ use camino::{Utf8Path, Utf8PathBuf};
 use tera::Context as TeraContext;
 use tracing::{info, warn};
 
-use crate::config::{self, Config, IconsMode, MountStrategy};
+use crate::config::{self, Config, HookPhase, IconsMode, MountStrategy};
+use crate::hook::{self, HookOutcome};
 use crate::icons::Icons;
 use crate::link::{self, EffectiveDirMode, EffectiveFileMode, resolve_dir_mode, resolve_file_mode};
 use crate::marker::{self, MarkerSpec};
@@ -55,6 +56,21 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
     // matcher isn't re-built per-flow.
     let yuiignore = paths::load_yuiignore(&source)?;
 
+    let mut engine = template::Engine::new();
+    let tera_ctx = template::template_context(&yui, &config.vars);
+
+    // 0. Pre-apply hooks (before render / link). Bail on hook failure so
+    //    apply doesn't proceed past a broken bootstrap.
+    hook::run_phase(
+        &config,
+        &source,
+        &yui,
+        &mut engine,
+        &tera_ctx,
+        HookPhase::Pre,
+        dry_run,
+    )?;
+
     // 1. Render templates first so the link walk picks up rendered files.
     let render_report = render::render_all(&source, &config, &yui, &yuiignore, dry_run)?;
     log_render_report(&render_report);
@@ -66,8 +82,6 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
     }
 
     // 2. Resolve mounts and link.
-    let mut engine = template::Engine::new();
-    let tera_ctx = template::template_context(&yui, &config.vars);
     let mounts = mount::resolve(
         &config.mount.entry,
         config.mount.default_strategy,
@@ -96,6 +110,17 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
         info!("mount: {} → {}", m.src, m.dst);
         process_mount(&source, m, &ctx, &mut engine, &tera_ctx)?;
     }
+
+    // 3. Post-apply hooks (after every link is in place).
+    hook::run_phase(
+        &config,
+        &source,
+        &yui,
+        &mut engine,
+        &tera_ctx,
+        HookPhase::Post,
+        dry_run,
+    )?;
     Ok(())
 }
 
@@ -972,6 +997,99 @@ pub fn doctor(source: Option<Utf8PathBuf>) -> Result<()> {
 
 pub fn gc_backup(_source: Option<Utf8PathBuf>, _older_than: Option<String>) -> Result<()> {
     todo!("yui gc-backup — clean up old backups")
+}
+
+/// `yui hooks list` — show every configured hook + its last-run state.
+pub fn hooks_list(source: Option<Utf8PathBuf>) -> Result<()> {
+    let source = resolve_source(source)?;
+    let yui = YuiVars::detect(&source);
+    let config = config::load(&source, &yui)?;
+    let state = hook::State::load(&source)?;
+
+    if config.hook.is_empty() {
+        println!("(no [[hook]] entries in config)");
+        return Ok(());
+    }
+
+    for h in &config.hook {
+        let phase = match h.phase {
+            HookPhase::Pre => "pre",
+            HookPhase::Post => "post",
+        };
+        let when_run = match h.when_run {
+            config::WhenRun::Once => "once",
+            config::WhenRun::Onchange => "onchange",
+            config::WhenRun::Every => "every",
+        };
+        let last = state
+            .hooks
+            .get(&h.name)
+            .and_then(|s| s.last_run_at.as_deref())
+            .unwrap_or("(never)");
+        println!(
+            "{name:<20}  phase={phase:<4}  when_run={when_run:<8}  last_run_at={last}",
+            name = h.name,
+        );
+        if let Some(when) = &h.when {
+            println!("                       when = {when}");
+        }
+        println!("                       script = {}", h.script);
+        println!(
+            "                       command = {} {}",
+            h.command,
+            h.args.join(" ")
+        );
+    }
+    Ok(())
+}
+
+/// `yui hooks run [<name>] [--force]` — run a single hook (or every
+/// hook) on demand. `--force` bypasses the `when_run` state check;
+/// the `when` filter (`yui.os == 'macos'` etc.) is always honored.
+pub fn hooks_run(source: Option<Utf8PathBuf>, name: Option<String>, force: bool) -> Result<()> {
+    let source = resolve_source(source)?;
+    let yui = YuiVars::detect(&source);
+    let config = config::load(&source, &yui)?;
+    let mut engine = template::Engine::new();
+    let tera_ctx = template::template_context(&yui, &config.vars);
+
+    let targets: Vec<&config::HookConfig> = match &name {
+        Some(want) => {
+            let m = config
+                .hook
+                .iter()
+                .find(|h| &h.name == want)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "no [[hook]] named {want:?}; run `yui hooks list` to see available names"
+                    )
+                })?;
+            vec![m]
+        }
+        None => config.hook.iter().collect(),
+    };
+
+    for h in targets {
+        let outcome = hook::run_hook(
+            h,
+            &source,
+            &yui,
+            &config.vars,
+            &mut engine,
+            &tera_ctx,
+            /* dry_run */ false,
+            force,
+        )?;
+        let label = match outcome {
+            HookOutcome::Ran => "ran",
+            HookOutcome::SkippedOnce => "skipped (once: already ran)",
+            HookOutcome::SkippedUnchanged => "skipped (onchange: hash matches)",
+            HookOutcome::SkippedWhenFalse => "skipped (when=false)",
+            HookOutcome::DryRun => "would run (dry-run)",
+        };
+        info!("hook[{}]: {label}", h.name);
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1069,6 +1069,7 @@ pub fn hooks_run(source: Option<Utf8PathBuf>, name: Option<String>, force: bool)
         None => config.hook.iter().collect(),
     };
 
+    let mut state = hook::State::load(&source)?;
     for h in targets {
         let outcome = hook::run_hook(
             h,
@@ -1077,6 +1078,7 @@ pub fn hooks_run(source: Option<Utf8PathBuf>, name: Option<String>, force: bool)
             &config.vars,
             &mut engine,
             &tera_ctx,
+            &mut state,
             /* dry_run */ false,
             force,
         )?;
@@ -1088,6 +1090,9 @@ pub fn hooks_run(source: Option<Utf8PathBuf>, name: Option<String>, force: bool)
             HookOutcome::DryRun => "would run (dry-run)",
         };
         info!("hook[{}]: {label}", h.name);
+        if outcome == HookOutcome::Ran {
+            state.save(&source)?;
+        }
     }
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,79 @@ pub struct Config {
 
     #[serde(default)]
     pub ui: UiConfig,
+
+    #[serde(default)]
+    pub hook: Vec<HookConfig>,
+}
+
+/// One hook = one script invocation triggered around `yui apply`.
+///
+/// The script lives at `$DOTFILES/<script>` (kept yui-agnostic — runnable
+/// directly with no yui involvement); `command` + `args` decide how to
+/// invoke it. Both are Tera-rendered with the standard yui context plus
+/// `script_path` / `script_dir` / `script_name` / `script_stem` /
+/// `script_ext`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HookConfig {
+    /// Unique identifier — used as the state-tracking key and the
+    /// argument to `yui hooks run <name>`.
+    pub name: String,
+    /// Script path relative to `$DOTFILES`. Hashed for `onchange` runs;
+    /// also exposed to `command` / `args` Tera as `script_path` etc.
+    pub script: Utf8PathBuf,
+
+    /// Interpreter / command to invoke. Tera-rendered. Default `"bash"`.
+    #[serde(default = "default_hook_command")]
+    pub command: String,
+    /// Arguments to `command`. Each element Tera-rendered. Default
+    /// `["{{ script_path }}"]`.
+    #[serde(default = "default_hook_args")]
+    pub args: Vec<String>,
+
+    /// Re-run policy. Default `Onchange`.
+    #[serde(default)]
+    pub when_run: WhenRun,
+    /// Apply phase to fire on. Default `Post`.
+    #[serde(default)]
+    pub phase: HookPhase,
+
+    /// Optional Tera bool predicate; absent = always eligible.
+    #[serde(default)]
+    pub when: Option<String>,
+}
+
+fn default_hook_command() -> String {
+    "bash".to_string()
+}
+
+fn default_hook_args() -> Vec<String> {
+    vec!["{{ script_path }}".to_string()]
+}
+
+#[derive(Debug, Deserialize, Default, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum WhenRun {
+    /// Run exactly once across the lifetime of the source repo. Tracked
+    /// via `last_run_at` in `.yui/state.json`.
+    Once,
+    /// Run when the script content (SHA-256 of `script`) differs from
+    /// the last successful run. Default — best fit for "re-run when I
+    /// edit the bootstrap".
+    #[default]
+    Onchange,
+    /// Run on every apply.
+    Every,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum HookPhase {
+    /// Before any render / link work — useful for prerequisite installs.
+    Pre,
+    /// After all linking finishes. Default — "I just `apply`'d, now
+    /// reload the launchd / brew bundle / etc.".
+    #[default]
+    Post,
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -69,15 +69,20 @@ impl State {
         }
     }
 
+    /// Atomically persist the state to disk: write to a sibling `.tmp`
+    /// file then rename, so an interrupted save can't leave a half-
+    /// written state.json behind. (gemini medium PR #20)
     pub fn save(&self, source: &Utf8Path) -> Result<()> {
         let path = source.join(STATE_REL_PATH);
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
+        let tmp = path.with_extension("json.tmp");
         let mut body = serde_json::to_string_pretty(self)
             .map_err(|e| Error::Config(format!("serialize state: {e}")))?;
         body.push('\n');
-        std::fs::write(&path, body)?;
+        std::fs::write(&tmp, body)?;
+        std::fs::rename(&tmp, &path)?;
         Ok(())
     }
 }
@@ -125,8 +130,10 @@ pub fn build_hook_context(
     ctx
 }
 
-/// Decide whether to run `hook` and run it if so. Side-effects:
-/// updates `.yui/state.json` on a successful run; nothing otherwise.
+/// Decide whether to run `hook` and run it if so. Updates `state` in
+/// memory on a successful run — caller is responsible for persisting
+/// (typically via `state.save(source)` after each `Ran` outcome, so a
+/// later hook failure doesn't lose the record of the earlier success).
 ///
 /// `force = true` bypasses the `when_run` state check (still respects
 /// `when` — an explicit `yui hooks run <name>` shouldn't suddenly run a
@@ -139,6 +146,7 @@ pub fn run_hook(
     vars: &toml::Table,
     engine: &mut Engine,
     base_ctx: &TeraContext,
+    state: &mut State,
     dry_run: bool,
     force: bool,
 ) -> Result<HookOutcome> {
@@ -150,16 +158,21 @@ pub fn run_hook(
 
     let script_path = source.join(&hook.script);
 
-    // Compute the script hash up front (cheap, and we want it to record
-    // on a successful run regardless of mode).
-    let current_hash = match std::fs::read(&script_path) {
-        Ok(bytes) => Some(sha256_hex(&bytes)),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
-        Err(e) => return Err(e.into()),
+    // Hash the script body only when the `when_run` policy actually
+    // uses the value (`Onchange`). For `Once` / `Every` we don't need
+    // the hash either for the decision OR for state, so skip the
+    // read+SHA. (gemini medium PR #20)
+    let current_hash = if hook.when_run == WhenRun::Onchange {
+        match std::fs::read(&script_path) {
+            Ok(bytes) => Some(sha256_hex(&bytes)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+            Err(e) => return Err(e.into()),
+        }
+    } else {
+        None
     };
 
     if !force {
-        let state = State::load(source)?;
         let prior = state.hooks.get(&hook.name);
         match hook.when_run {
             WhenRun::Once => {
@@ -178,15 +191,19 @@ pub fn run_hook(
         }
     }
 
-    if dry_run {
-        return Ok(HookOutcome::DryRun);
-    }
-
-    if current_hash.is_none() {
+    // Validate that the script exists *before* the dry-run early
+    // return — `apply --dry-run` should still surface a missing script
+    // as an error rather than silently reporting "would run". (gemini
+    // medium PR #20)
+    if !script_path.is_file() {
         return Err(Error::Other(anyhow::anyhow!(
             "hook[{}]: script not found at {script_path}",
             hook.name
         )));
+    }
+
+    if dry_run {
+        return Ok(HookOutcome::DryRun);
     }
 
     let hook_ctx = build_hook_context(yui, vars, &script_path);
@@ -216,19 +233,14 @@ pub fn run_hook(
         )));
     }
 
-    let mut state = State::load(source)?;
     state.version = STATE_VERSION;
     state.hooks.insert(
         hook.name.clone(),
         HookState {
             last_run_at: Some(now_iso8601()),
-            last_content_hash: match hook.when_run {
-                WhenRun::Onchange => current_hash,
-                _ => None,
-            },
+            last_content_hash: current_hash,
         },
     );
-    state.save(source)?;
 
     Ok(HookOutcome::Ran)
 }
@@ -245,6 +257,7 @@ pub fn run_phase(
     phase: HookPhase,
     dry_run: bool,
 ) -> Result<()> {
+    let mut state = State::load(source)?;
     for hook in &config.hook {
         if hook.phase != phase {
             continue;
@@ -256,6 +269,7 @@ pub fn run_phase(
             &config.vars,
             engine,
             base_ctx,
+            &mut state,
             dry_run,
             /* force */ false,
         )?;
@@ -264,6 +278,11 @@ pub fn run_phase(
             HookPhase::Post => "post",
         };
         info!("hook[{}] {phase_name}: {:?}", hook.name, outcome);
+        // Save after each successful run so a later failure doesn't
+        // discard the earlier successes.
+        if outcome == HookOutcome::Ran {
+            state.save(source)?;
+        }
     }
     Ok(())
 }
@@ -352,23 +371,55 @@ mod tests {
         path
     }
 
-    #[test]
-    fn dry_run_returns_dry_run_outcome() {
-        let tmp = TempDir::new().unwrap();
-        let source = utf8(tmp.path().to_path_buf());
-        write_script(&source, ".yui/bin/h.sh", "#!/bin/sh\nexit 0\n");
-        let hook = HookConfig {
+    /// Helper that wraps run_hook + a freshly-loaded state. Used by all
+    /// the test cases below — the production callers (`run_phase`,
+    /// `cmd::hooks_run`) reuse one State across multiple hooks, but
+    /// per-test isolation is fine here.
+    #[allow(clippy::too_many_arguments)]
+    fn run_hook_test(
+        hook: &HookConfig,
+        source: &Utf8Path,
+        yui: &YuiVars,
+        vars: &toml::Table,
+        engine: &mut Engine,
+        ctx: &TeraContext,
+        dry_run: bool,
+        force: bool,
+    ) -> Result<HookOutcome> {
+        let mut state = State::load(source)?;
+        let outcome = run_hook(
+            hook, source, yui, vars, engine, ctx, &mut state, dry_run, force,
+        )?;
+        if outcome == HookOutcome::Ran {
+            state.save(source)?;
+        }
+        Ok(outcome)
+    }
+
+    /// Most tests need only a `bash` hook; this builds one with the
+    /// usual defaults. Caller picks the `when_run`.
+    fn bash_hook(when_run: WhenRun, when: Option<&str>) -> HookConfig {
+        HookConfig {
             name: "h".into(),
             script: ".yui/bin/h.sh".into(),
             command: "bash".into(),
             args: vec!["{{ script_path }}".into()],
-            when_run: WhenRun::Every,
+            when_run,
             phase: HookPhase::Post,
-            when: None,
-        };
+            when: when.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn dry_run_returns_dry_run_outcome() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().to_path_buf());
+        // Script must exist — dry_run now validates existence.
+        write_script(&source, ".yui/bin/h.sh", "#!/bin/sh\nexit 0\n");
+        let hook = bash_hook(WhenRun::Every, None);
         let vars = toml::Table::new();
         let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
-        let outcome = run_hook(
+        let outcome = run_hook_test(
             &hook,
             &source,
             &yui_vars(&source),
@@ -380,8 +431,31 @@ mod tests {
         )
         .unwrap();
         assert_eq!(outcome, HookOutcome::DryRun);
-        // No state file written on dry-run.
         assert!(!source.join(STATE_REL_PATH).exists());
+    }
+
+    #[test]
+    fn dry_run_errors_when_script_missing() {
+        // Even in dry-run we should validate that the script exists —
+        // otherwise `apply --dry-run` would happily report "would run"
+        // for a misconfigured hook. (gemini PR #20 medium #4.)
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().to_path_buf());
+        let hook = bash_hook(WhenRun::Every, None);
+        let vars = toml::Table::new();
+        let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
+        let err = run_hook_test(
+            &hook,
+            &source,
+            &yui_vars(&source),
+            &vars,
+            &mut engine,
+            &ctx,
+            /* dry_run */ true,
+            /* force */ false,
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("script not found"));
     }
 
     #[test]
@@ -389,18 +463,10 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let source = utf8(tmp.path().to_path_buf());
         write_script(&source, ".yui/bin/h.sh", "#!/bin/sh\nexit 1\n"); // would fail if run
-        let hook = HookConfig {
-            name: "h".into(),
-            script: ".yui/bin/h.sh".into(),
-            command: "bash".into(),
-            args: vec!["{{ script_path }}".into()],
-            when_run: WhenRun::Every,
-            phase: HookPhase::Post,
-            when: Some("yui.os == 'no-such-os'".into()),
-        };
+        let hook = bash_hook(WhenRun::Every, Some("yui.os == 'no-such-os'"));
         let vars = toml::Table::new();
         let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
-        let outcome = run_hook(
+        let outcome = run_hook_test(
             &hook,
             &source,
             &yui_vars(&source),
@@ -416,28 +482,52 @@ mod tests {
     }
 
     #[test]
+    fn force_still_respects_when_filter() {
+        // --force bypasses the time/hash state check, but the OS gate
+        // (`when = "yui.os == 'no-such-os'"`) is a real config filter
+        // that should still keep the hook from running.
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().to_path_buf());
+        write_script(&source, ".yui/bin/h.sh", "#!/bin/sh\nexit 1\n");
+        let hook = bash_hook(WhenRun::Every, Some("yui.os == 'no-such-os'"));
+        let vars = toml::Table::new();
+        let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
+        let outcome = run_hook_test(
+            &hook,
+            &source,
+            &yui_vars(&source),
+            &vars,
+            &mut engine,
+            &ctx,
+            false,
+            /* force */ true,
+        )
+        .unwrap();
+        assert_eq!(outcome, HookOutcome::SkippedWhenFalse);
+    }
+
+    // The remaining tests actually spawn `bash` so they're Unix-only —
+    // Windows GitHub runners don't have bash on $PATH (and we don't
+    // want to tie the test suite to Git Bash's path on Windows). The
+    // production code is portable; the tests just pick a portable
+    // command set when CI matters.
+
+    #[cfg(unix)]
+    #[test]
     fn once_runs_first_then_skips() {
         let tmp = TempDir::new().unwrap();
         let source = utf8(tmp.path().to_path_buf());
         let marker = source.join(".ran");
-        let script = write_script(
+        write_script(
             &source,
             ".yui/bin/h.sh",
             &format!("#!/bin/sh\necho ok > {:?}\n", marker.as_str()),
         );
-        let _ = script; // keep script_path alive
-        let hook = HookConfig {
-            name: "h".into(),
-            script: ".yui/bin/h.sh".into(),
-            command: "bash".into(),
-            args: vec!["{{ script_path }}".into()],
-            when_run: WhenRun::Once,
-            phase: HookPhase::Post,
-            when: None,
-        };
+        let hook = bash_hook(WhenRun::Once, None);
         let vars = toml::Table::new();
         let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
-        let first = run_hook(
+
+        let first = run_hook_test(
             &hook,
             &source,
             &yui_vars(&source),
@@ -449,13 +539,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(first, HookOutcome::Ran);
-        assert!(
-            marker.exists(),
-            "first invocation should have run the script"
-        );
+        assert!(marker.exists());
         std::fs::remove_file(&marker).unwrap();
 
-        let second = run_hook(
+        let second = run_hook_test(
             &hook,
             &source,
             &yui_vars(&source),
@@ -467,12 +554,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(second, HookOutcome::SkippedOnce);
-        assert!(
-            !marker.exists(),
-            "second invocation should NOT have run the script"
-        );
+        assert!(!marker.exists());
     }
 
+    #[cfg(unix)]
     #[test]
     fn onchange_runs_when_hash_differs() {
         let tmp = TempDir::new().unwrap();
@@ -482,20 +567,11 @@ mod tests {
         std::fs::create_dir_all(script.parent().unwrap()).unwrap();
         let body_v1 = format!("#!/bin/sh\necho v1 > {:?}\n", marker.as_str());
         std::fs::write(&script, &body_v1).unwrap();
-        let hook = HookConfig {
-            name: "h".into(),
-            script: ".yui/bin/h.sh".into(),
-            command: "bash".into(),
-            args: vec!["{{ script_path }}".into()],
-            when_run: WhenRun::Onchange,
-            phase: HookPhase::Post,
-            when: None,
-        };
+        let hook = bash_hook(WhenRun::Onchange, None);
         let vars = toml::Table::new();
         let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
 
-        // First run — fresh script, no state, runs.
-        let first = run_hook(
+        let first = run_hook_test(
             &hook,
             &source,
             &yui_vars(&source),
@@ -509,8 +585,7 @@ mod tests {
         assert_eq!(first, HookOutcome::Ran);
         std::fs::remove_file(&marker).unwrap();
 
-        // Second run — same script, hash matches, skipped.
-        let second = run_hook(
+        let second = run_hook_test(
             &hook,
             &source,
             &yui_vars(&source),
@@ -524,10 +599,9 @@ mod tests {
         assert_eq!(second, HookOutcome::SkippedUnchanged);
         assert!(!marker.exists());
 
-        // Edit script — hash differs, runs again.
         let body_v2 = format!("#!/bin/sh\necho v2 > {:?}\n", marker.as_str());
         std::fs::write(&script, &body_v2).unwrap();
-        let third = run_hook(
+        let third = run_hook_test(
             &hook,
             &source,
             &yui_vars(&source),
@@ -542,6 +616,7 @@ mod tests {
         assert!(marker.exists());
     }
 
+    #[cfg(unix)]
     #[test]
     fn force_bypasses_state_check() {
         let tmp = TempDir::new().unwrap();
@@ -554,20 +629,11 @@ mod tests {
             format!("#!/bin/sh\necho hi >> {:?}\n", marker.as_str()),
         )
         .unwrap();
-        let hook = HookConfig {
-            name: "h".into(),
-            script: ".yui/bin/h.sh".into(),
-            command: "bash".into(),
-            args: vec!["{{ script_path }}".into()],
-            when_run: WhenRun::Once,
-            phase: HookPhase::Post,
-            when: None,
-        };
+        let hook = bash_hook(WhenRun::Once, None);
         let vars = toml::Table::new();
         let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
 
-        // Run once normally — succeeds.
-        let _ = run_hook(
+        let _ = run_hook_test(
             &hook,
             &source,
             &yui_vars(&source),
@@ -578,8 +644,7 @@ mod tests {
             false,
         )
         .unwrap();
-        // Forced second run — bypasses `Once` check, runs anyway.
-        let forced = run_hook(
+        let forced = run_hook_test(
             &hook,
             &source,
             &yui_vars(&source),
@@ -592,43 +657,56 @@ mod tests {
         .unwrap();
         assert_eq!(forced, HookOutcome::Ran);
         let body = std::fs::read_to_string(&marker).unwrap();
-        assert_eq!(
-            body.lines().count(),
-            2,
-            "force should have re-run the script"
-        );
+        assert_eq!(body.lines().count(), 2);
     }
 
+    #[cfg(unix)]
     #[test]
-    fn force_still_respects_when_filter() {
-        // --force bypasses the time/hash state check, but the OS gate
-        // (`when = "yui.os == 'no-such-os'"`) is a real config filter
-        // that should still keep the hook from running.
+    fn run_phase_saves_after_each_success() {
+        // Two `every` hooks; both run, both records persist in
+        // state.json — verifying we save inside the loop, not at end.
         let tmp = TempDir::new().unwrap();
         let source = utf8(tmp.path().to_path_buf());
-        write_script(&source, ".yui/bin/h.sh", "#!/bin/sh\nexit 1\n");
-        let hook = HookConfig {
-            name: "h".into(),
-            script: ".yui/bin/h.sh".into(),
-            command: "bash".into(),
-            args: vec!["{{ script_path }}".into()],
-            when_run: WhenRun::Every,
-            phase: HookPhase::Post,
-            when: Some("yui.os == 'no-such-os'".into()),
+        write_script(&source, ".yui/bin/a.sh", "#!/bin/sh\nexit 0\n");
+        write_script(&source, ".yui/bin/b.sh", "#!/bin/sh\nexit 0\n");
+        let cfg = Config {
+            hook: vec![
+                HookConfig {
+                    name: "a".into(),
+                    script: ".yui/bin/a.sh".into(),
+                    command: "bash".into(),
+                    args: vec!["{{ script_path }}".into()],
+                    when_run: WhenRun::Every,
+                    phase: HookPhase::Post,
+                    when: None,
+                },
+                HookConfig {
+                    name: "b".into(),
+                    script: ".yui/bin/b.sh".into(),
+                    command: "bash".into(),
+                    args: vec!["{{ script_path }}".into()],
+                    when_run: WhenRun::Every,
+                    phase: HookPhase::Post,
+                    when: None,
+                },
+            ],
+            ..Default::default()
         };
-        let vars = toml::Table::new();
-        let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
-        let outcome = run_hook(
-            &hook,
+        let yui = yui_vars(&source);
+        let mut engine = Engine::new();
+        let ctx = template::template_context(&yui, &cfg.vars);
+        run_phase(
+            &cfg,
             &source,
-            &yui_vars(&source),
-            &vars,
+            &yui,
             &mut engine,
             &ctx,
+            HookPhase::Post,
             false,
-            /* force */ true,
         )
         .unwrap();
-        assert_eq!(outcome, HookOutcome::SkippedWhenFalse);
+        let state = State::load(&source).unwrap();
+        assert!(state.hooks.contains_key("a"));
+        assert!(state.hooks.contains_key("b"));
     }
 }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,0 +1,634 @@
+//! Hook system — run user-supplied scripts around `yui apply`.
+//!
+//! Scripts live at `$DOTFILES/<config.script>` (idiomatic place is
+//! `.yui/bin/<name>.sh`). They're plain executables — no yui imports,
+//! no special protocol. yui just decides *when* to invoke them based on
+//! the `[[hook]]` config and the persisted state file.
+//!
+//! ## State
+//!
+//! Per-hook outcomes are stored in `$DOTFILES/.yui/state.json`:
+//!
+//! ```json
+//! {
+//!   "version": 1,
+//!   "hooks": {
+//!     "install-tools": {
+//!       "last_run_at": "2026-04-29T08:30:00+09:00[Asia/Tokyo]",
+//!       "last_content_hash": "sha256:abc123..."
+//!     }
+//!   }
+//! }
+//! ```
+//!
+//! `last_run_at` is filled on every successful run; `last_content_hash`
+//! is only filled for `when_run = "onchange"` hooks.
+
+use std::collections::BTreeMap;
+use std::process::Command;
+
+use camino::Utf8Path;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tera::Context as TeraContext;
+use tracing::info;
+
+use crate::config::{Config, HookConfig, HookPhase, WhenRun};
+use crate::template::{self, Engine};
+use crate::vars::YuiVars;
+use crate::{Error, Result};
+
+const STATE_REL_PATH: &str = ".yui/state.json";
+const STATE_VERSION: u32 = 1;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct State {
+    #[serde(default)]
+    pub version: u32,
+    #[serde(default)]
+    pub hooks: BTreeMap<String, HookState>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct HookState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_content_hash: Option<String>,
+}
+
+impl State {
+    pub fn load(source: &Utf8Path) -> Result<Self> {
+        let path = source.join(STATE_REL_PATH);
+        match std::fs::read_to_string(&path) {
+            Ok(s) => {
+                serde_json::from_str(&s).map_err(|e| Error::Config(format!("parse {path}: {e}")))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(Error::Io(e)),
+        }
+    }
+
+    pub fn save(&self, source: &Utf8Path) -> Result<()> {
+        let path = source.join(STATE_REL_PATH);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut body = serde_json::to_string_pretty(self)
+            .map_err(|e| Error::Config(format!("serialize state: {e}")))?;
+        body.push('\n');
+        std::fs::write(&path, body)?;
+        Ok(())
+    }
+}
+
+/// What happened when we considered running a hook.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookOutcome {
+    /// The hook ran and exited successfully.
+    Ran,
+    /// `when_run = "once"` and the hook has run before.
+    SkippedOnce,
+    /// `when_run = "onchange"` and the script's hash matches state.
+    SkippedUnchanged,
+    /// `when` evaluated false on this host.
+    SkippedWhenFalse,
+    /// `dry_run = true` — the hook would have run.
+    DryRun,
+}
+
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    format!("sha256:{digest:x}")
+}
+
+fn now_iso8601() -> String {
+    jiff::Zoned::now().to_string()
+}
+
+/// Build a Tera context for a hook: standard `template_context` + the
+/// `script_*` vars that `command` / `args` can interpolate.
+pub fn build_hook_context(
+    yui: &YuiVars,
+    vars: &toml::Table,
+    script_path: &Utf8Path,
+) -> TeraContext {
+    let mut ctx = template::template_context(yui, vars);
+    ctx.insert("script_path", &script_path.as_str());
+    ctx.insert(
+        "script_dir",
+        &script_path.parent().map(|p| p.as_str()).unwrap_or(""),
+    );
+    ctx.insert("script_name", &script_path.file_name().unwrap_or(""));
+    ctx.insert("script_stem", &script_path.file_stem().unwrap_or(""));
+    ctx.insert("script_ext", &script_path.extension().unwrap_or(""));
+    ctx
+}
+
+/// Decide whether to run `hook` and run it if so. Side-effects:
+/// updates `.yui/state.json` on a successful run; nothing otherwise.
+///
+/// `force = true` bypasses the `when_run` state check (still respects
+/// `when` — an explicit `yui hooks run <name>` shouldn't suddenly run a
+/// hook that's `when = "yui.os == 'macos'"` on Linux).
+#[allow(clippy::too_many_arguments)]
+pub fn run_hook(
+    hook: &HookConfig,
+    source: &Utf8Path,
+    yui: &YuiVars,
+    vars: &toml::Table,
+    engine: &mut Engine,
+    base_ctx: &TeraContext,
+    dry_run: bool,
+    force: bool,
+) -> Result<HookOutcome> {
+    if let Some(when) = &hook.when {
+        if !template::eval_truthy(when, engine, base_ctx)? {
+            return Ok(HookOutcome::SkippedWhenFalse);
+        }
+    }
+
+    let script_path = source.join(&hook.script);
+
+    // Compute the script hash up front (cheap, and we want it to record
+    // on a successful run regardless of mode).
+    let current_hash = match std::fs::read(&script_path) {
+        Ok(bytes) => Some(sha256_hex(&bytes)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => return Err(e.into()),
+    };
+
+    if !force {
+        let state = State::load(source)?;
+        let prior = state.hooks.get(&hook.name);
+        match hook.when_run {
+            WhenRun::Once => {
+                if prior.and_then(|s| s.last_run_at.as_ref()).is_some() {
+                    return Ok(HookOutcome::SkippedOnce);
+                }
+            }
+            WhenRun::Onchange => {
+                if let (Some(prior_state), Some(now_hash)) = (prior, current_hash.as_deref()) {
+                    if prior_state.last_content_hash.as_deref() == Some(now_hash) {
+                        return Ok(HookOutcome::SkippedUnchanged);
+                    }
+                }
+            }
+            WhenRun::Every => {}
+        }
+    }
+
+    if dry_run {
+        return Ok(HookOutcome::DryRun);
+    }
+
+    if current_hash.is_none() {
+        return Err(Error::Other(anyhow::anyhow!(
+            "hook[{}]: script not found at {script_path}",
+            hook.name
+        )));
+    }
+
+    let hook_ctx = build_hook_context(yui, vars, &script_path);
+    let command = engine.render(&hook.command, &hook_ctx)?;
+    let args: Vec<String> = hook
+        .args
+        .iter()
+        .map(|a| engine.render(a, &hook_ctx))
+        .collect::<Result<_>>()?;
+
+    info!(
+        "hook[{}] running: {} {}",
+        hook.name,
+        command,
+        args.join(" ")
+    );
+    let status = Command::new(&command)
+        .args(&args)
+        .current_dir(source.as_std_path())
+        .status()
+        .map_err(|e| Error::Other(anyhow::anyhow!("hook[{}]: spawn {command}: {e}", hook.name)))?;
+
+    if !status.success() {
+        return Err(Error::Other(anyhow::anyhow!(
+            "hook[{}] exited with status {status}",
+            hook.name
+        )));
+    }
+
+    let mut state = State::load(source)?;
+    state.version = STATE_VERSION;
+    state.hooks.insert(
+        hook.name.clone(),
+        HookState {
+            last_run_at: Some(now_iso8601()),
+            last_content_hash: match hook.when_run {
+                WhenRun::Onchange => current_hash,
+                _ => None,
+            },
+        },
+    );
+    state.save(source)?;
+
+    Ok(HookOutcome::Ran)
+}
+
+/// Run every hook whose phase matches. Stops at the first failure (the
+/// user can investigate, fix, and re-run; we don't want to silently keep
+/// going after a failed `pre` hook).
+pub fn run_phase(
+    config: &Config,
+    source: &Utf8Path,
+    yui: &YuiVars,
+    engine: &mut Engine,
+    base_ctx: &TeraContext,
+    phase: HookPhase,
+    dry_run: bool,
+) -> Result<()> {
+    for hook in &config.hook {
+        if hook.phase != phase {
+            continue;
+        }
+        let outcome = run_hook(
+            hook,
+            source,
+            yui,
+            &config.vars,
+            engine,
+            base_ctx,
+            dry_run,
+            /* force */ false,
+        )?;
+        let phase_name = match phase {
+            HookPhase::Pre => "pre",
+            HookPhase::Post => "post",
+        };
+        info!("hook[{}] {phase_name}: {:?}", hook.name, outcome);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+
+    fn utf8(p: std::path::PathBuf) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(p).unwrap()
+    }
+
+    fn yui_vars(source: &Utf8Path) -> YuiVars {
+        YuiVars {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            host: "test".into(),
+            user: "u".into(),
+            source: source.to_string(),
+        }
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().to_path_buf());
+        let state = State {
+            version: STATE_VERSION,
+            hooks: BTreeMap::from([(
+                "h1".to_string(),
+                HookState {
+                    last_run_at: Some("2026-04-29T00:00:00Z".into()),
+                    last_content_hash: Some("sha256:abc".into()),
+                },
+            )]),
+        };
+        state.save(&source).unwrap();
+        let reloaded = State::load(&source).unwrap();
+        assert_eq!(reloaded.version, STATE_VERSION);
+        assert_eq!(
+            reloaded
+                .hooks
+                .get("h1")
+                .unwrap()
+                .last_content_hash
+                .as_deref(),
+            Some("sha256:abc")
+        );
+    }
+
+    #[test]
+    fn state_load_returns_default_when_absent() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().to_path_buf());
+        let s = State::load(&source).unwrap();
+        assert_eq!(s.version, 0);
+        assert!(s.hooks.is_empty());
+    }
+
+    #[test]
+    fn sha256_hex_format_includes_prefix() {
+        let h = sha256_hex(b"hello");
+        assert!(h.starts_with("sha256:"));
+        assert_eq!(h.len(), 7 + 64); // "sha256:" + 64 hex chars
+    }
+
+    fn make_engine_and_ctx(source: &Utf8Path, vars: &toml::Table) -> (Engine, TeraContext) {
+        let engine = Engine::new();
+        let ctx = template::template_context(&yui_vars(source), vars);
+        (engine, ctx)
+    }
+
+    fn write_script(source: &Utf8Path, rel: &str, body: &str) -> Utf8PathBuf {
+        let path = source.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, body).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn dry_run_returns_dry_run_outcome() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().to_path_buf());
+        write_script(&source, ".yui/bin/h.sh", "#!/bin/sh\nexit 0\n");
+        let hook = HookConfig {
+            name: "h".into(),
+            script: ".yui/bin/h.sh".into(),
+            command: "bash".into(),
+            args: vec!["{{ script_path }}".into()],
+            when_run: WhenRun::Every,
+            phase: HookPhase::Post,
+            when: None,
+        };
+        let vars = toml::Table::new();
+        let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
+        let outcome = run_hook(
+            &hook,
+            &source,
+            &yui_vars(&source),
+            &vars,
+            &mut engine,
+            &ctx,
+            /* dry_run */ true,
+            /* force */ false,
+        )
+        .unwrap();
+        assert_eq!(outcome, HookOutcome::DryRun);
+        // No state file written on dry-run.
+        assert!(!source.join(STATE_REL_PATH).exists());
+    }
+
+    #[test]
+    fn when_false_skips_without_running() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().to_path_buf());
+        write_script(&source, ".yui/bin/h.sh", "#!/bin/sh\nexit 1\n"); // would fail if run
+        let hook = HookConfig {
+            name: "h".into(),
+            script: ".yui/bin/h.sh".into(),
+            command: "bash".into(),
+            args: vec!["{{ script_path }}".into()],
+            when_run: WhenRun::Every,
+            phase: HookPhase::Post,
+            when: Some("yui.os == 'no-such-os'".into()),
+        };
+        let vars = toml::Table::new();
+        let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
+        let outcome = run_hook(
+            &hook,
+            &source,
+            &yui_vars(&source),
+            &vars,
+            &mut engine,
+            &ctx,
+            /* dry_run */ false,
+            /* force */ false,
+        )
+        .unwrap();
+        assert_eq!(outcome, HookOutcome::SkippedWhenFalse);
+        assert!(!source.join(STATE_REL_PATH).exists());
+    }
+
+    #[test]
+    fn once_runs_first_then_skips() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().to_path_buf());
+        let marker = source.join(".ran");
+        let script = write_script(
+            &source,
+            ".yui/bin/h.sh",
+            &format!("#!/bin/sh\necho ok > {:?}\n", marker.as_str()),
+        );
+        let _ = script; // keep script_path alive
+        let hook = HookConfig {
+            name: "h".into(),
+            script: ".yui/bin/h.sh".into(),
+            command: "bash".into(),
+            args: vec!["{{ script_path }}".into()],
+            when_run: WhenRun::Once,
+            phase: HookPhase::Post,
+            when: None,
+        };
+        let vars = toml::Table::new();
+        let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
+        let first = run_hook(
+            &hook,
+            &source,
+            &yui_vars(&source),
+            &vars,
+            &mut engine,
+            &ctx,
+            false,
+            false,
+        )
+        .unwrap();
+        assert_eq!(first, HookOutcome::Ran);
+        assert!(
+            marker.exists(),
+            "first invocation should have run the script"
+        );
+        std::fs::remove_file(&marker).unwrap();
+
+        let second = run_hook(
+            &hook,
+            &source,
+            &yui_vars(&source),
+            &vars,
+            &mut engine,
+            &ctx,
+            false,
+            false,
+        )
+        .unwrap();
+        assert_eq!(second, HookOutcome::SkippedOnce);
+        assert!(
+            !marker.exists(),
+            "second invocation should NOT have run the script"
+        );
+    }
+
+    #[test]
+    fn onchange_runs_when_hash_differs() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().to_path_buf());
+        let marker = source.join(".ran");
+        let script = source.join(".yui/bin/h.sh");
+        std::fs::create_dir_all(script.parent().unwrap()).unwrap();
+        let body_v1 = format!("#!/bin/sh\necho v1 > {:?}\n", marker.as_str());
+        std::fs::write(&script, &body_v1).unwrap();
+        let hook = HookConfig {
+            name: "h".into(),
+            script: ".yui/bin/h.sh".into(),
+            command: "bash".into(),
+            args: vec!["{{ script_path }}".into()],
+            when_run: WhenRun::Onchange,
+            phase: HookPhase::Post,
+            when: None,
+        };
+        let vars = toml::Table::new();
+        let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
+
+        // First run — fresh script, no state, runs.
+        let first = run_hook(
+            &hook,
+            &source,
+            &yui_vars(&source),
+            &vars,
+            &mut engine,
+            &ctx,
+            false,
+            false,
+        )
+        .unwrap();
+        assert_eq!(first, HookOutcome::Ran);
+        std::fs::remove_file(&marker).unwrap();
+
+        // Second run — same script, hash matches, skipped.
+        let second = run_hook(
+            &hook,
+            &source,
+            &yui_vars(&source),
+            &vars,
+            &mut engine,
+            &ctx,
+            false,
+            false,
+        )
+        .unwrap();
+        assert_eq!(second, HookOutcome::SkippedUnchanged);
+        assert!(!marker.exists());
+
+        // Edit script — hash differs, runs again.
+        let body_v2 = format!("#!/bin/sh\necho v2 > {:?}\n", marker.as_str());
+        std::fs::write(&script, &body_v2).unwrap();
+        let third = run_hook(
+            &hook,
+            &source,
+            &yui_vars(&source),
+            &vars,
+            &mut engine,
+            &ctx,
+            false,
+            false,
+        )
+        .unwrap();
+        assert_eq!(third, HookOutcome::Ran);
+        assert!(marker.exists());
+    }
+
+    #[test]
+    fn force_bypasses_state_check() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().to_path_buf());
+        let marker = source.join(".ran");
+        let script = source.join(".yui/bin/h.sh");
+        std::fs::create_dir_all(script.parent().unwrap()).unwrap();
+        std::fs::write(
+            &script,
+            format!("#!/bin/sh\necho hi >> {:?}\n", marker.as_str()),
+        )
+        .unwrap();
+        let hook = HookConfig {
+            name: "h".into(),
+            script: ".yui/bin/h.sh".into(),
+            command: "bash".into(),
+            args: vec!["{{ script_path }}".into()],
+            when_run: WhenRun::Once,
+            phase: HookPhase::Post,
+            when: None,
+        };
+        let vars = toml::Table::new();
+        let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
+
+        // Run once normally — succeeds.
+        let _ = run_hook(
+            &hook,
+            &source,
+            &yui_vars(&source),
+            &vars,
+            &mut engine,
+            &ctx,
+            false,
+            false,
+        )
+        .unwrap();
+        // Forced second run — bypasses `Once` check, runs anyway.
+        let forced = run_hook(
+            &hook,
+            &source,
+            &yui_vars(&source),
+            &vars,
+            &mut engine,
+            &ctx,
+            false,
+            /* force */ true,
+        )
+        .unwrap();
+        assert_eq!(forced, HookOutcome::Ran);
+        let body = std::fs::read_to_string(&marker).unwrap();
+        assert_eq!(
+            body.lines().count(),
+            2,
+            "force should have re-run the script"
+        );
+    }
+
+    #[test]
+    fn force_still_respects_when_filter() {
+        // --force bypasses the time/hash state check, but the OS gate
+        // (`when = "yui.os == 'no-such-os'"`) is a real config filter
+        // that should still keep the hook from running.
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().to_path_buf());
+        write_script(&source, ".yui/bin/h.sh", "#!/bin/sh\nexit 1\n");
+        let hook = HookConfig {
+            name: "h".into(),
+            script: ".yui/bin/h.sh".into(),
+            command: "bash".into(),
+            args: vec!["{{ script_path }}".into()],
+            when_run: WhenRun::Every,
+            phase: HookPhase::Post,
+            when: Some("yui.os == 'no-such-os'".into()),
+        };
+        let vars = toml::Table::new();
+        let (mut engine, ctx) = make_engine_and_ctx(&source, &vars);
+        let outcome = run_hook(
+            &hook,
+            &source,
+            &yui_vars(&source),
+            &vars,
+            &mut engine,
+            &ctx,
+            false,
+            /* force */ true,
+        )
+        .unwrap();
+        assert_eq!(outcome, HookOutcome::SkippedWhenFalse);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cmd;
 pub mod config;
 pub mod error;
 pub mod git;
+pub mod hook;
 pub mod icons;
 pub mod link;
 pub mod marker;


### PR DESCRIPTION
## Summary

Adds the second half of the 0.5.0 milestone: a `[[hook]]` system that
fires user-supplied scripts around `yui apply`. Scripts live at
\`$DOTFILES/.yui/bin/\` (idiomatic) but yui doesn't care — they're
plain executables. The config decides *when* to run them.

\`\`\`toml
[[hook]]
name   = "brew-bundle"
script = ".yui/bin/brew-bundle.sh"
when   = "yui.os == 'macos'"
# defaults: command="bash", args=["{{ script_path }}"],
#           when_run="onchange", phase="post"
\`\`\`

### State + when_run

\`$DOTFILES/.yui/state.json\` records \`last_run_at\` + (for \`onchange\`)
\`last_content_hash\` (SHA-256 of script body).

| \`when_run\` | re-run policy |
|---|---|
| \`once\` | only the very first time |
| \`onchange\` (default) | when script hash differs from state |
| \`every\` | every \`apply\` |

### Phases

\`pre\` runs after config load, before render/link.
\`post\` runs after all linking. \`apply\` aborts on the first hook
failure — fix the script, re-run.

### Tera context for \`command\` / \`args\`

Standard \`yui.*\` / \`vars.*\` / \`env(...)\` + extras:
\`script_path\`, \`script_dir\`, \`script_name\`, \`script_stem\`,
\`script_ext\`. Example with Deno:

\`\`\`toml
[[hook]]
name = "denops-build"
script = ".yui/bin/build.ts"
command = "deno"
args = ["run", "-A", "{{ script_path }}"]
\`\`\`

### Manual control

\`\`\`
yui hooks list                    # configured + last-run state
yui hooks run                     # all hooks per their rules
yui hooks run brew-bundle         # just this one (when filter still honored)
yui hooks run brew-bundle --force # bypass when_run state check
\`\`\`

### Out-of-scope (deferred)

- per-hook \`working_dir\` / \`env\` / \`timeout_secs\` (cwd hardcoded to
  \`\$DOTFILES\`, env inherited, no timeout)
- per-phase \`pre-render\` / \`pre-link\` granularity (today: just \`pre\` /
  \`post\`)

### New deps

- \`sha2 = \"0.10\"\` — script content hashing
- \`serde_json = \"1\"\` — state.json (de)serialization

## Test plan

- [x] \`cargo make check\` clean
- [x] 98 unit tests (9 new hook tests covering: state roundtrip,
      load-default-when-absent, sha256 format, dry-run, when=false,
      once-then-skip, onchange-runs-on-edit, force-bypasses-state,
      force-still-respects-when)
- [ ] CI on \`feat/hooks\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hook system for executing scripts before and after applying configurations with state tracking
  * Added `yui hooks list` command to view configured hooks and their execution history
  * Added `yui hooks run` command to manually trigger hooks with optional `--force` flag
  * Hooks support conditional execution via filters and frequency control (once, onchange, every)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->