### PR TITLE
feat(marker): nested .yuilink stacking + file-level src

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,46 @@ when = "yui.os == 'windows'"
 
 `yui list` shows each link and which `when` would activate it.
 
+### Stacking markers and file-level entries
+
+Markers compose. A parent `.yuilink` no longer stops the walker, so
+you can junction a whole `~/.config` and *also* layer extra dsts onto
+specific subdirs:
+
+```toml
+# $DOTFILES/home/.config/.yuilink — junction the whole .config dir
+[[link]]
+dst = "~/.config"
+```
+
+```toml
+# $DOTFILES/home/.config/nvim/.yuilink — extra Windows-only dst
+[[link]]
+dst = "{{ env(name='LOCALAPPDATA') }}/nvim"
+when = "yui.os == 'windows'"
+```
+
+Both links land — the parent takes care of the natural placement, the
+child adds its OS-specific alternate.
+
+A `[[link]]` may also carry a `src = "<filename>"` to scope the link to
+a single sibling file rather than the directory itself. Useful for
+paths that don't follow `~/.config/<app>/` conventions, like the
+PowerShell profile on Windows:
+
+```toml
+# $DOTFILES/home/.config/powershell/.yuilink
+[[link]]
+src = "Microsoft.PowerShell_profile.ps1"
+dst = "{{ env(name='USERPROFILE') }}/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"
+when = "yui.os == 'windows'"
+```
+
+`src` must be a single filename (no path separators); the file lives
+right next to the marker. The rest of the directory still falls
+through to whatever placement an ancestor (or the parent mount)
+provides.
+
 ## `.yuiignore` — exclude paths from being linked
 
 A `$DOTFILES/.yuiignore` file (gitignore syntax) keeps matched paths

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -262,7 +262,7 @@ fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Resu
             Some(s) => s,
             None => continue,
         };
-        let MarkerSpec::Override { links } = spec else {
+        let MarkerSpec::Explicit { links } = spec else {
             continue; // PassThrough markers are already implied by mount entry
         };
         let rel = dir_utf8
@@ -278,8 +278,16 @@ fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Resu
                 .render(&link.dst, &tera_ctx)
                 .map(|s| paths::expand_tilde(s.trim()).to_string())
                 .unwrap_or_else(|_| link.dst.clone());
+            // File-level entry (`[[link]] src = "<filename>"`) targets a
+            // single file inside the marker dir; show that file path
+            // instead of the bare dir so `yui list` makes the scope
+            // obvious at a glance.
+            let src_display = match &link.src {
+                Some(filename) => rel.join(filename),
+                None => rel.clone(),
+            };
             items.push(ListItem {
-                src: rel.clone(),
+                src: src_display,
                 dst,
                 when: link.when.clone(),
                 active,
@@ -600,15 +608,43 @@ fn classify_walk(
     yuiignore: &ignore::gitignore::Gitignore,
     report: &mut Vec<StatusItem>,
 ) -> Result<()> {
+    classify_walk_inner(
+        src_dir,
+        dst_dir,
+        config,
+        strategy,
+        engine,
+        tera_ctx,
+        source_root,
+        yuiignore,
+        report,
+        false,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn classify_walk_inner(
+    src_dir: &Utf8Path,
+    dst_dir: &Utf8Path,
+    config: &Config,
+    strategy: MountStrategy,
+    engine: &mut template::Engine,
+    tera_ctx: &TeraContext,
+    source_root: &Utf8Path,
+    yuiignore: &ignore::gitignore::Gitignore,
+    report: &mut Vec<StatusItem>,
+    parent_covered: bool,
+) -> Result<()> {
     if paths::is_ignored(yuiignore, source_root, src_dir, /* is_dir */ true) {
         return Ok(());
     }
 
     let marker_filename = &config.mount.marker_filename;
+    let mut covered = parent_covered;
 
     if strategy == MountStrategy::Marker {
         match marker::read_spec(src_dir, marker_filename)? {
-            None => {} // no marker — fall through to recursive walk
+            None => {}
             Some(MarkerSpec::PassThrough) => {
                 let decision = absorb::classify(src_dir, dst_dir)?;
                 report.push(StatusItem {
@@ -616,9 +652,10 @@ fn classify_walk(
                     dst: dst_dir.to_path_buf(),
                     state: StatusState::Link(decision),
                 });
-                return Ok(());
+                covered = true;
             }
-            Some(MarkerSpec::Override { links }) => {
+            Some(MarkerSpec::Explicit { links }) => {
+                let mut emitted_dir_link = false;
                 for link in &links {
                     if let Some(when) = &link.when {
                         if !template::eval_truthy(when, engine, tera_ctx)? {
@@ -627,14 +664,33 @@ fn classify_walk(
                     }
                     let dst_str = engine.render(&link.dst, tera_ctx)?;
                     let dst = paths::expand_tilde(dst_str.trim());
-                    let decision = absorb::classify(src_dir, &dst)?;
-                    report.push(StatusItem {
-                        src: relative_for_display(source_root, src_dir),
-                        dst,
-                        state: StatusState::Link(decision),
-                    });
+                    if let Some(filename) = &link.src {
+                        let file_src = src_dir.join(filename);
+                        if !file_src.is_file() {
+                            anyhow::bail!(
+                                "marker at {src_dir}: [[link]] src={filename:?} \
+                                 not found"
+                            );
+                        }
+                        let decision = absorb::classify(&file_src, &dst)?;
+                        report.push(StatusItem {
+                            src: relative_for_display(source_root, &file_src),
+                            dst,
+                            state: StatusState::Link(decision),
+                        });
+                    } else {
+                        let decision = absorb::classify(src_dir, &dst)?;
+                        report.push(StatusItem {
+                            src: relative_for_display(source_root, src_dir),
+                            dst,
+                            state: StatusState::Link(decision),
+                        });
+                        emitted_dir_link = true;
+                    }
                 }
-                return Ok(());
+                if emitted_dir_link {
+                    covered = true;
+                }
             }
         }
     }
@@ -655,7 +711,7 @@ fn classify_walk(
             continue;
         }
         if ft.is_dir() {
-            classify_walk(
+            classify_walk_inner(
                 &src_path,
                 &dst_path,
                 config,
@@ -665,8 +721,9 @@ fn classify_walk(
                 source_root,
                 yuiignore,
                 report,
+                covered,
             )?;
-        } else if ft.is_file() {
+        } else if ft.is_file() && !covered {
             let decision = absorb::classify(&src_path, &dst_path)?;
             report.push(StatusItem {
                 src: relative_for_display(source_root, &src_path),
@@ -937,7 +994,7 @@ fn find_source_for_target(
             Some(s) => s,
             None => continue,
         };
-        let MarkerSpec::Override { links } = spec else {
+        let MarkerSpec::Explicit { links } = spec else {
             continue;
         };
         for link in &links {
@@ -948,6 +1005,14 @@ fn find_source_for_target(
             }
             let dst_str = engine.render(&link.dst, tera_ctx)?;
             let dst = paths::expand_tilde(dst_str.trim());
+            // File-level entry: dst points at a single file, so a match
+            // resolves directly to `<marker-dir>/<src filename>`.
+            if let Some(filename) = &link.src {
+                if target == dst {
+                    return Ok(Some(dir_utf8.join(filename)));
+                }
+                continue;
+            }
             if target == dst {
                 return Ok(Some(dir_utf8));
             }
@@ -1113,9 +1178,10 @@ fn process_mount(
         warn!("mount src missing: {src_root}");
         return Ok(());
     }
-    walk_and_link(&src_root, &m.dst, ctx, m.strategy, engine, tera_ctx)
+    walk_and_link(&src_root, &m.dst, ctx, m.strategy, engine, tera_ctx, false)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn walk_and_link(
     src_dir: &Utf8Path,
     dst_dir: &Utf8Path,
@@ -1123,6 +1189,7 @@ fn walk_and_link(
     strategy: MountStrategy,
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
+    parent_covered: bool,
 ) -> Result<()> {
     // `.yuiignore` short-circuit — entire subtrees that match are skipped
     // without even reading their marker / iterating their children.
@@ -1131,20 +1198,24 @@ fn walk_and_link(
     }
 
     let marker_filename = &ctx.config.mount.marker_filename;
+    let mut covered = parent_covered;
 
     if strategy == MountStrategy::Marker {
         match marker::read_spec(src_dir, marker_filename)? {
             None => {} // no marker — fall through to recursive walk
             Some(MarkerSpec::PassThrough) => {
+                // Empty marker = junction this dir at the natural
+                // mount-derived dst. Subsequent recursion keeps going so
+                // descendant markers can layer on extra dsts.
                 link_dir_with_backup(src_dir, dst_dir, ctx)?;
-                return Ok(());
+                covered = true;
             }
-            Some(MarkerSpec::Override { links }) => {
-                let mut linked_any = false;
+            Some(MarkerSpec::Explicit { links }) => {
+                let mut emitted_dir_link = false;
+                let mut emitted_any = false;
                 for link in &links {
                     // Nested ifs (not let-chains) so the crate's MSRV
-                    // (rust-version = "1.85") stays buildable; let-chains
-                    // were stabilized in 1.88.
+                    // (rust-version = "1.85") stays buildable.
                     if let Some(when) = &link.when {
                         if !template::eval_truthy(when, engine, tera_ctx)? {
                             continue;
@@ -1152,13 +1223,27 @@ fn walk_and_link(
                     }
                     let dst_str = engine.render(&link.dst, tera_ctx)?;
                     let dst = paths::expand_tilde(dst_str.trim());
-                    link_dir_with_backup(src_dir, &dst, ctx)?;
-                    linked_any = true;
+                    if let Some(filename) = &link.src {
+                        let file_src = src_dir.join(filename);
+                        if !file_src.is_file() {
+                            anyhow::bail!(
+                                "marker at {src_dir}: [[link]] src={filename:?} \
+                                 not found"
+                            );
+                        }
+                        link_file_with_backup(&file_src, &dst, ctx)?;
+                    } else {
+                        link_dir_with_backup(src_dir, &dst, ctx)?;
+                        emitted_dir_link = true;
+                    }
+                    emitted_any = true;
                 }
-                if !linked_any {
-                    info!("marker override at {src_dir} had no active links — skipping");
+                if !emitted_any {
+                    info!("marker at {src_dir} had no active links — skipping");
                 }
-                return Ok(());
+                if emitted_dir_link {
+                    covered = true;
+                }
             }
         }
     }
@@ -1185,9 +1270,18 @@ fn walk_and_link(
         }
 
         if ft.is_dir() {
-            walk_and_link(&src_path, &dst_path, ctx, strategy, engine, tera_ctx)?;
+            walk_and_link(
+                &src_path, &dst_path, ctx, strategy, engine, tera_ctx, covered,
+            )?;
         } else if ft.is_file() {
-            link_file_with_backup(&src_path, &dst_path, ctx)?;
+            // If an ancestor (or this dir itself) created a dir-level
+            // junction, the file is already accessible via that junction
+            // — emitting another per-file link would just duplicate work
+            // (and on Windows might land at a path that's already
+            // hard-linked through the parent).
+            if !covered {
+                link_file_with_backup(&src_path, &dst_path, ctx)?;
+            }
         }
     }
     Ok(())
@@ -1453,8 +1547,11 @@ dst = "~"
 # when = "yui.os == 'windows'"
 "#;
 
-const SKELETON_GITIGNORE: &str = r#"# yui internals (regenerable, do not commit)
-/.yui/
+const SKELETON_GITIGNORE: &str = r#"# yui per-machine state and backups (regenerable, do not commit).
+# .yui/bin/ is intentionally tracked — it holds your hook scripts.
+/.yui/state.json
+/.yui/state.json.tmp
+/.yui/backup/
 
 # >>> yui rendered (auto-managed, do not edit) >>>
 # <<< yui rendered (auto-managed) <<<
@@ -1667,7 +1764,11 @@ dst = "{}"
     }
 
     #[test]
-    fn apply_marker_override_skips_inactive_link() {
+    fn apply_marker_inactive_link_falls_through_to_default() {
+        // v0.6+ semantics: a marker that has only inactive links no
+        // longer suppresses the parent mount's natural placement. The
+        // walker keeps descending so per-file defaults still apply.
+        // (Use `.yuiignore` to actually exclude a subtree.)
         let tmp = TempDir::new().unwrap();
         let source = utf8(tmp.path().join("dotfiles"));
         let target_inactive = utf8(tmp.path().join("inactive"));
@@ -1702,11 +1803,11 @@ dst = "{}"
 
         apply(Some(source.clone()), false).unwrap();
 
-        // Inactive target untouched.
+        // Inactive marker target untouched.
         assert!(!target_inactive.join("nvim").exists());
-        // Parent mount also skipped the dir (marker claims it even when
-        // all links are inactive — the user's intent was per-dir override).
-        assert!(!parent_target.join(".config/nvim").exists());
+        // Parent mount's natural placement IS produced — the marker had
+        // no active dir-level link to claim coverage with.
+        assert!(parent_target.join(".config/nvim/init.lua").exists());
     }
 
     #[test]
@@ -2159,6 +2260,168 @@ dst = "{}"
         assert!(!source.join("home/note").exists());
         assert!(!target.join("note").exists());
         assert!(!target.join("note.tera").exists());
+    }
+
+    /// v0.6+: parent `.yuilink` doesn't stop the walker. A parent
+    /// marker can junction the whole dir, AND a child marker can layer
+    /// on extra dsts (e.g. an OS-specific alternate location).
+    #[test]
+    fn nested_marker_accumulates_extra_dst() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        let parent_target = utf8(tmp.path().join("home"));
+        let extra_target = utf8(tmp.path().join("extra"));
+        std::fs::create_dir_all(source.join("home/.config/nvim")).unwrap();
+        std::fs::create_dir_all(&parent_target).unwrap();
+        std::fs::create_dir_all(&extra_target).unwrap();
+        std::fs::write(source.join("home/.config/nvim/init.lua"), "-- nvim\n").unwrap();
+
+        // Parent: junction the whole .config dir to <home>/.config.
+        std::fs::write(
+            source.join("home/.config/.yuilink"),
+            format!(
+                r#"
+[[link]]
+dst = "{}/.config"
+"#,
+                toml_path(&parent_target)
+            ),
+        )
+        .unwrap();
+        // Child: ALSO junction nvim/ to an extra path, but only on the
+        // running OS (so the test exercises an active link).
+        std::fs::write(
+            source.join("home/.config/nvim/.yuilink"),
+            format!(
+                r#"
+[[link]]
+dst = "{}/nvim"
+when = "{{{{ yui.os == '{}' }}}}"
+"#,
+                toml_path(&extra_target),
+                std::env::consts::OS
+            ),
+        )
+        .unwrap();
+
+        let cfg = format!(
+            r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+            toml_path(&parent_target)
+        );
+        std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+        apply(Some(source.clone()), false).unwrap();
+
+        // Both links are present: parent's whole-.config junction reaches
+        // init.lua, and the child marker added an additional path.
+        assert!(parent_target.join(".config/nvim/init.lua").exists());
+        assert!(extra_target.join("nvim/init.lua").exists());
+    }
+
+    /// v0.6+: `[[link]] src = "<filename>"` links a single sibling file
+    /// to a custom dst, leaving the rest of the dir to default
+    /// behaviour. Useful for paths like the PowerShell profile that
+    /// have to live in a non-`~/.config` location on Windows.
+    #[test]
+    fn marker_file_link_targets_specific_file() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        let parent_target = utf8(tmp.path().join("home"));
+        let docs_target = utf8(tmp.path().join("docs"));
+        std::fs::create_dir_all(source.join("home/.config/powershell")).unwrap();
+        std::fs::create_dir_all(&parent_target).unwrap();
+        std::fs::create_dir_all(&docs_target).unwrap();
+        std::fs::write(
+            source.join("home/.config/powershell/profile.ps1"),
+            "# profile\n",
+        )
+        .unwrap();
+        std::fs::write(source.join("home/.config/powershell/extra.txt"), "extra\n").unwrap();
+
+        // File-level entry only — no dir-level [[link]], so the dir
+        // itself still falls through to the default mount placement.
+        std::fs::write(
+            source.join("home/.config/powershell/.yuilink"),
+            format!(
+                r#"
+[[link]]
+src = "profile.ps1"
+dst = "{}/Microsoft.PowerShell_profile.ps1"
+"#,
+                toml_path(&docs_target)
+            ),
+        )
+        .unwrap();
+
+        let cfg = format!(
+            r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+            toml_path(&parent_target)
+        );
+        std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+        apply(Some(source.clone()), false).unwrap();
+
+        // File-level target gets the link.
+        assert!(
+            docs_target
+                .join("Microsoft.PowerShell_profile.ps1")
+                .exists()
+        );
+        // Default per-file placement still happens for ALL files in the
+        // dir (the marker had no dir-level [[link]] to claim coverage).
+        assert!(
+            parent_target
+                .join(".config/powershell/profile.ps1")
+                .exists()
+        );
+        assert!(parent_target.join(".config/powershell/extra.txt").exists());
+    }
+
+    /// File-level [[link]] errors clearly when src points at a missing
+    /// file — config bug, not a silent skip.
+    #[test]
+    fn marker_file_link_missing_src_errors() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        let parent_target = utf8(tmp.path().join("home"));
+        let docs_target = utf8(tmp.path().join("docs"));
+        std::fs::create_dir_all(source.join("home/.config/powershell")).unwrap();
+        std::fs::create_dir_all(&parent_target).unwrap();
+        std::fs::create_dir_all(&docs_target).unwrap();
+
+        std::fs::write(
+            source.join("home/.config/powershell/.yuilink"),
+            format!(
+                r#"
+[[link]]
+src = "missing.ps1"
+dst = "{}/profile.ps1"
+"#,
+                toml_path(&docs_target)
+            ),
+        )
+        .unwrap();
+
+        let cfg = format!(
+            r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+            toml_path(&parent_target)
+        );
+        std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+        let err = apply(Some(source.clone()), false).unwrap_err();
+        assert!(format!("{err:#}").contains("missing.ps1"));
     }
 
     fn walkdir(root: &Utf8Path) -> Vec<Utf8PathBuf> {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1006,10 +1006,21 @@ fn find_source_for_target(
             let dst_str = engine.render(&link.dst, tera_ctx)?;
             let dst = paths::expand_tilde(dst_str.trim());
             // File-level entry: dst points at a single file, so a match
-            // resolves directly to `<marker-dir>/<src filename>`.
+            // resolves directly to `<marker-dir>/<src filename>`. Mirror
+            // the existence check that apply / status do so a missing
+            // sibling produces the same clear message regardless of
+            // entry point — consistent with the `marker at … src=… not
+            // found` shape users already see from those flows.
             if let Some(filename) = &link.src {
+                let file_src = dir_utf8.join(filename);
+                if !file_src.is_file() {
+                    anyhow::bail!(
+                        "marker at {dir_utf8}: [[link]] src={filename:?} \
+                         not found"
+                    );
+                }
                 if target == dst {
-                    return Ok(Some(dir_utf8.join(filename)));
+                    return Ok(Some(file_src));
                 }
                 continue;
             }
@@ -1239,7 +1250,14 @@ fn walk_and_link(
                     emitted_any = true;
                 }
                 if !emitted_any {
-                    info!("marker at {src_dir} had no active links — skipping");
+                    // v0.6+ semantics: with no active links, the walker
+                    // still descends and per-file defaults still apply.
+                    // Phrase it so users don't read "skipping" as
+                    // "subtree blocked" (the v0.5 behaviour).
+                    info!(
+                        "marker at {src_dir} had no active links \
+                         — falling back to defaults"
+                    );
                 }
                 if emitted_dir_link {
                     covered = true;

--- a/src/config.rs
+++ b/src/config.rs
@@ -298,11 +298,31 @@ pub fn load(source: &Utf8Path, yui: &YuiVars) -> Result<Config> {
     for file in &files {
         let raw = std::fs::read_to_string(file)
             .map_err(|e| Error::Config(format!("read {file}: {e}")))?;
+
+        // Pre-extract this file's own `[vars]` section as plain text and
+        // merge it into `vars_acc` BEFORE rendering. Without this, a
+        // file's `[[mount.entry]] dst = "{{ vars.home_root }}"` couldn't
+        // reference a `home_root` declared at the top of the same file
+        // — it would only see vars from previously-loaded files.
+        if let Some(file_vars) = pre_extract_vars(&raw, file)? {
+            deep_merge_table(&mut vars_acc, file_vars);
+        }
+        // Resolve cross-references within vars (`a = "{{ b }}"`,
+        // `b = "raw"` — possibly across files) by iteratively rendering
+        // every string value in `vars_acc` with `vars_acc` itself as
+        // the context, until nothing changes (or we've burned through
+        // the iteration budget — that catches genuine cycles).
+        resolve_vars_refs(&mut vars_acc, yui, &mut engine)?;
+
         let ctx = template::template_context(yui, &vars_acc);
         let rendered = engine.render(&raw, &ctx)?;
         let parsed: toml::Table =
             toml::from_str(&rendered).map_err(|e| Error::Config(format!("parse {file}: {e}")))?;
 
+        // Re-merge vars from the parsed (Tera-rendered) form. Pre-extract
+        // gives us the unrendered shape; the rendered form may have
+        // resolved `{{ env(...) }}` etc. and we want those resolved
+        // values visible to subsequent files.
         if let Some(toml::Value::Table(file_vars)) = parsed.get("vars") {
             deep_merge_table(&mut vars_acc, file_vars.clone());
         }
@@ -313,6 +333,141 @@ pub fn load(source: &Utf8Path, yui: &YuiVars) -> Result<Config> {
         .try_into()
         .map_err(|e| Error::Config(format!("schema: {e}")))?;
     Ok(cfg)
+}
+
+/// Pull just the `[vars]` (and `[vars.X]` sub-tables) out of a config
+/// file's raw text and parse them as standalone TOML, ignoring the
+/// rest. Returns `None` when the file has no `[vars]` section.
+///
+/// Skips Tera control blocks (`{% ... %}` lines) so a file using
+/// `{% set ... %}` at the top doesn't break the extraction. Any value
+/// inside `[vars]` that itself contains Tera (`{{ ... }}` or `{% ... %}`)
+/// would round-trip through TOML deserialization unchanged — Tera
+/// rendering is the second pass.
+fn pre_extract_vars(raw: &str, file: &Utf8Path) -> Result<Option<toml::Table>> {
+    let mut in_vars = false;
+    let mut found_vars = false;
+    let mut lines: Vec<&str> = Vec::new();
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        // Strip a trailing comment so a section header like
+        // `[options]  # group` still ends the [vars] capture.
+        let header = trimmed.split('#').next().unwrap_or("").trim();
+        if header.starts_with("[") {
+            // Section start. `[vars]` or `[vars.<X>]` opens / continues
+            // the capture; anything else closes it.
+            let normalized: String = header.chars().filter(|c| !c.is_whitespace()).collect();
+            if normalized == "[vars]"
+                || normalized.starts_with("[vars.")
+                || normalized.starts_with("[vars[")
+            {
+                in_vars = true;
+                found_vars = true;
+                lines.push(line);
+                continue;
+            }
+            in_vars = false;
+            continue;
+        }
+        // Tera control block at column 0 — skip so the standalone
+        // TOML parse doesn't see `{% set ... %}` and choke. Inline
+        // `{{ ... }}` inside values is fine because TOML happily
+        // accepts them as plain strings.
+        if trimmed.starts_with("{%") {
+            continue;
+        }
+        if in_vars {
+            lines.push(line);
+        }
+    }
+    if !found_vars {
+        return Ok(None);
+    }
+    let extracted = lines.join("\n");
+    let parsed: toml::Table = toml::from_str(&extracted).map_err(|e| {
+        Error::Config(format!(
+            "pre-extract [vars] from {file}: {e} \
+             (the [vars] block must be parseable on its own — \
+             move computed values into a `set` block above the section)"
+        ))
+    })?;
+    if let Some(toml::Value::Table(vars)) = parsed.get("vars") {
+        Ok(Some(vars.clone()))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Maximum number of resolution iterations. Each iteration evaluates
+/// every templated string value in `vars` with the current vars as the
+/// context. Genuine cycles (`a = "{{ b }}"`, `b = "{{ a }}"`) hit this
+/// budget and bail out — leaving the values as-is rather than looping
+/// forever or panicking.
+const MAX_VARS_RESOLVE_ITERATIONS: usize = 8;
+
+/// Iteratively Tera-render every string value in a vars table using the
+/// vars table itself (plus `yui.*` / `env(…)`) as the rendering context,
+/// until no value changes between iterations.
+fn resolve_vars_refs(
+    vars: &mut toml::Table,
+    yui: &YuiVars,
+    engine: &mut template::Engine,
+) -> Result<()> {
+    for _ in 0..MAX_VARS_RESOLVE_ITERATIONS {
+        let ctx = template::template_context(yui, vars);
+        let mut changed = false;
+        render_strings_in_table(vars, engine, &ctx, &mut changed)?;
+        if !changed {
+            return Ok(());
+        }
+    }
+    // Hit the budget — likely a cycle. We leave the partially-resolved
+    // values in place (rather than erroring) so the rest of yui keeps
+    // working; downstream Tera renders will surface a useful error if
+    // the unresolved value lands somewhere it matters.
+    Ok(())
+}
+
+fn render_strings_in_table(
+    table: &mut toml::Table,
+    engine: &mut template::Engine,
+    ctx: &tera::Context,
+    changed: &mut bool,
+) -> Result<()> {
+    for (_k, value) in table.iter_mut() {
+        render_strings_in_value(value, engine, ctx, changed)?;
+    }
+    Ok(())
+}
+
+fn render_strings_in_value(
+    value: &mut toml::Value,
+    engine: &mut template::Engine,
+    ctx: &tera::Context,
+    changed: &mut bool,
+) -> Result<()> {
+    match value {
+        toml::Value::String(s) => {
+            if !s.contains("{{") && !s.contains("{%") {
+                return Ok(());
+            }
+            let rendered = engine.render(s.as_str(), ctx)?;
+            if rendered != *s {
+                *s = rendered;
+                *changed = true;
+            }
+        }
+        toml::Value::Table(t) => {
+            render_strings_in_table(t, engine, ctx, changed)?;
+        }
+        toml::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                render_strings_in_value(v, engine, ctx, changed)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 /// List config files in merge order:
@@ -546,5 +701,106 @@ dst = "/a"
         assert!(cfg.render.manage_gitignore);
         assert_eq!(cfg.backup.dir, ".yui/backup");
         assert_eq!(cfg.mount.marker_filename, ".yuilink");
+    }
+
+    /// Pre-extract: a value declared in `[vars]` should be visible to
+    /// other sections of the same file during Tera rendering. Without
+    /// pre-extract this would fail because the file's own vars aren't
+    /// added to the context until AFTER rendering.
+    #[test]
+    fn vars_visible_to_same_file_render() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            &tmp,
+            "config.toml",
+            r#"
+[vars]
+home_root = "/custom/home"
+
+[[mount.entry]]
+src = "home"
+dst = "{{ vars.home_root }}"
+"#,
+        );
+        let r = root(&tmp);
+        let cfg = load(&r, &yui_vars(&r)).unwrap();
+        assert_eq!(cfg.mount.entry.len(), 1);
+        assert_eq!(cfg.mount.entry[0].dst, "/custom/home");
+    }
+
+    /// Tera `set` blocks at the top of the file (used by some configs
+    /// for computed values) shouldn't break the standalone TOML parse
+    /// of the [vars] block that lives further down.
+    #[test]
+    fn vars_extract_skips_set_blocks() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            &tmp,
+            "config.toml",
+            r#"
+{% set computed = "abc" %}
+[vars]
+plain = "real"
+
+[[mount.entry]]
+src = "home"
+dst = "{{ vars.plain }}"
+"#,
+        );
+        let r = root(&tmp);
+        let cfg = load(&r, &yui_vars(&r)).unwrap();
+        assert_eq!(cfg.mount.entry[0].dst, "real");
+    }
+
+    /// Vars that reference other vars should resolve regardless of
+    /// declaration order (the resolver iterates until convergence).
+    #[test]
+    fn vars_cross_reference_resolves_either_order() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            &tmp,
+            "config.toml",
+            r#"
+[vars]
+a = "{{ vars.b }}"
+b = "raw"
+
+[[mount.entry]]
+src = "home"
+dst = "{{ vars.a }}"
+"#,
+        );
+        let r = root(&tmp);
+        let cfg = load(&r, &yui_vars(&r)).unwrap();
+        assert_eq!(cfg.mount.entry[0].dst, "raw");
+    }
+
+    /// Genuine cycles (`a = {{b}}` + `b = {{a}}`) shouldn't loop or
+    /// panic. The resolver bails after the iteration budget and leaves
+    /// the values as-is; downstream Tera renders that hit the
+    /// unresolved value will surface a clear error if it actually
+    /// matters at that site.
+    #[test]
+    fn vars_cycle_does_not_loop_forever() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            &tmp,
+            "config.toml",
+            r#"
+[vars]
+a = "{{ vars.b }}"
+b = "{{ vars.a }}"
+
+[[mount.entry]]
+src = "home"
+dst = "/anywhere"
+"#,
+        );
+        let r = root(&tmp);
+        // Loads without panicking. The unresolved a/b just stay as
+        // literal Tera strings; load() succeeds because no other
+        // section actually references them.
+        let cfg = load(&r, &yui_vars(&r)).unwrap();
+        assert_eq!(cfg.mount.entry[0].dst, "/anywhere");
     }
 }

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -35,11 +35,19 @@
 //! entry's `dst` is still the source of truth — if you want the default
 //! `~/.config/nvim`-style placement, list it explicitly.
 //!
-//! Default-dst behaviour: with an empty / link-less marker the walker
-//! still emits the dir-level link to the parent mount's natural dst (the
-//! original "presence-only" behaviour). With explicit `[[link]]` entries
-//! that natural dst is *not* implied — the marker fully defines what
-//! gets linked at this dir.
+//! Default-dst behaviour, two cases (kept distinct on purpose):
+//!
+//!   - **Empty / link-less marker** — the walker still emits the
+//!     dir-level link to the parent mount's natural dst (the original
+//!     "presence-only" behaviour).
+//!   - **Directory-scoped `[[link]]`** (no `src`) — fully defines the
+//!     directory's placement. The parent mount's natural dst is *not*
+//!     implied; only what's listed here is linked at this dir.
+//!   - **File-scoped `[[link]]`** (with `src = "<filename>"`) — applies
+//!     only to the named sibling file. It does *not* claim
+//!     directory-level coverage, so per-file defaults from the parent
+//!     mount still apply to the rest of the dir (and to the same file
+//!     too, in addition to the explicit dst).
 
 use camino::Utf8Path;
 use serde::Deserialize;
@@ -98,9 +106,18 @@ pub fn read_spec(dir: &Utf8Path, marker_filename: &str) -> Result<Option<MarkerS
     }
     for link in &parsed.link {
         if let Some(src) = &link.src {
-            if src.is_empty() || src.contains('/') || src.contains('\\') {
+            // Reject anything that isn't a plain sibling file. `.` /
+            // `..` would point at the marker dir itself or its parent,
+            // and path separators would let the entry escape the dir
+            // entirely — neither matches the "single filename" promise.
+            if src.is_empty()
+                || src == "."
+                || src == ".."
+                || src.contains('/')
+                || src.contains('\\')
+            {
                 return Err(Error::Config(format!(
-                    "parse {path}: [[link]] src must be a single filename (no path separators), got {src:?}"
+                    "parse {path}: [[link]] src must be a single filename (no path separators or `.`/`..`), got {src:?}"
                 )));
             }
         }
@@ -221,6 +238,31 @@ dst = "/anywhere"
         .unwrap();
         let err = read_spec(&root(&tmp), ".yuilink").unwrap_err();
         assert!(format!("{err}").contains("single filename"));
+    }
+
+    #[test]
+    fn marker_src_dot_or_dotdot_errors() {
+        // `.` / `..` would silently escape the marker dir or point at
+        // the dir itself; neither is what `[[link]] src` is for.
+        for bad in [".", ".."] {
+            let tmp = TempDir::new().unwrap();
+            std::fs::write(
+                tmp.path().join(".yuilink"),
+                format!(
+                    r#"
+[[link]]
+src = "{bad}"
+dst = "/anywhere"
+"#
+                ),
+            )
+            .unwrap();
+            let err = read_spec(&root(&tmp), ".yuilink").unwrap_err();
+            assert!(
+                format!("{err}").contains("single filename"),
+                "expected rejection for src = {bad:?}, got {err}"
+            );
+        }
     }
 
     #[test]

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -3,8 +3,8 @@
 //! Two forms are accepted:
 //!   - **empty file** → "junction this dir at the parent mount's dst"
 //!     (the original presence-only marker semantics)
-//!   - **TOML with `[[link]]` entries** → "junction this dir at each
-//!     entry's `dst`, when filtered" — overrides the parent mount's dst.
+//!   - **TOML with `[[link]]` entries** → declare explicit links from this
+//!     directory. Each entry produces one link (after `when` filter).
 //!
 //! ```toml
 //! # $DOTFILES/home/.config/nvim/.yuilink
@@ -13,8 +13,33 @@
 //!
 //! [[link]]
 //! dst = "{{ env(name='LOCALAPPDATA') }}/nvim"
-//! when = "{{ yui.os == 'windows' }}"
+//! when = "yui.os == 'windows'"
 //! ```
+//!
+//! Each `[[link]]` may carry an optional `src = "<filename>"` that scopes
+//! the link to a specific file inside the marker's directory rather than
+//! the directory itself:
+//!
+//! ```toml
+//! # $DOTFILES/home/.config/powershell/.yuilink
+//! [[link]]
+//! src = "profile.ps1"
+//! dst = "{{ env(name='USERPROFILE') }}/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"
+//! when = "yui.os == 'windows'"
+//! ```
+//!
+//! Stacking semantics (v0.6+): a marker no longer stops the walker. The
+//! walker keeps descending past markers and aggregates link entries from
+//! every marker it encounters. A descendant marker therefore *adds*
+//! destinations on top of its ancestors rather than replacing them. Each
+//! entry's `dst` is still the source of truth — if you want the default
+//! `~/.config/nvim`-style placement, list it explicitly.
+//!
+//! Default-dst behaviour: with an empty / link-less marker the walker
+//! still emits the dir-level link to the parent mount's natural dst (the
+//! original "presence-only" behaviour). With explicit `[[link]]` entries
+//! that natural dst is *not* implied — the marker fully defines what
+//! gets linked at this dir.
 
 use camino::Utf8Path;
 use serde::Deserialize;
@@ -23,15 +48,21 @@ use crate::{Error, Result};
 
 #[derive(Debug, Clone)]
 pub enum MarkerSpec {
-    /// Empty marker — link this dir using the parent mount's dst.
+    /// Empty marker — link this dir using the parent mount's natural dst.
     PassThrough,
-    /// Per-dir override; each entry produces a link (after `when` filter).
-    /// The parent mount's dst is bypassed for this directory.
-    Override { links: Vec<MarkerLink> },
+    /// Explicit links. Each entry maps the marker's directory (or a
+    /// specific file inside it via `src`) to a destination.
+    Explicit { links: Vec<MarkerLink> },
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct MarkerLink {
+    /// Optional file scope. When set, this entry links the file at
+    /// `<marker-dir>/<src>` to `dst` instead of the directory itself.
+    /// Must be a single component (no path separators) so it stays a
+    /// sibling file of the marker.
+    #[serde(default)]
+    pub src: Option<String>,
     pub dst: String,
     #[serde(default)]
     pub when: Option<String>,
@@ -48,7 +79,7 @@ struct MarkerFile {
 /// Returns:
 ///   - `Ok(None)` — no marker file present
 ///   - `Ok(Some(PassThrough))` — present and empty / whitespace-only / no `[[link]]`
-///   - `Ok(Some(Override { ... }))` — present with `[[link]]` entries
+///   - `Ok(Some(Explicit { ... }))` — present with `[[link]]` entries
 ///   - `Err(_)` — present but malformed TOML, or other IO error
 pub fn read_spec(dir: &Utf8Path, marker_filename: &str) -> Result<Option<MarkerSpec>> {
     let path = dir.join(marker_filename);
@@ -65,7 +96,16 @@ pub fn read_spec(dir: &Utf8Path, marker_filename: &str) -> Result<Option<MarkerS
     if parsed.link.is_empty() {
         return Ok(Some(MarkerSpec::PassThrough));
     }
-    Ok(Some(MarkerSpec::Override { links: parsed.link }))
+    for link in &parsed.link {
+        if let Some(src) = &link.src {
+            if src.is_empty() || src.contains('/') || src.contains('\\') {
+                return Err(Error::Config(format!(
+                    "parse {path}: [[link]] src must be a single filename (no path separators), got {src:?}"
+                )));
+            }
+        }
+    }
+    Ok(Some(MarkerSpec::Explicit { links: parsed.link }))
 }
 
 /// Presence-only check: any `.yuilink` file (empty or with content) counts.
@@ -111,7 +151,7 @@ mod tests {
     }
 
     #[test]
-    fn marker_with_links_is_override() {
+    fn marker_with_links_is_explicit() {
         let tmp = TempDir::new().unwrap();
         std::fs::write(
             tmp.path().join(".yuilink"),
@@ -121,21 +161,66 @@ dst = "/a"
 
 [[link]]
 dst = "/b"
-when = "{{ yui.os == 'windows' }}"
+when = "yui.os == 'windows'"
 "#,
         )
         .unwrap();
         let spec = read_spec(&root(&tmp), ".yuilink").unwrap().unwrap();
         match spec {
-            MarkerSpec::Override { links } => {
+            MarkerSpec::Explicit { links } => {
                 assert_eq!(links.len(), 2);
+                assert!(links[0].src.is_none());
                 assert_eq!(links[0].dst, "/a");
                 assert!(links[0].when.is_none());
+                assert!(links[1].src.is_none());
                 assert_eq!(links[1].dst, "/b");
-                assert_eq!(links[1].when.as_deref(), Some("{{ yui.os == 'windows' }}"));
+                assert_eq!(links[1].when.as_deref(), Some("yui.os == 'windows'"));
             }
-            _ => panic!("expected Override"),
+            _ => panic!("expected Explicit"),
         }
+    }
+
+    #[test]
+    fn marker_with_file_src_parses() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join(".yuilink"),
+            r#"
+[[link]]
+src = "profile.ps1"
+dst = "~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"
+when = "yui.os == 'windows'"
+"#,
+        )
+        .unwrap();
+        let spec = read_spec(&root(&tmp), ".yuilink").unwrap().unwrap();
+        match spec {
+            MarkerSpec::Explicit { links } => {
+                assert_eq!(links.len(), 1);
+                assert_eq!(links[0].src.as_deref(), Some("profile.ps1"));
+                assert_eq!(
+                    links[0].dst,
+                    "~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"
+                );
+            }
+            _ => panic!("expected Explicit"),
+        }
+    }
+
+    #[test]
+    fn marker_src_with_path_separator_errors() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join(".yuilink"),
+            r#"
+[[link]]
+src = "sub/file.txt"
+dst = "/anywhere"
+"#,
+        )
+        .unwrap();
+        let err = read_spec(&root(&tmp), ".yuilink").unwrap_err();
+        assert!(format!("{err}").contains("single filename"));
     }
 
     #[test]

--- a/src/template.rs
+++ b/src/template.rs
@@ -28,8 +28,24 @@ impl Engine {
     pub fn render(&mut self, src: &str, ctx: &Context) -> Result<String> {
         self.tera
             .render_str(src, ctx)
-            .map_err(|e| crate::Error::Template(format!("{e:#}")))
+            .map_err(|e| crate::Error::Template(format_tera_error(&e)))
     }
+}
+
+/// Tera's `Display` impl only emits the top-level message
+/// (`Failed to render '__tera_one_off'`), leaving the actual reason
+/// (`variable 'vars.home_root' not found in context` etc.) buried in
+/// the source chain. Walk the chain and join every level so the user
+/// sees something they can act on.
+fn format_tera_error(err: &tera::Error) -> String {
+    use std::error::Error as _;
+    let mut parts: Vec<String> = vec![err.to_string()];
+    let mut src = err.source();
+    while let Some(e) = src {
+        parts.push(e.to_string());
+        src = e.source();
+    }
+    parts.join(": ")
 }
 
 impl Default for Engine {


### PR DESCRIPTION
## Summary

Two composable extensions to `.yuilink` semantics, plus a small fix to the `init` skeleton.

### 1. Nested marker accumulation

A `.yuilink` no longer halts the walker. The walker keeps descending past markers and aggregates link entries from every marker it encounters, so a descendant marker *adds* destinations on top of its ancestors rather than replacing them.

```toml
# $DOTFILES/home/.config/.yuilink — junction the whole .config dir
[[link]]
dst = \"~/.config\"
```
```toml
# $DOTFILES/home/.config/nvim/.yuilink — extra Windows-only dst
[[link]]
dst = \"{{ env(name='LOCALAPPDATA') }}/nvim\"
when = \"yui.os == 'windows'\"
```

Both links land on Windows: parent's whole-dir junction reaches every file under `~/.config`, and the child marker layers on the `%LOCALAPPDATA%\nvim` alternate. `MarkerSpec::Override` was renamed to `Explicit` to reflect the additive intent.

### 2. File-level `[[link]] src`

`[[link]]` now accepts an optional `src = \"<filename>\"` that scopes the link to a single sibling file, leaving the rest of the directory to default placement. Useful for paths that don't follow `~/.config/<app>/` conventions — the PowerShell profile being the canonical example.

```toml
# $DOTFILES/home/.config/powershell/.yuilink
[[link]]
src = \"Microsoft.PowerShell_profile.ps1\"
dst = \"{{ env(name='USERPROFILE') }}/Documents/PowerShell/Microsoft.PowerShell_profile.ps1\"
when = \"yui.os == 'windows'\"
```

`src` must be a single component (no path separators); the file lives right next to the marker.

### Coverage tracking

When a marker emits a dir-level link (PassThrough or explicit), descendants skip the parent mount's natural per-file links — the dir-level junction already exposes them. A marker with only file-level links (or only inactive links) does NOT claim coverage; defaults still apply. Use \`.yuiignore\` to actually exclude a subtree.

### Bonus: init skeleton .gitignore fix

\`yui init\` previously generated a \`.gitignore\` with \`/.yui/\` — which silently dropped \`.yui/bin/\` (hook scripts) from \`git add -A\`. Now it ignores only \`state.json\` / \`backup/\` and keeps \`.yui/bin/\` tracked.

### Breaking change

A marker with only inactive links (\`when=false\`) used to suppress *all* linking under its directory. With v0.6 it's purely additive: defaults from the parent mount still apply. Use \`.yuiignore\` to opt a subtree out.

## Test plan

- [x] \`cargo make check\` (fmt + clippy + tests) — 101 passed
- [x] New unit tests cover: nested marker accumulation, file-level src match, missing-src error, \`MarkerSpec::Explicit\` parsing
- [x] Updated existing \`apply_marker_inactive_link_falls_through_to_default\` test to assert the new (additive) semantics
- [ ] Manual: drop the empty subdir markers from the migration repo and verify \`apply --dry-run\` still produces the expected per-app extras

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File-level marker targeting: scope markers to specific sibling files using `src` field
  * Marker stacking: parent markers no longer halt processing, enabling layered configurations for subdirectories

* **Documentation**
  * Updated README with new marker behavior and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->