### PR TITLE
fix(absorb): recursive remove for non-empty target dirs after backup

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1485,8 +1485,27 @@ fn link_dir_with_backup(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>) -> R
             // `.yui/backup/...`. Without this fall-through the absorb
             // chokes on `Directory not empty` (Windows error 145) for
             // anything migrated from a per-file dotfiles manager.
-            if link::unlink(dst).is_err() {
-                std::fs::remove_dir_all(dst)?;
+            //
+            // Narrow the fallback to the case it's actually for: the
+            // target still exists and is a real (non-link) directory.
+            // Anything else — permission denied, I/O error, the path
+            // suddenly being a file or junction — propagates instead
+            // of being silently coerced into `remove_dir_all`.
+            if let Err(unlink_err) = link::unlink(dst) {
+                let meta = std::fs::symlink_metadata(dst).with_context(|| {
+                    format!("stat {dst} after link::unlink failed: {unlink_err}")
+                })?;
+                let ft = meta.file_type();
+                if ft.is_dir() && !ft.is_symlink() {
+                    std::fs::remove_dir_all(dst).with_context(|| {
+                        format!(
+                            "remove_dir_all({dst}) after link::unlink failed: \
+                             {unlink_err}"
+                        )
+                    })?;
+                } else {
+                    return Err(unlink_err).with_context(|| format!("unlink({dst}) before relink"));
+                }
             }
             info!("relink dir: {src} → {dst}");
             link::link_dir(src, dst, ctx.dir_mode)?;

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1477,7 +1477,17 @@ fn link_dir_with_backup(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>) -> R
             // backup + replace, the same behaviour as before the
             // absorb classifier landed.
             backup_existing(dst, ctx.backup_root, /* is_dir */ true)?;
-            link::unlink(dst)?;
+            // `link::unlink` is intentionally conservative: it refuses to
+            // recursively delete a non-empty regular directory. That's
+            // the right default for ad-hoc cleanup, but here we have
+            // *just* backed the directory up, so a recursive remove is
+            // safe — the user's pre-yui content is preserved under
+            // `.yui/backup/...`. Without this fall-through the absorb
+            // chokes on `Directory not empty` (Windows error 145) for
+            // anything migrated from a per-file dotfiles manager.
+            if link::unlink(dst).is_err() {
+                std::fs::remove_dir_all(dst)?;
+            }
             info!("relink dir: {src} → {dst}");
             link::link_dir(src, dst, ctx.dir_mode)?;
             Ok(())
@@ -2154,6 +2164,64 @@ dst = "{}"
         assert_eq!(
             std::fs::read_to_string(source.join("home/.bashrc")).unwrap(),
             "user's edit (older)"
+        );
+    }
+
+    /// Regression for the Windows-error-145 bug: a `home/.config/.yuilink`
+    /// (PassThrough) marker pointing at a non-empty regular `~/.config`
+    /// directory (the typical chezmoi-migrated state, where every file
+    /// inside is an individual hardlink) used to fail the absorb with
+    /// `Directory not empty` because `link::unlink` refuses to recurse.
+    /// After backup we now `remove_dir_all` as a fallback.
+    #[test]
+    fn apply_replaces_non_empty_target_dir_after_backup() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        let target = utf8(tmp.path().join("target"));
+        std::fs::create_dir_all(source.join("home/.config/app")).unwrap();
+        std::fs::create_dir_all(target.join(".config/app")).unwrap();
+        // Marker that says "junction this dir at the parent mount's dst"
+        // — same shape as a typical home/.config/.yuilink.
+        std::fs::write(source.join("home/.config/.yuilink"), "").unwrap();
+        std::fs::write(source.join("home/.config/app/config.toml"), "src side").unwrap();
+        // Pre-existing non-empty regular dir at the target — chezmoi /
+        // any per-file dotfiles flow leaves things in this shape.
+        std::fs::write(target.join(".config/app/config.toml"), "target side").unwrap();
+        std::fs::write(target.join(".config/app/state.json"), "{}").unwrap();
+
+        let cfg = format!(
+            r#"
+[absorb]
+on_anomaly = "force"
+
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+            toml_path(&target)
+        );
+        std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+        // Used to bail with `unlink: ... Directory not empty` here.
+        apply(Some(source.clone()), false).unwrap();
+
+        // ~/.config now reaches source/home/.config via the link.
+        assert_eq!(
+            std::fs::read_to_string(target.join(".config/app/config.toml")).unwrap(),
+            "src side"
+        );
+        // Pre-existing target content is preserved in `.yui/backup/`.
+        let backup_root = source.join(".yui/backup");
+        let mut found_backup_state = false;
+        for entry in walkdir(&backup_root) {
+            if entry.file_name() == Some("state.json") {
+                found_backup_state = true;
+                break;
+            }
+        }
+        assert!(
+            found_backup_state,
+            "expected target's state.json to land in the backup tree"
         );
     }
 


### PR DESCRIPTION
## Summary

`link_dir_with_backup` backs the target dir up to `.yui/backup/...` then calls `link::unlink` to clear the way for the junction. `unlink` is intentionally conservative — it refuses to recursively delete a regular non-empty directory — so any chezmoi-migrated layout where `~/.config/<app>/` is a real dir packed with individually-hardlinked files exploded with `unlink: ... Directory not empty (os error 145)` on Windows the moment `home/.config/.yuilink` (or similar) tried to take over.

Since `backup_existing` is the gating step (the `?` propagates a backup failure before we reach unlink), by the time unlink runs the user's pre-yui content is already preserved in the backup tree. So if `unlink` fails — the only path here is "non-empty regular dir" — fall through to `remove_dir_all` instead of aborting the apply.

```rust
backup_existing(dst, ctx.backup_root, true)?;
if link::unlink(dst).is_err() {
    std::fs::remove_dir_all(dst)?;
}
```

## Encountered in the wild

Hit this stepping through a real chezmoi → yui migration on Windows: `home/.config/.yuilink` → junction at `~/.config`, with the existing `~/.config/<app>/` dirs full of chezmoi-linked content.

## Test plan

- [x] `cargo make check` — 107 tests pass (1 new regression test, 106 pre-existing).
- [x] New `apply_replaces_non_empty_target_dir_after_backup` reproduces the chezmoi-style shape (parent `.yuilink` + non-empty regular target dir) and asserts both that the apply succeeds and that the target's pre-yui content lands in `.yui/backup/`.
- [x] Re-ran the failing real-world apply against `~/.config` after the fix — succeeds, `~/.config` becomes a junction to source, prior runtime state is preserved in backup.

## Follow-up work (separate PR / v0.7.0)

The current dir-absorb only **backs up + replaces** target with a junction to source. README documents AutoAbsorb as "back up source, copy target's content into source, then relink", and the file-level `absorb_target_into_source` does this. The dir-level path is missing the "copy target → source" step, so an absorbed `~/.config` loses any subdirs that source didn't already have (e.g. `~/.config/gh/hosts.yml` ends up only in `.yui/backup/...`). Worth tackling next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed directory relinking failures when targets are out-of-sync. The apply command now gracefully handles non-empty directory targets and properly preserves original content in backups while replacing targets with source content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->