### PR TITLE
feat(cli): colourise --help output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,12 +1,32 @@
 use anyhow::Result;
 use camino::Utf8PathBuf;
+use clap::builder::styling::{AnsiColor, Effects, Styles};
 use clap::{Parser, Subcommand};
 
 use crate::cmd;
 use crate::config::IconsMode;
 
+/// Explicit colour palette for `--help` output. clap honours `NO_COLOR`
+/// and falls back to monochrome when stdout isn't a TTY, so this is
+/// safe to leave on unconditionally — the styled bytes are only ever
+/// emitted when a real terminal is reading them. The palette mirrors
+/// the bind-points / icon colours used in `yui list` / `yui status` so
+/// help, list, and status all feel like the same tool.
+const HELP_STYLES: Styles = Styles::styled()
+    // Section headers ("Usage:", "Commands:", "Options:").
+    .header(AnsiColor::BrightCyan.on_default().effects(Effects::BOLD))
+    // The literal "yui" / subcommand names in usage strings.
+    .usage(AnsiColor::BrightCyan.on_default().effects(Effects::BOLD))
+    // Subcommand / option literals (`--source`, `init`, …).
+    .literal(AnsiColor::Magenta.on_default().effects(Effects::BOLD))
+    // <PLACEHOLDER> values inside option signatures.
+    .placeholder(AnsiColor::Cyan.on_default())
+    .error(AnsiColor::Red.on_default().effects(Effects::BOLD))
+    .valid(AnsiColor::Green.on_default())
+    .invalid(AnsiColor::Yellow.on_default().effects(Effects::BOLD));
+
 #[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
+#[command(version, about, long_about = None, styles = HELP_STYLES)]
 pub struct Cli {
     /// Path to dotfiles source repository ($DOTFILES)
     #[arg(short, long, env = "YUI_SOURCE", global = true)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,11 +13,13 @@ use crate::config::IconsMode;
 /// the bind-points / icon colours used in `yui list` / `yui status` so
 /// help, list, and status all feel like the same tool.
 const HELP_STYLES: Styles = Styles::styled()
-    // Section headers ("Usage:", "Commands:", "Options:").
+    // "Commands:" / "Options:" / etc. section headers.
     .header(AnsiColor::BrightCyan.on_default().effects(Effects::BOLD))
-    // The literal "yui" / subcommand names in usage strings.
+    // The "Usage:" heading label itself (NOT the binary name — that
+    // falls under `literal` below).
     .usage(AnsiColor::BrightCyan.on_default().effects(Effects::BOLD))
-    // Subcommand / option literals (`--source`, `init`, …).
+    // Binary name in the usage line + every subcommand / option
+    // literal (`init`, `--source`, …).
     .literal(AnsiColor::Magenta.on_default().effects(Effects::BOLD))
     // <PLACEHOLDER> values inside option signatures.
     .placeholder(AnsiColor::Cyan.on_default())


### PR DESCRIPTION
Closes #31.

## Summary

clap 4 has colour support but its default palette is intentionally minimal — `yui --help` came out essentially monochrome compared to the `list` / `status` surfaces that already lean on owo-colors. Define an explicit `Styles` so the help output reads with the same visual weight as the rest of yui:

| element | style |
|---|---|
| section headers (\"Usage:\", \"Commands:\", \"Options:\") | bright cyan + bold |
| binary name in usage line + literal subcommands / options (`init`, `--source`, …) | magenta + bold |
| `<PLACEHOLDER>` values | cyan |
| error / valid / invalid | red bold / green / yellow bold |

clap honours `NO_COLOR` and only emits ANSI when stdout is a TTY, so this is safe to leave on unconditionally.

## Verified

- `yui --help` in a real terminal — colourised, headers / literals / placeholders distinguishable at a glance.
- `yui --help | cat` — plain text (TTY auto-detect works).
- `CLICOLOR_FORCE=1 yui --help | cat -v` — confirms the expected ANSI sequences (`^[[96m` cyan headers, `^[[35m` magenta literals, `^[[36m` cyan placeholders).
- `cargo make check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI help output now includes custom styling with enhanced colors and visual effects for improved readability and user experience. The help text features better visual differentiation for various sections including headers, usage information, literals, placeholders, and error validation messages. This makes it easier for users to navigate and understand command options and help documentation more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->