### PR TITLE
feat(hooks): coloured table for `hooks list`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,7 +125,14 @@ pub enum Command {
 #[derive(Subcommand, Debug)]
 pub enum HookAction {
     /// List configured hooks with their last-run state
-    List,
+    List {
+        /// Override [ui] icons mode for this invocation
+        #[arg(long, value_name = "MODE")]
+        icons: Option<IconsMode>,
+        /// Disable color output (also respected via NO_COLOR env)
+        #[arg(long)]
+        no_color: bool,
+    },
     /// Run a hook (or every hook). The `when` filter is always honored;
     /// `--force` bypasses the `when_run` state check (so a `once` hook
     /// can be re-run, an `onchange` hook re-runs even with matching
@@ -158,7 +165,7 @@ impl Cli {
             Command::Doctor => cmd::doctor(source),
             Command::GcBackup { older_than } => cmd::gc_backup(source, older_than),
             Command::Hooks { action } => match action {
-                HookAction::List => cmd::hooks_list(source),
+                HookAction::List { icons, no_color } => cmd::hooks_list(source, icons, no_color),
                 HookAction::Run { name, force } => cmd::hooks_run(source, name, force),
             },
         }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1103,13 +1103,16 @@ pub fn hooks_list(
     let rows: Vec<HookRow> = config
         .hook
         .iter()
-        .map(|h| {
+        .map(|h| -> Result<HookRow> {
+            // Propagate Tera errors instead of silently coercing them
+            // to "inactive" — a syntax error in the user's `when`
+            // expression should surface, not hide.
             let active = match &h.when {
                 None => true,
-                Some(w) => template::eval_truthy(w, &mut engine, &tera_ctx).unwrap_or(false),
+                Some(w) => template::eval_truthy(w, &mut engine, &tera_ctx)?,
             };
             let last_run_at = state.hooks.get(&h.name).and_then(|s| s.last_run_at.clone());
-            HookRow {
+            Ok(HookRow {
                 name: h.name.clone(),
                 phase: match h.phase {
                     HookPhase::Pre => "pre",
@@ -1123,9 +1126,9 @@ pub fn hooks_list(
                 last_run_at,
                 when: h.when.clone(),
                 active,
-            }
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>>>()?;
 
     print_hooks_table(&rows, icons, color);
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1076,47 +1076,213 @@ pub fn gc_backup(_source: Option<Utf8PathBuf>, _older_than: Option<String>) -> R
 }
 
 /// `yui hooks list` — show every configured hook + its last-run state.
-pub fn hooks_list(source: Option<Utf8PathBuf>) -> Result<()> {
+pub fn hooks_list(
+    source: Option<Utf8PathBuf>,
+    icons_override: Option<IconsMode>,
+    no_color: bool,
+) -> Result<()> {
     let source = resolve_source(source)?;
     let yui = YuiVars::detect(&source);
     let config = config::load(&source, &yui)?;
     let state = hook::State::load(&source)?;
+
+    let icons_mode = icons_override.unwrap_or(config.ui.icons);
+    let icons = Icons::for_mode(icons_mode);
+    let color = !no_color && supports_color_stdout();
 
     if config.hook.is_empty() {
         println!("(no [[hook]] entries in config)");
         return Ok(());
     }
 
-    for h in &config.hook {
-        let phase = match h.phase {
-            HookPhase::Pre => "pre",
-            HookPhase::Post => "post",
-        };
-        let when_run = match h.when_run {
-            config::WhenRun::Once => "once",
-            config::WhenRun::Onchange => "onchange",
-            config::WhenRun::Every => "every",
-        };
-        let last = state
-            .hooks
-            .get(&h.name)
-            .and_then(|s| s.last_run_at.as_deref())
-            .unwrap_or("(never)");
-        println!(
-            "{name:<20}  phase={phase:<4}  when_run={when_run:<8}  last_run_at={last}",
-            name = h.name,
-        );
-        if let Some(when) = &h.when {
-            println!("                       when = {when}");
-        }
-        println!("                       script = {}", h.script);
-        println!(
-            "                       command = {} {}",
-            h.command,
-            h.args.join(" ")
-        );
-    }
+    // Pre-evaluate the `when` filter for every hook so the status icon
+    // can distinguish "skipped because the OS gate is false" from
+    // "active but never run".
+    let mut engine = template::Engine::new();
+    let tera_ctx = template::template_context(&yui, &config.vars);
+    let rows: Vec<HookRow> = config
+        .hook
+        .iter()
+        .map(|h| {
+            let active = match &h.when {
+                None => true,
+                Some(w) => template::eval_truthy(w, &mut engine, &tera_ctx).unwrap_or(false),
+            };
+            let last_run_at = state.hooks.get(&h.name).and_then(|s| s.last_run_at.clone());
+            HookRow {
+                name: h.name.clone(),
+                phase: match h.phase {
+                    HookPhase::Pre => "pre",
+                    HookPhase::Post => "post",
+                },
+                when_run: match h.when_run {
+                    config::WhenRun::Once => "once",
+                    config::WhenRun::Onchange => "onchange",
+                    config::WhenRun::Every => "every",
+                },
+                last_run_at,
+                when: h.when.clone(),
+                active,
+            }
+        })
+        .collect();
+
+    print_hooks_table(&rows, icons, color);
+
+    let total = rows.len();
+    let active = rows.iter().filter(|r| r.active).count();
+    let inactive = total - active;
+    let ran = rows.iter().filter(|r| r.last_run_at.is_some()).count();
+    let never = total - ran;
+    println!();
+    println!(
+        "  {total} hooks · {active} active · {inactive} inactive · {ran} ran · {never} never run"
+    );
+
     Ok(())
+}
+
+#[derive(Debug)]
+struct HookRow {
+    name: String,
+    phase: &'static str,
+    when_run: &'static str,
+    last_run_at: Option<String>,
+    when: Option<String>,
+    active: bool,
+}
+
+fn print_hooks_table(rows: &[HookRow], icons: Icons, color: bool) {
+    use owo_colors::OwoColorize as _;
+    use std::fmt::Write as _;
+
+    let name_w = rows
+        .iter()
+        .map(|r| r.name.chars().count())
+        .max()
+        .unwrap_or(0)
+        .max("NAME".len());
+    let phase_w = rows
+        .iter()
+        .map(|r| r.phase.len())
+        .max()
+        .unwrap_or(0)
+        .max("PHASE".len());
+    let when_run_w = rows
+        .iter()
+        .map(|r| r.when_run.len())
+        .max()
+        .unwrap_or(0)
+        .max("WHEN_RUN".len());
+    let last_w = rows
+        .iter()
+        .map(|r| {
+            r.last_run_at
+                .as_deref()
+                .map(|s| s.chars().count())
+                .unwrap_or("(never)".len())
+        })
+        .max()
+        .unwrap_or(0)
+        .max("LAST_RUN".len());
+    let status_w = "STATUS".len();
+
+    // Header
+    let mut header = String::new();
+    let _ = write!(
+        &mut header,
+        "  {:<status_w$}  {:<name_w$}  {:<phase_w$}  {:<when_run_w$}  {:<last_w$}  WHEN",
+        "STATUS", "NAME", "PHASE", "WHEN_RUN", "LAST_RUN"
+    );
+    if color {
+        println!("{}", header.bold());
+    } else {
+        println!("{header}");
+    }
+
+    // Separator (re-uses the same sep glyph the list / status table picks).
+    let bar = |n: usize| icons.sep.to_string().repeat(n);
+    let sep = format!(
+        "  {}  {}  {}  {}  {}  {}",
+        bar(status_w),
+        bar(name_w),
+        bar(phase_w),
+        bar(when_run_w),
+        bar(last_w),
+        bar("WHEN".len())
+    );
+    if color {
+        println!("{}", sep.dimmed());
+    } else {
+        println!("{sep}");
+    }
+
+    // Rows
+    for r in rows {
+        // Status icon picks one of three states. We could expand this
+        // (✗ failed, ↻ would-rerun-via-onchange-hash) once `hooks list`
+        // grows enough fields to justify it; today's set is enough to
+        // make the table scannable.
+        let (icon, ran) = match (r.active, r.last_run_at.is_some()) {
+            (false, _) => (icons.inactive, false),
+            (true, true) => (icons.active, true),
+            (true, false) => (icons.info, false),
+        };
+        let last = r.last_run_at.as_deref().unwrap_or("(never)");
+        let when_str = r
+            .when
+            .as_deref()
+            .map(strip_braces)
+            .unwrap_or_else(|| "(always)".to_string());
+
+        let cell_status = format!("{icon:<status_w$}");
+        let cell_name = format!("{:<name_w$}", r.name);
+        let cell_phase = format!("{:<phase_w$}", r.phase);
+        let cell_when_run = format!("{:<when_run_w$}", r.when_run);
+        let cell_last = format!("{last:<last_w$}");
+
+        if !color {
+            println!(
+                "  {cell_status}  {cell_name}  {cell_phase}  {cell_when_run}  {cell_last}  {when_str}"
+            );
+            continue;
+        }
+
+        // Active+ran: green status, bold name. Active-but-never: yellow
+        // status (the "🆕 new — apply hasn't ticked it" signal). Inactive
+        // (when-false): dimmed across the row.
+        if !r.active {
+            println!(
+                "  {}  {}  {}  {}  {}  {}",
+                cell_status.dimmed(),
+                cell_name.dimmed(),
+                cell_phase.dimmed(),
+                cell_when_run.dimmed(),
+                cell_last.dimmed(),
+                when_str.dimmed()
+            );
+        } else if ran {
+            println!(
+                "  {}  {}  {}  {}  {}  {}",
+                cell_status.green(),
+                cell_name.cyan().bold(),
+                cell_phase.dimmed(),
+                cell_when_run.dimmed(),
+                cell_last.green(),
+                when_str.dimmed()
+            );
+        } else {
+            println!(
+                "  {}  {}  {}  {}  {}  {}",
+                cell_status.yellow(),
+                cell_name.cyan().bold(),
+                cell_phase.dimmed(),
+                cell_when_run.dimmed(),
+                cell_last.yellow(),
+                when_str.dimmed()
+            );
+        }
+    }
 }
 
 /// `yui hooks run [<name>] [--force]` — run a single hook (or every


### PR DESCRIPTION
Closes #32.

## Before

```
mac-init             phase=pre   when_run=once      last_run_at=(never)
                       when = yui.os == 'macos'
                       script = .yui/bin/mac-init.sh
                       command = bash {{ script_path }}
brew-bundle          phase=post  when_run=every     last_run_at=(never)
                       when = yui.os == 'macos'
                       script = .yui/bin/brew-bundle.sh
                       command = bash {{ script_path }}
…
```

Flat, monochrome, repetitive `phase=` / `when_run=` / `last_run_at=` labels, and you can't tell at a glance which hook would actually fire if you ran `yui apply` right now.

## After

```
  STATUS  NAME             PHASE  WHEN_RUN  LAST_RUN                                       WHEN
  ──────  ───────────────  ─────  ────────  ─────────────────────────────────────────────  ────
  ✗       mac-init         pre    once      (never)                                        yui.os == 'macos'
  ✗       brew-bundle      post   every     (never)                                        yui.os == 'macos'
  ✗       setup-wsl        post   onchange  (never)                                        yui.os == 'linux'
  ✗       setup-openclaw   post   onchange  (never)                                        yui.os == 'linux'
  ✗       enable-openclaw  post   onchange  (never)                                        yui.os == 'linux'
  ✓       windows-setup    post   onchange  2026-04-29T20:54:21.0952972+09:00[Asia/Tokyo]  yui.os == 'windows' and vars.production

  6 hooks · 1 active · 5 inactive · 1 ran · 5 never run
```

Status icon picks one of three states per hook:

| icon | meaning |
|---|---|
| ✗ | inactive — `when` predicate evaluates false on this host (dimmed row) |
| ℹ | active but never run yet (yellow status / `LAST_RUN`) |
| ✓ | active and has a recorded `last_run_at` (green status / `LAST_RUN`) |

Active rows get bold cyan names + dimmed phase / when_run / when columns to keep the eye on the actual identifiers.

Re-uses `Icons::for_mode` so `--icons MODE` (`unicode` / `nerd` / `ascii`) and `--no-color` honor the same flags as `yui list` / `yui status`. Footer matches the same `N hooks · M active · …` rhythm as the list table.

## Test plan

- [x] `cargo make check` clean
- [x] Manual: `yui hooks list` against the migrated dotfiles repo on Windows — output renders as above, the one ran-on-this-host hook (`windows-setup`) lights green
- [x] `--no-color` / piped output strips ANSI as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--icons` and `--no-color` flags to the `hooks list` command for customizing output display.

* **Improvements**
  * Redesigned `hooks list` output with a table format showing hook status (active/inactive), last run information, and execution counts for better visibility.
  * Removed verbose script and command details from output for a cleaner, more focused display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->