### PR TITLE
feat(doctor): grouped, severity-coloured output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,7 +106,14 @@ pub enum Command {
     },
 
     /// Diagnose environment (symlink capability, source detection, etc)
-    Doctor,
+    Doctor {
+        /// Override [ui] icons mode for this invocation
+        #[arg(long, value_name = "MODE")]
+        icons: Option<IconsMode>,
+        /// Disable color output (also respected via NO_COLOR env)
+        #[arg(long)]
+        no_color: bool,
+    },
 
     /// Garbage-collect old backups
     GcBackup {
@@ -162,7 +169,7 @@ impl Cli {
                 no_color,
             } => cmd::list(source, all, icons, no_color),
             Command::Absorb { target, dry_run } => cmd::absorb(source, target, dry_run),
-            Command::Doctor => cmd::doctor(source),
+            Command::Doctor { icons, no_color } => cmd::doctor(source, icons, no_color),
             Command::GcBackup { older_than } => cmd::gc_backup(source, older_than),
             Command::Hooks { action } => match action {
                 HookAction::List { icons, no_color } => cmd::hooks_list(source, icons, no_color),

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1047,17 +1047,28 @@ pub fn doctor(
     // gracefully. A missing source is the single most common cause of yui
     // misbehaving, so we want to surface it loudly and skip the dependent
     // probes rather than blowing up.
-    let yui = YuiVars::detect(Utf8Path::new("."));
     let resolved_source = resolve_source(source);
 
-    // Pull `[ui] icons` from the loaded config when we have one — otherwise
-    // fall back to the unicode default. CLI flags still override.
-    let cfg = match &resolved_source {
-        Ok(s) => config::load(s, &yui).ok(),
+    // `YuiVars::detect` reads `yui.source` from the resolved source path
+    // (so `{{ yui.source }}` renders correctly in config templates); when
+    // no source is detected we fall back to `.` so identity probes can
+    // still report os/arch/user/host.
+    let yui = match &resolved_source {
+        Ok(s) => YuiVars::detect(s),
+        Err(_) => YuiVars::detect(Utf8Path::new(".")),
+    };
+
+    // Cache the loaded config — both the icons-override fallback and the
+    // hooks-section probe need it. `cfg_res` keeps the original error
+    // around so the `repo / config` probe can render a meaningful
+    // message instead of just "not loaded".
+    let cfg_res = match &resolved_source {
+        Ok(s) => Some(config::load(s, &yui)),
         Err(_) => None,
     };
+    let cfg = cfg_res.as_ref().and_then(|r| r.as_ref().ok());
     let icons_mode = icons_override
-        .or_else(|| cfg.as_ref().map(|c| c.ui.icons))
+        .or_else(|| cfg.map(|c| c.ui.icons))
         .unwrap_or_default();
     let icons = Icons::for_mode(icons_mode);
     let color = !no_color && supports_color_stdout();
@@ -1076,18 +1087,18 @@ pub fn doctor(
         Ok(s) => {
             have_source = true;
             probes.push(Probe::ok("source", s.to_string()));
-            match config::load(s, &yui) {
-                Ok(cfg) => {
+            match cfg_res.as_ref().expect("cfg_res set when source is Ok") {
+                Ok(c) => {
                     probes.push(Probe::ok(
                         "config",
                         format!(
                             "{} mount{} · {} hook{} · {} render rule{}",
-                            cfg.mount.entry.len(),
-                            plural(cfg.mount.entry.len()),
-                            cfg.hook.len(),
-                            plural(cfg.hook.len()),
-                            cfg.render.rule.len(),
-                            plural(cfg.render.rule.len()),
+                            c.mount.entry.len(),
+                            plural(c.mount.entry.len()),
+                            c.hook.len(),
+                            plural(c.hook.len()),
+                            c.render.rule.len(),
+                            plural(c.render.rule.len()),
                         ),
                     ));
                 }
@@ -1126,32 +1137,30 @@ pub fn doctor(
 
     // ── hooks ─────────────────────────────────────────────────
     if have_source {
-        if let Ok(s) = &resolved_source {
-            if let Ok(cfg) = config::load(s, &yui) {
-                probes.push(Probe::group("hooks"));
-                if cfg.hook.is_empty() {
-                    probes.push(Probe::ok("hooks", "(none configured)"));
-                } else {
-                    let mut missing = 0usize;
-                    for h in &cfg.hook {
-                        if !s.join(&h.script).is_file() {
-                            missing += 1;
-                            probes.push(Probe::error(
-                                format!("hook[{}]", h.name),
-                                format!("script not found at {}", h.script),
-                            ));
-                        }
-                    }
-                    if missing == 0 {
-                        probes.push(Probe::ok(
-                            "scripts",
-                            format!(
-                                "{} hook{} configured, all scripts present",
-                                cfg.hook.len(),
-                                plural(cfg.hook.len())
-                            ),
+        if let (Ok(s), Some(c)) = (&resolved_source, cfg) {
+            probes.push(Probe::group("hooks"));
+            if c.hook.is_empty() {
+                probes.push(Probe::ok("hooks", "(none configured)"));
+            } else {
+                let mut missing = 0usize;
+                for h in &c.hook {
+                    if !s.join(&h.script).is_file() {
+                        missing += 1;
+                        probes.push(Probe::error(
+                            format!("hook[{}]", h.name),
+                            format!("script not found at {}", h.script),
                         ));
                     }
+                }
+                if missing == 0 {
+                    probes.push(Probe::ok(
+                        "scripts",
+                        format!(
+                            "{} hook{} configured, all scripts present",
+                            c.hook.len(),
+                            plural(c.hook.len())
+                        ),
+                    ));
                 }
             }
         }
@@ -1268,41 +1277,47 @@ impl Probe {
             }
             Self::Ok { label, detail } => {
                 let icon = icons.ok;
+                // Pad the raw label first; styling adds invisible ANSI
+                // bytes that `format!("{:<14}")` would count as visible
+                // width and silently break alignment between rows.
+                let padded = format!("{label:<14}");
                 if color {
                     println!(
-                        "    {}  {:<14}  {}",
+                        "    {}  {}  {}",
                         icon.green(),
-                        label.bold(),
+                        padded.bold(),
                         detail.dimmed()
                     );
                 } else {
-                    println!("    {icon}  {label:<14}  {detail}");
+                    println!("    {icon}  {padded}  {detail}");
                 }
             }
             Self::Warn { label, detail } => {
                 let icon = icons.warn;
+                let padded = format!("{label:<14}");
                 if color {
                     println!(
-                        "    {}  {:<14}  {}",
+                        "    {}  {}  {}",
                         icon.yellow(),
-                        label.bold().yellow(),
+                        padded.bold().yellow(),
                         detail
                     );
                 } else {
-                    println!("    {icon}  {label:<14}  {detail}");
+                    println!("    {icon}  {padded}  {detail}");
                 }
             }
             Self::Error { label, detail } => {
                 let icon = icons.error;
+                let padded = format!("{label:<14}");
                 if color {
                     println!(
-                        "    {}  {:<14}  {}",
+                        "    {}  {}  {}",
                         icon.red().bold(),
-                        label.bold().red(),
+                        padded.bold().red(),
                         detail.red()
                     );
                 } else {
-                    println!("    {icon}  {label:<14}  {detail}");
+                    println!("    {icon}  {padded}  {detail}");
                 }
             }
         }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1036,39 +1036,281 @@ fn find_source_for_target(
     Ok(None)
 }
 
-pub fn doctor(source: Option<Utf8PathBuf>) -> Result<()> {
+pub fn doctor(
+    source: Option<Utf8PathBuf>,
+    icons_override: Option<IconsMode>,
+    no_color: bool,
+) -> Result<()> {
+    use owo_colors::OwoColorize as _;
+
+    // Resolve source up-front so probes that depend on it can short-circuit
+    // gracefully. A missing source is the single most common cause of yui
+    // misbehaving, so we want to surface it loudly and skip the dependent
+    // probes rather than blowing up.
     let yui = YuiVars::detect(Utf8Path::new("."));
-    println!("yui doctor");
-    println!("==========");
-    println!("os:    {}", yui.os);
-    println!("arch:  {}", yui.arch);
-    println!("user:  {}", yui.user);
-    println!("host:  {}", yui.host);
-    match resolve_source(source) {
+    let resolved_source = resolve_source(source);
+
+    // Pull `[ui] icons` from the loaded config when we have one — otherwise
+    // fall back to the unicode default. CLI flags still override.
+    let cfg = match &resolved_source {
+        Ok(s) => config::load(s, &yui).ok(),
+        Err(_) => None,
+    };
+    let icons_mode = icons_override
+        .or_else(|| cfg.as_ref().map(|c| c.ui.icons))
+        .unwrap_or_default();
+    let icons = Icons::for_mode(icons_mode);
+    let color = !no_color && supports_color_stdout();
+
+    let mut probes: Vec<Probe> = Vec::new();
+
+    // ── identity ──────────────────────────────────────────────
+    probes.push(Probe::group("identity"));
+    probes.push(Probe::ok("os/arch", format!("{} / {}", yui.os, yui.arch)));
+    probes.push(Probe::ok("user@host", format!("{}@{}", yui.user, yui.host)));
+
+    // ── repository ────────────────────────────────────────────
+    probes.push(Probe::group("repo"));
+    let mut have_source = false;
+    match &resolved_source {
         Ok(s) => {
-            println!("source: {s}");
-            // Probe: try loading config
-            match config::load(&s, &yui) {
-                Ok(cfg) => println!(
-                    "config: ok ({} mount entries, {} render rules)",
-                    cfg.mount.entry.len(),
-                    cfg.render.rule.len()
-                ),
-                Err(e) => println!("config: ERROR — {e}"),
+            have_source = true;
+            probes.push(Probe::ok("source", s.to_string()));
+            match config::load(s, &yui) {
+                Ok(cfg) => {
+                    probes.push(Probe::ok(
+                        "config",
+                        format!(
+                            "{} mount{} · {} hook{} · {} render rule{}",
+                            cfg.mount.entry.len(),
+                            plural(cfg.mount.entry.len()),
+                            cfg.hook.len(),
+                            plural(cfg.hook.len()),
+                            cfg.render.rule.len(),
+                            plural(cfg.render.rule.len()),
+                        ),
+                    ));
+                }
+                Err(e) => probes.push(Probe::error("config", format!("{e}"))),
+            }
+            // git-clean check is informational here — the actual gate is
+            // `[absorb] require_clean_git` on apply; warn so the user
+            // knows auto-absorb will defer if they have uncommitted work.
+            match crate::git::is_clean(s) {
+                Ok(true) => probes.push(Probe::ok("git", "clean")),
+                Ok(false) => probes.push(Probe::warn(
+                    "git",
+                    "uncommitted changes — `[absorb] require_clean_git` will defer auto-absorb",
+                )),
+                Err(_) => probes.push(Probe::warn(
+                    "git",
+                    "no git repo (auto-absorb still works; commit history won't track drift)",
+                )),
             }
         }
-        Err(e) => println!("source: NOT FOUND — {e}"),
+        Err(e) => {
+            probes.push(Probe::error("source", format!("not found — {e}")));
+        }
+    }
+
+    // ── link / render mode ────────────────────────────────────
+    probes.push(Probe::group("links"));
+    if cfg!(windows) {
+        probes.push(Probe::ok(
+            "default mode",
+            "files=hardlink, dirs=junction (no admin needed)",
+        ));
+    } else {
+        probes.push(Probe::ok("default mode", "files=symlink, dirs=symlink"));
+    }
+
+    // ── hooks ─────────────────────────────────────────────────
+    if have_source {
+        if let Ok(s) = &resolved_source {
+            if let Ok(cfg) = config::load(s, &yui) {
+                probes.push(Probe::group("hooks"));
+                if cfg.hook.is_empty() {
+                    probes.push(Probe::ok("hooks", "(none configured)"));
+                } else {
+                    let mut missing = 0usize;
+                    for h in &cfg.hook {
+                        if !s.join(&h.script).is_file() {
+                            missing += 1;
+                            probes.push(Probe::error(
+                                format!("hook[{}]", h.name),
+                                format!("script not found at {}", h.script),
+                            ));
+                        }
+                    }
+                    if missing == 0 {
+                        probes.push(Probe::ok(
+                            "scripts",
+                            format!(
+                                "{} hook{} configured, all scripts present",
+                                cfg.hook.len(),
+                                plural(cfg.hook.len())
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    // ── chezmoi cleanup hint ─────────────────────────────────
+    if let Some(home) = paths::home_dir() {
+        let chezmoi_src = home.join(".local/share/chezmoi");
+        if chezmoi_src.is_dir() {
+            probes.push(Probe::group("chezmoi"));
+            probes.push(Probe::warn(
+                "legacy source",
+                format!(
+                    "{chezmoi_src} still exists — yui doesn't use it, safe to archive once your migration has settled"
+                ),
+            ));
+        }
+    }
+
+    // Render
+    println!();
+    if color {
+        println!("  {}", "yui doctor".bold().underline());
+    } else {
+        println!("  yui doctor");
     }
     println!();
-    println!("link mode (auto resolves to):");
-    if cfg!(windows) {
-        println!("  files: hardlink");
-        println!("  dirs:  junction");
+    for probe in &probes {
+        probe.print(&icons, color);
+    }
+
+    let errors = probes.iter().filter(|p| p.is_error()).count();
+    let warns = probes.iter().filter(|p| p.is_warn()).count();
+    let oks = probes.iter().filter(|p| p.is_ok()).count();
+    println!();
+    let summary = format!("{oks} ok · {warns} warn · {errors} error");
+    if color {
+        if errors > 0 {
+            println!("  {}", summary.red().bold());
+        } else if warns > 0 {
+            println!("  {}", summary.yellow());
+        } else {
+            println!("  {}", summary.green());
+        }
     } else {
-        println!("  files: symlink");
-        println!("  dirs:  symlink");
+        println!("  {summary}");
+    }
+
+    if errors > 0 {
+        anyhow::bail!("doctor: {errors} probe(s) failed");
     }
     Ok(())
+}
+
+#[derive(Debug)]
+enum Probe {
+    /// Section divider (just a heading, no severity).
+    Group(&'static str),
+    Ok {
+        label: String,
+        detail: String,
+    },
+    Warn {
+        label: String,
+        detail: String,
+    },
+    Error {
+        label: String,
+        detail: String,
+    },
+}
+
+impl Probe {
+    fn group(label: &'static str) -> Self {
+        Self::Group(label)
+    }
+    fn ok(label: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self::Ok {
+            label: label.into(),
+            detail: detail.into(),
+        }
+    }
+    fn warn(label: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self::Warn {
+            label: label.into(),
+            detail: detail.into(),
+        }
+    }
+    fn error(label: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self::Error {
+            label: label.into(),
+            detail: detail.into(),
+        }
+    }
+    fn is_ok(&self) -> bool {
+        matches!(self, Self::Ok { .. })
+    }
+    fn is_warn(&self) -> bool {
+        matches!(self, Self::Warn { .. })
+    }
+    fn is_error(&self) -> bool {
+        matches!(self, Self::Error { .. })
+    }
+    fn print(&self, icons: &Icons, color: bool) {
+        use owo_colors::OwoColorize as _;
+        match self {
+            Self::Group(name) => {
+                println!();
+                if color {
+                    println!("  {}", name.cyan().bold());
+                } else {
+                    println!("  {name}");
+                }
+            }
+            Self::Ok { label, detail } => {
+                let icon = icons.ok;
+                if color {
+                    println!(
+                        "    {}  {:<14}  {}",
+                        icon.green(),
+                        label.bold(),
+                        detail.dimmed()
+                    );
+                } else {
+                    println!("    {icon}  {label:<14}  {detail}");
+                }
+            }
+            Self::Warn { label, detail } => {
+                let icon = icons.warn;
+                if color {
+                    println!(
+                        "    {}  {:<14}  {}",
+                        icon.yellow(),
+                        label.bold().yellow(),
+                        detail
+                    );
+                } else {
+                    println!("    {icon}  {label:<14}  {detail}");
+                }
+            }
+            Self::Error { label, detail } => {
+                let icon = icons.error;
+                if color {
+                    println!(
+                        "    {}  {:<14}  {}",
+                        icon.red().bold(),
+                        label.bold().red(),
+                        detail.red()
+                    );
+                } else {
+                    println!("    {icon}  {label:<14}  {detail}");
+                }
+            }
+        }
+    }
+}
+
+fn plural(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
 }
 
 pub fn gc_backup(_source: Option<Utf8PathBuf>, _older_than: Option<String>) -> Result<()> {


### PR DESCRIPTION
Closes #33.

## Before

```
yui doctor
==========
os:    windows
arch:  x86_64
user:  yukimemi
host:  minipc
source: C:\Users\yukimemi\dotfiles
config: ok (4 mount entries, 0 render rules)

link mode (auto resolves to):
  files: hardlink
  dirs:  junction
```

Flat. Every line has the same weight; \"ok\" reads identically to \"ERROR — config not loaded\" until you parse the words. The whole point of \`doctor\` is to surface environmental problems before \`apply\` hits them, but you couldn't spot a failure at a glance.

## After

```
  yui doctor

  identity
    ✓  os/arch         windows / x86_64
    ✓  user@host       yukimemi@minipc

  repo
    ✓  source          C:\Users\yukimemi\dotfiles
    ✓  config          1 mount · 6 hooks · 0 render rules
    ✓  git             clean

  links
    ✓  default mode    files=hardlink, dirs=junction (no admin needed)

  hooks
    ✓  scripts         6 hooks configured, all scripts present

  chezmoi
    ⚠  legacy source   ~/.local/share/chezmoi still exists — yui doesn't use it, safe to archive once your migration has settled

  7 ok · 1 warn · 0 error
```

## What's new

- Probes are grouped by section: identity / repo / links / hooks / chezmoi.
- Severity icons + colours come from the existing `Icons` table — green ✓ / yellow ⚠ / red ✗ (unicode / nerd / ascii via `--icons MODE`).
- Summary line picks a colour to match the worst severity (green clean / yellow on any warn / red+bold on any error).
- Doctor now exits non-zero when any probe is an error — `yui doctor` becomes scriptable.
- Honors `--icons MODE` / `--no-color` like `list` / `status` / `hooks list`.

New probes:

- **git cleanliness** — warns when source repo has uncommitted changes, since `[absorb] require_clean_git` will defer auto-absorb in that state.
- **per-hook script existence** — errors when `.yui/bin/<name>` is missing, so a misconfigured `[[hook]]` doesn't surprise you on apply.
- **legacy chezmoi directory** — warns when `~/.local/share/chezmoi` still exists after migrating to yui, hinting at archive-and-forget cleanup.
- **repo summary** folds hooks + render rules alongside mount entries (was just mount + render).

## Test plan

- [x] `cargo make check` clean (113 tests pass, fmt + clippy quiet)
- [x] Manual: `yui doctor` against the migrated dotfiles repo — output renders as above
- [x] Manual: `yui doctor --no-color | cat` — plain text, columns aligned
- [x] Manual: temporarily renamed a hook script to verify the error probe surfaces and exits non-zero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--icons` option to customize icon display modes in the doctor command
  * Added `--no-color` flag to disable ANSI color formatting in output
  * Expanded doctor command diagnostics to include source validation, configuration details, git repository status, platform information, hook validation, and legacy directory checks
  * Doctor output now includes severity-level reporting with summary counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->