### PR TITLE
fix(template): hook script_* tokens pass through config-load unwrapped

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -803,4 +803,39 @@ dst = "/anywhere"
         let cfg = load(&r, &yui_vars(&r)).unwrap();
         assert_eq!(cfg.mount.entry[0].dst, "/anywhere");
     }
+
+    /// Hook-level Tera tokens (`{{ script_path }}` etc.) must survive
+    /// the config-load render verbatim — otherwise every author would
+    /// have to wrap them in `{% raw %}{% endraw %}`. The placeholders
+    /// are seeded as self-references in `template_context` so Tera
+    /// just emits them back; the hook executor's
+    /// `build_hook_context` overrides them with real paths at run
+    /// time.
+    #[test]
+    fn hook_script_vars_survive_config_load_render_verbatim() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            &tmp,
+            "config.toml",
+            r#"
+[[mount.entry]]
+src = "home"
+dst = "/home/u"
+
+[[hook]]
+name = "deno-build"
+script = ".yui/bin/build.ts"
+command = "deno"
+args = ["run", "-A", "{{ script_path }}"]
+when_run = "onchange"
+"#,
+        );
+        let r = root(&tmp);
+        let cfg = load(&r, &yui_vars(&r)).unwrap();
+        assert_eq!(cfg.hook.len(), 1);
+        // The args literal made it through config-load untouched —
+        // the third arg is `{{ script_path }}`, ready for the hook
+        // executor to render with the real path.
+        assert_eq!(cfg.hook[0].args, vec!["run", "-A", "{{ script_path }}"]);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -314,7 +314,10 @@ pub fn load(source: &Utf8Path, yui: &YuiVars) -> Result<Config> {
         // the iteration budget — that catches genuine cycles).
         resolve_vars_refs(&mut vars_acc, yui, &mut engine)?;
 
-        let ctx = template::template_context(yui, &vars_acc);
+        // Use the config-flavoured context so hook-level placeholders
+        // (`{{ script_path }}` etc.) survive this pass intact. Dotfile
+        // rendering keeps the bare `template_context`.
+        let ctx = template::config_render_context(yui, &vars_acc);
         let rendered = engine.render(&raw, &ctx)?;
         let parsed: toml::Table =
             toml::from_str(&rendered).map_err(|e| Error::Config(format!("parse {file}: {e}")))?;
@@ -414,7 +417,11 @@ fn resolve_vars_refs(
     engine: &mut template::Engine,
 ) -> Result<()> {
     for _ in 0..MAX_VARS_RESOLVE_ITERATIONS {
-        let ctx = template::template_context(yui, vars);
+        // `config_render_context` for parity with the main config
+        // render pass — a vars value that happens to include
+        // `{{ script_path }}` should pass through here for the same
+        // reason it does at the file level.
+        let ctx = template::config_render_context(yui, vars);
         let mut changed = false;
         render_strings_in_table(vars, engine, &ctx, &mut changed)?;
         if !changed {

--- a/src/template.rs
+++ b/src/template.rs
@@ -79,17 +79,25 @@ pub fn template_context<V: Serialize>(yui: &YuiVars, vars: &V) -> Context {
     let mut ctx = Context::new();
     ctx.insert("yui", yui);
     ctx.insert("vars", vars);
-    // Hook-level placeholders that the *real* hook context fills in
-    // at execute time. Seeding them as self-referencing strings
-    // here means a `[[hook]] args = ["{{ script_path }}"]` survives
-    // the config-load Tera pass intact instead of erroring on
-    // "Variable `script_path` not found in context" — Tera looks
-    // them up, gets the literal `{{ script_path }}` back, and
-    // emits it verbatim. The hook executor then re-renders with
-    // the real path via `build_hook_context`, which `Context::insert`
-    // overrides cleanly. Without this, every reference would have
-    // to be wrapped in `{% raw %}{% endraw %}`, which is ugly UX
-    // for the very tokens hook authors reach for first.
+    ctx
+}
+
+/// `template_context` plus self-referencing placeholders for the
+/// hook script vars (`script_path` / `script_dir` / `script_name` /
+/// `script_stem` / `script_ext`). Use this *only* for the
+/// config-load Tera pass, where those tokens haven't been bound
+/// yet but should survive verbatim so the hook executor can
+/// resolve them at run time.
+///
+/// Why a separate builder rather than seeding the placeholders in
+/// `template_context` itself: dotfile (`*.tera`) rendering uses
+/// `template_context` too, and a typo'd `{{ script_path }}` in a
+/// dotfile should surface as "Variable not found in context"
+/// rather than silently rendering to the literal `{{ script_path }}`.
+/// Keeping the placeholders carve-out config-only preserves that
+/// loud failure for dotfiles.
+pub fn config_render_context<V: Serialize>(yui: &YuiVars, vars: &V) -> Context {
+    let mut ctx = template_context(yui, vars);
     for placeholder in [
         "script_path",
         "script_dir",
@@ -178,5 +186,34 @@ mod tests {
         assert_eq!(out, "hi u");
         // ensure the camino import isn't unused
         let _: &Utf8Path = Utf8Path::new(".");
+    }
+
+    /// Bare `template_context` (used by dotfile / status / list /
+    /// apply rendering) deliberately does NOT seed the hook
+    /// `script_*` placeholders — a typo'd `{{ script_path }}` in a
+    /// `*.tera` dotfile must error loudly so the user catches the
+    /// mistake instead of silently emitting a literal `{{ script_path }}`
+    /// into the rendered output.
+    #[test]
+    fn dotfile_render_errors_on_undefined_script_path() {
+        let mut e = Engine::new();
+        let user_vars = toml::Table::new();
+        let ctx = template_context(&vars(), &user_vars);
+        let err = e
+            .render("hello {{ script_path }}", &ctx)
+            .expect_err("dotfile render must reject undefined script_path");
+        assert!(format!("{err}").contains("script_path"), "{err}");
+    }
+
+    /// `config_render_context`, on the other hand, is used by the
+    /// config-load pass and seeds `script_*` as self-references so
+    /// `[[hook]] args = ["{{ script_path }}"]` survives Tera intact.
+    #[test]
+    fn config_render_context_preserves_script_path_placeholder() {
+        let mut e = Engine::new();
+        let user_vars = toml::Table::new();
+        let ctx = config_render_context(&vars(), &user_vars);
+        let out = e.render("hello {{ script_path }}", &ctx).unwrap();
+        assert_eq!(out, "hello {{ script_path }}");
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -79,6 +79,26 @@ pub fn template_context<V: Serialize>(yui: &YuiVars, vars: &V) -> Context {
     let mut ctx = Context::new();
     ctx.insert("yui", yui);
     ctx.insert("vars", vars);
+    // Hook-level placeholders that the *real* hook context fills in
+    // at execute time. Seeding them as self-referencing strings
+    // here means a `[[hook]] args = ["{{ script_path }}"]` survives
+    // the config-load Tera pass intact instead of erroring on
+    // "Variable `script_path` not found in context" — Tera looks
+    // them up, gets the literal `{{ script_path }}` back, and
+    // emits it verbatim. The hook executor then re-renders with
+    // the real path via `build_hook_context`, which `Context::insert`
+    // overrides cleanly. Without this, every reference would have
+    // to be wrapped in `{% raw %}{% endraw %}`, which is ugly UX
+    // for the very tokens hook authors reach for first.
+    for placeholder in [
+        "script_path",
+        "script_dir",
+        "script_name",
+        "script_stem",
+        "script_ext",
+    ] {
+        ctx.insert(placeholder, &format!("{{{{ {placeholder} }}}}"));
+    }
     ctx
 }
 


### PR DESCRIPTION
## Why

\`config.toml\` is Tera-rendered as a whole at load time, but the hook-level placeholders (\`{{ script_path }}\`, \`{{ script_dir }}\`, \`{{ script_name }}\`, \`{{ script_stem }}\`, \`{{ script_ext }}\`) only become defined during hook **execution**. Pre-fix, that meant every \`[[hook]] args = ["{{ script_path }}"]\` had to be wrapped in \`{% raw %}{% endraw %}\` to survive the config-load pass:

\`\`\`toml
# What docs said you could write
args = ["-NoProfile", "-File", "{{ script_path }}"]

# What actually worked
args = ["-NoProfile", "-File", "{% raw %}{{ script_path }}{% endraw %}"]
\`\`\`

Bad UX for the very tokens the documentation tells authors to reach for first, and the README's own example was technically broken.

## Fix

Seed \`template_context\` with each placeholder mapped to its own \`{{ name }}\` literal:

\`\`\`rust
ctx.insert("script_path", "{{ script_path }}");
// …script_dir / script_name / script_stem / script_ext likewise
\`\`\`

Tera's lookup at config-load returns the self-reference, the rendered string survives intact through the config-parse-then-store path, and \`build_hook_context\` overrides the same keys with real values at hook execute time so the second render resolves them properly. \`Context::insert\` overrides cleanly, so no special API.

## Trade-off

A Tera filter applied on top of \`{{ script_path }}\` (e.g. \`{{ script_path | upper }}\`) would now apply to the literal \`"{{ script_path }}"\` string at config-load and store gibberish in the parsed value. That's a deliberately rare case — users who need filter-on-script-var can still wrap in raw blocks. The common case (just emit the path) Just Works.

## Test plan

- [x] \`cargo make check\` clean (119 tests, 1 new)
- [x] New \`hook_script_vars_survive_config_load_render_verbatim\` asserts the round-trip: a config with \`args = ["run", "-A", "{{ script_path }}"]\` loads + stores the third arg as the literal \`"{{ script_path }}"\`, ready for the hook executor.
- [x] Existing hook tests (which use the same \`build_hook_context\` override path) continue to pass.

## Follow-up (not in this PR)

The migrated dotfiles repo at \`yukimemi/dotfiles\` still has \`args = ["-NoProfile", "-File", "{% raw %}{{ script_path }}{% endraw %}"]\` for the windows-setup hook. Once this lands and 0.7.6 ships, the raw-block wrapping can be dropped over there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of template tokens in hook configurations to preserve placeholder strings like `{{ script_path }}` without requiring special wrapping syntax.

* **New Features**
  * Added support for script-related context variables (`script_path`, `script_dir`, `script_name`, `script_stem`, `script_ext`) in templates.

* **Tests**
  * Added test case to verify proper loading and rendering of hook configurations containing template tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->