### PR TITLE
feat(yuiignore): walk nested .yuiignore files like .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,11 @@ build/
 !build/result.toml
 ```
 
-Currently only the repo-root `.yuiignore` is honored — nested
-`.yuiignore` files inside subdirectories are not yet walked, so put
-all your rules at the top.
+Nested `.yuiignore` files inside subdirectories are honored too, with
+the same rule-scoping semantics as `.gitignore`: deeper layers override
+shallower ones, `!negation` re-includes paths, and rules apply only to
+the subtree below the file. Put repo-wide rules at `$DOTFILES/.yuiignore`
+and per-tree rules where they belong.
 
 ## Hooks — run scripts around `apply`
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -196,9 +196,6 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
     let source = resolve_source(source)?;
     let yui = YuiVars::detect(&source);
     let config = config::load(&source, &yui)?;
-    // Load `.yuiignore` once and thread through render + walk so the
-    // matcher isn't re-built per-flow.
-    let yuiignore = paths::load_yuiignore(&source)?;
 
     let mut engine = template::Engine::new();
     let tera_ctx = template::template_context(&yui, &config.vars);
@@ -216,7 +213,7 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
     )?;
 
     // 1. Render templates first so the link walk picks up rendered files.
-    let render_report = render::render_all(&source, &config, &yui, &yuiignore, dry_run)?;
+    let render_report = render::render_all(&source, &config, &yui, dry_run)?;
     log_render_report(&render_report);
     if render_report.has_drift() {
         anyhow::bail!(
@@ -237,7 +234,6 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
     let ctx = ApplyCtx {
         config: &config,
         source: &source,
-        yuiignore: &yuiignore,
         file_mode: resolve_file_mode(config.link.file_mode),
         dir_mode: resolve_dir_mode(config.link.dir_mode),
         backup_root: &backup_root,
@@ -250,10 +246,20 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
         info!("dry-run: nothing will be written");
     }
 
-    for m in &mounts {
-        info!("mount: {} → {}", m.src, m.dst);
-        process_mount(&source, m, &ctx, &mut engine, &tera_ctx)?;
-    }
+    // Nested `.yuiignore` stack — push on dir entry, pop on exit.
+    // Seed with the source-root layer so root-level rules apply from
+    // the start without `walk_and_link` having to special-case it.
+    let mut yuiignore = paths::YuiIgnoreStack::new();
+    yuiignore.push_dir(&source)?;
+    let walk_result = (|| -> Result<()> {
+        for m in &mounts {
+            info!("mount: {} → {}", m.src, m.dst);
+            process_mount(&source, m, &ctx, &mut engine, &tera_ctx, &mut yuiignore)?;
+        }
+        Ok(())
+    })();
+    yuiignore.pop_dir(&source);
+    walk_result?;
 
     // 3. Post-apply hooks (after every link is in place).
     hook::run_phase(
@@ -287,14 +293,15 @@ fn log_render_report(r: &RenderReport) {
 }
 
 /// Bundle of immutable settings threaded through the apply walk.
+///
+/// `.yuiignore` rules are not in here — they need a `&mut` stack
+/// (push on dir entry, pop on dir exit) which doesn't compose with
+/// `ApplyCtx` being shared by `&`. The stack is plumbed through
+/// `walk_and_link` as its own parameter instead.
 struct ApplyCtx<'a> {
     config: &'a Config,
-    /// Source repo root — needed for git-clean checks during absorb and
-    /// for resolving paths inside `is_ignored` against `.yuiignore`.
+    /// Source repo root — needed for git-clean checks during absorb.
     source: &'a Utf8Path,
-    /// Patterns from `$source/.yuiignore`. Empty matcher when the file
-    /// is absent.
-    yuiignore: &'a ignore::gitignore::Gitignore,
     file_mode: EffectiveFileMode,
     dir_mode: EffectiveDirMode,
     backup_root: &'a Utf8Path,
@@ -355,7 +362,6 @@ struct ListItem {
 fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Result<Vec<ListItem>> {
     let mut engine = template::Engine::new();
     let tera_ctx = template::template_context(yui, &config.vars);
-    let yuiignore = paths::load_yuiignore(source)?;
     let mut items = Vec::new();
 
     // 1. config.toml [[mount.entry]] entries
@@ -398,10 +404,9 @@ fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Resu
             Ok(p) => p,
             Err(_) => continue,
         };
-        // .yuiignore filter — markers inside ignored subtrees are skipped.
-        if paths::is_ignored(&yuiignore, source, &dir_utf8, true) {
-            continue;
-        }
+        // .yuiignore filtering happens in `source_walker` via
+        // `add_custom_ignore_filename` — markers under ignored
+        // subtrees never reach here.
         let spec = match marker::read_spec(&dir_utf8, marker_filename)? {
             Some(s) => s,
             None => continue,
@@ -596,9 +601,8 @@ pub fn render(source: Option<Utf8PathBuf>, check: bool, dry_run: bool) -> Result
     let source = resolve_source(source)?;
     let yui = YuiVars::detect(&source);
     let config = config::load(&source, &yui)?;
-    let yuiignore = paths::load_yuiignore(&source)?;
     // --check is a stricter dry-run: never writes, exits non-zero on drift.
-    let report = render::render_all(&source, &config, &yui, &yuiignore, dry_run || check)?;
+    let report = render::render_all(&source, &config, &yui, dry_run || check)?;
     log_render_report(&report);
     if check && report.has_drift() {
         anyhow::bail!("render drift detected ({} file(s))", report.diverged.len());
@@ -659,14 +663,10 @@ pub fn status(
     let color = !no_color && supports_color_stdout();
 
     let mut report: Vec<StatusItem> = Vec::new();
-    // Load `.yuiignore` once and reuse for both render-drift detection
-    // and the link-drift walk below.
-    let yuiignore = paths::load_yuiignore(&source)?;
 
     // 1. Template drift — render in dry-run mode and surface anything
     //    whose rendered counterpart on disk no longer matches.
-    let render_report =
-        render::render_all(&source, &config, &yui, &yuiignore, /* dry_run */ true)?;
+    let render_report = render::render_all(&source, &config, &yui, /* dry_run */ true)?;
     for rendered in &render_report.diverged {
         // `diverged` holds the rendered path; the template lives at
         // `<rendered>.tera`. Show the .tera as src so it's clear which
@@ -680,24 +680,33 @@ pub fn status(
     }
 
     // 2. Link drift — classify each src→dst pair under every mount.
-    for m in &mounts {
-        let src_root = source.join(&m.src);
-        if !src_root.is_dir() {
-            warn!("mount src missing: {src_root}");
-            continue;
+    // Single nested-`.yuiignore` stack threaded across all mounts.
+    // Seed the source-root layer so root rules apply from the start.
+    let mut yuiignore = paths::YuiIgnoreStack::new();
+    yuiignore.push_dir(&source)?;
+    let walk_result = (|| -> Result<()> {
+        for m in &mounts {
+            let src_root = source.join(&m.src);
+            if !src_root.is_dir() {
+                warn!("mount src missing: {src_root}");
+                continue;
+            }
+            classify_walk(
+                &src_root,
+                &m.dst,
+                &config,
+                m.strategy,
+                &mut engine,
+                &tera_ctx,
+                &source,
+                &mut yuiignore,
+                &mut report,
+            )?;
         }
-        classify_walk(
-            &src_root,
-            &m.dst,
-            &config,
-            m.strategy,
-            &mut engine,
-            &tera_ctx,
-            &source,
-            &yuiignore,
-            &mut report,
-        )?;
-    }
+        Ok(())
+    })();
+    yuiignore.pop_dir(&source);
+    walk_result?;
 
     report.sort_by(|a, b| a.src.cmp(&b.src).then_with(|| a.dst.cmp(&b.dst)));
 
@@ -749,7 +758,7 @@ fn classify_walk(
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
     source_root: &Utf8Path,
-    yuiignore: &ignore::gitignore::Gitignore,
+    yuiignore: &mut paths::YuiIgnoreStack,
     report: &mut Vec<StatusItem>,
 ) -> Result<()> {
     classify_walk_inner(
@@ -775,14 +784,45 @@ fn classify_walk_inner(
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
     source_root: &Utf8Path,
-    yuiignore: &ignore::gitignore::Gitignore,
+    yuiignore: &mut paths::YuiIgnoreStack,
     report: &mut Vec<StatusItem>,
     parent_covered: bool,
 ) -> Result<()> {
-    if paths::is_ignored(yuiignore, source_root, src_dir, /* is_dir */ true) {
+    if yuiignore.is_ignored(src_dir, /* is_dir */ true) {
         return Ok(());
     }
+    // Layer this dir's .yuiignore (if any) on top before we recurse;
+    // pop on exit so siblings don't see our subtree's rules.
+    yuiignore.push_dir(src_dir)?;
+    let result = classify_walk_inner_body(
+        src_dir,
+        dst_dir,
+        config,
+        strategy,
+        engine,
+        tera_ctx,
+        source_root,
+        yuiignore,
+        report,
+        parent_covered,
+    );
+    yuiignore.pop_dir(src_dir);
+    result
+}
 
+#[allow(clippy::too_many_arguments)]
+fn classify_walk_inner_body(
+    src_dir: &Utf8Path,
+    dst_dir: &Utf8Path,
+    config: &Config,
+    strategy: MountStrategy,
+    engine: &mut template::Engine,
+    tera_ctx: &TeraContext,
+    source_root: &Utf8Path,
+    yuiignore: &mut paths::YuiIgnoreStack,
+    report: &mut Vec<StatusItem>,
+    parent_covered: bool,
+) -> Result<()> {
     let marker_filename = &config.mount.marker_filename;
     let mut covered = parent_covered;
 
@@ -851,7 +891,7 @@ fn classify_walk_inner(
         let src_path = src_dir.join(name);
         let dst_path = dst_dir.join(name);
         let ft = entry.file_type()?;
-        if paths::is_ignored(yuiignore, source_root, &src_path, ft.is_dir()) {
+        if yuiignore.is_ignored(&src_path, ft.is_dir()) {
             continue;
         }
         if ft.is_dir() {
@@ -1033,18 +1073,9 @@ pub fn absorb(source: Option<Utf8PathBuf>, target: Utf8PathBuf, dry_run: bool) -
 
     let mut engine = template::Engine::new();
     let tera_ctx = template::template_context(&yui, &config.vars);
-    // Single load — the matcher is shared with both find_source_for_target
-    // and the eventual ApplyCtx below.
-    let yuiignore = paths::load_yuiignore(&source)?;
 
-    let src_path = match find_source_for_target(
-        &source,
-        &config,
-        &target,
-        &mut engine,
-        &tera_ctx,
-        &yuiignore,
-    )? {
+    let src_path = match find_source_for_target(&source, &config, &target, &mut engine, &tera_ctx)?
+    {
         Some(s) => s,
         None => anyhow::bail!(
             "no mount entry / .yuilink override claims target {target}; \
@@ -1063,7 +1094,6 @@ pub fn absorb(source: Option<Utf8PathBuf>, target: Utf8PathBuf, dry_run: bool) -
     let ctx = ApplyCtx {
         config: &config,
         source: &source,
-        yuiignore: &yuiignore,
         file_mode: resolve_file_mode(config.link.file_mode),
         dir_mode: resolve_dir_mode(config.link.dir_mode),
         backup_root: &backup_root,
@@ -1084,7 +1114,6 @@ fn find_source_for_target(
     target: &Utf8Path,
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
-    yuiignore: &ignore::gitignore::Gitignore,
 ) -> Result<Option<Utf8PathBuf>> {
     // 1. Mount entries — render dst, see if target is inside it.
     for entry in &config.mount.entry {
@@ -1099,8 +1128,9 @@ fn find_source_for_target(
             let candidate = source.join(&entry.src).join(rel);
             // Honor `.yuiignore` even on manual absorb — if you've
             // ignored a path, you've explicitly opted out of yui's
-            // managing it.
-            if paths::is_ignored(yuiignore, source, &candidate, candidate.is_dir()) {
+            // managing it. One-shot stack walk along the candidate's
+            // parents picks up nested `.yuiignore` files too.
+            if paths::is_ignored_at(source, &candidate, candidate.is_dir())? {
                 continue;
             }
             return Ok(Some(candidate));
@@ -1109,7 +1139,9 @@ fn find_source_for_target(
 
     // 2. `.yuilink` Override markers — walk source, parse, render each
     //    `[[link]] dst`, see if target is the rendered dst (or nested
-    //    inside a junction'd dir). Skips `.yui/` (backup mirrors etc.).
+    //    inside a junction'd dir). `source_walker` skips `.yui/` and
+    //    honours nested `.yuiignore` files automatically, so markers
+    //    inside ignored subtrees never reach this loop.
     let walker = paths::source_walker(source).build();
     let marker_filename = &config.mount.marker_filename;
     for ent in walker {
@@ -1131,9 +1163,6 @@ fn find_source_for_target(
             Ok(p) => p,
             Err(_) => continue,
         };
-        if paths::is_ignored(yuiignore, source, &dir_utf8, true) {
-            continue;
-        }
         let spec = match marker::read_spec(&dir_utf8, marker_filename)? {
             Some(s) => s,
             None => continue,
@@ -1747,19 +1776,23 @@ pub fn hooks_run(source: Option<Utf8PathBuf>, name: Option<String>, force: bool)
 // internals
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 fn process_mount(
     source: &Utf8Path,
     m: &ResolvedMount,
     ctx: &ApplyCtx<'_>,
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
+    yuiignore: &mut paths::YuiIgnoreStack,
 ) -> Result<()> {
     let src_root = source.join(&m.src);
     if !src_root.is_dir() {
         warn!("mount src missing: {src_root}");
         return Ok(());
     }
-    walk_and_link(&src_root, &m.dst, ctx, m.strategy, engine, tera_ctx, false)
+    walk_and_link(
+        &src_root, &m.dst, ctx, m.strategy, engine, tera_ctx, yuiignore, false,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1770,14 +1803,42 @@ fn walk_and_link(
     strategy: MountStrategy,
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
+    yuiignore: &mut paths::YuiIgnoreStack,
     parent_covered: bool,
 ) -> Result<()> {
     // `.yuiignore` short-circuit — entire subtrees that match are skipped
     // without even reading their marker / iterating their children.
-    if paths::is_ignored(ctx.yuiignore, ctx.source, src_dir, /* is_dir */ true) {
+    if yuiignore.is_ignored(src_dir, /* is_dir */ true) {
         return Ok(());
     }
+    // Layer this dir's `.yuiignore` (if any) on top, run the body, pop
+    // before returning so siblings don't see our subtree's rules.
+    yuiignore.push_dir(src_dir)?;
+    let result = walk_and_link_body(
+        src_dir,
+        dst_dir,
+        ctx,
+        strategy,
+        engine,
+        tera_ctx,
+        yuiignore,
+        parent_covered,
+    );
+    yuiignore.pop_dir(src_dir);
+    result
+}
 
+#[allow(clippy::too_many_arguments)]
+fn walk_and_link_body(
+    src_dir: &Utf8Path,
+    dst_dir: &Utf8Path,
+    ctx: &ApplyCtx<'_>,
+    strategy: MountStrategy,
+    engine: &mut template::Engine,
+    tera_ctx: &TeraContext,
+    yuiignore: &mut paths::YuiIgnoreStack,
+    parent_covered: bool,
+) -> Result<()> {
     let marker_filename = &ctx.config.mount.marker_filename;
     let mut covered = parent_covered;
 
@@ -1853,13 +1914,13 @@ fn walk_and_link(
         let dst_path = dst_dir.join(name);
         let ft = entry.file_type()?;
 
-        if paths::is_ignored(ctx.yuiignore, ctx.source, &src_path, ft.is_dir()) {
+        if yuiignore.is_ignored(&src_path, ft.is_dir()) {
             continue;
         }
 
         if ft.is_dir() {
             walk_and_link(
-                &src_path, &dst_path, ctx, strategy, engine, tera_ctx, covered,
+                &src_path, &dst_path, ctx, strategy, engine, tera_ctx, yuiignore, covered,
             )?;
         } else if ft.is_file() {
             // If an ancestor (or this dir itself) created a dir-level
@@ -3612,6 +3673,75 @@ dst = "{}"
         apply(Some(source.clone()), false).unwrap();
         assert!(target.join("keep.cache").exists());
         assert!(!target.join("drop.cache").exists());
+    }
+
+    /// Issue #47: a `.yuiignore` placed in a nested subdirectory must
+    /// scope its rules to that subtree, just like `.gitignore`.
+    /// `home/inner/.yuiignore` excluding `secret*` should drop
+    /// `home/inner/secret.txt` but leave `home/secret.txt` alone.
+    #[test]
+    fn nested_yuiignore_only_affects_its_subtree() {
+        let tmp = TempDir::new().unwrap();
+        let (source, target) = setup_minimal_dotfiles(&tmp);
+        std::fs::create_dir_all(source.join("home/inner")).unwrap();
+        std::fs::write(source.join("home/secret.txt"), "outer keep").unwrap();
+        std::fs::write(source.join("home/inner/secret.txt"), "inner drop").unwrap();
+        std::fs::write(source.join("home/inner/keep.txt"), "inner keep").unwrap();
+        // Nested ignore — affects only `home/inner/`.
+        std::fs::write(source.join("home/inner/.yuiignore"), "secret*\n").unwrap();
+        apply(Some(source.clone()), false).unwrap();
+        assert!(
+            target.join("secret.txt").exists(),
+            "outer secret.txt is outside the nested .yuiignore scope"
+        );
+        assert!(target.join("inner/keep.txt").exists());
+        assert!(
+            !target.join("inner/secret.txt").exists(),
+            "inner secret.txt should be excluded by the nested .yuiignore"
+        );
+    }
+
+    /// A nested `.yuiignore` can re-include (via `!negation`) a file
+    /// the root ignore had excluded — gitignore's last-rule-wins
+    /// semantics, scoped per-subtree.
+    #[test]
+    fn nested_yuiignore_negation_overrides_root_rule() {
+        let tmp = TempDir::new().unwrap();
+        let (source, target) = setup_minimal_dotfiles(&tmp);
+        std::fs::create_dir_all(source.join("home/keepers")).unwrap();
+        std::fs::write(source.join("home/drop.lock"), "outer drop").unwrap();
+        std::fs::write(source.join("home/keepers/wanted.lock"), "inner keep").unwrap();
+        std::fs::write(source.join(".yuiignore"), "*.lock\n").unwrap();
+        // Re-include `*.lock` only inside keepers/.
+        std::fs::write(source.join("home/keepers/.yuiignore"), "!*.lock\n").unwrap();
+        apply(Some(source.clone()), false).unwrap();
+        assert!(
+            !target.join("drop.lock").exists(),
+            "root rule still drops outer .lock file"
+        );
+        assert!(
+            target.join("keepers/wanted.lock").exists(),
+            "nested negation re-includes .lock under keepers/"
+        );
+    }
+
+    /// `yui status` walk uses the same nested-`.yuiignore` semantics:
+    /// a nested ignore scoped to one subtree must NOT make a sibling
+    /// subtree's identical filename look ignored.
+    #[test]
+    fn nested_yuiignore_status_walk_scoped() {
+        let tmp = TempDir::new().unwrap();
+        let (source, _target) = setup_minimal_dotfiles(&tmp);
+        std::fs::create_dir_all(source.join("home/a")).unwrap();
+        std::fs::create_dir_all(source.join("home/b")).unwrap();
+        std::fs::write(source.join("home/a/foo.txt"), "a-foo").unwrap();
+        std::fs::write(source.join("home/b/foo.txt"), "b-foo").unwrap();
+        // Only `home/a/` ignores foo.txt.
+        std::fs::write(source.join("home/a/.yuiignore"), "foo.txt\n").unwrap();
+        apply(Some(source.clone()), false).unwrap();
+        // status should not error; walk completes despite the nested rule.
+        let res = status(Some(source), None, /* no_color */ true);
+        assert!(res.is_ok() || matches!(&res, Err(e) if format!("{e}").contains("diverged")));
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -52,6 +52,14 @@ pub fn home_dir() -> Option<Utf8PathBuf> {
 /// Patterns use full gitignore syntax: glob (`*`, `**`), negation
 /// (`!`), trailing-slash dir-only matching, comments (`#`). Paths
 /// outside `source` short-circuit to `false`.
+///
+/// If an ancestor directory is itself ignored, we return `true`
+/// immediately rather than descending into its `.yuiignore` — the
+/// recursive walkers (`walk_and_link`, `classify_walk_inner`) skip
+/// ignored subtrees entirely, so they never see the inner rules.
+/// Honouring inner whitelists here would let manual `absorb` pick a
+/// path that apply / status would never have linked. (Caught in PR
+/// #50 review.)
 pub fn is_ignored_at(source: &Utf8Path, path: &Utf8Path, is_dir: bool) -> crate::Result<bool> {
     let Ok(rel) = path.strip_prefix(source) else {
         return Ok(false);
@@ -66,6 +74,9 @@ pub fn is_ignored_at(source: &Utf8Path, path: &Utf8Path, is_dir: bool) -> crate:
         cur.push(c);
         if cur == path {
             break;
+        }
+        if stack.is_ignored(&cur, /* is_dir */ true) {
+            return Ok(true);
         }
         stack.push_dir(&cur)?;
     }
@@ -336,6 +347,25 @@ mod tests {
         stack.pop_dir(&no_ignore); // no-op
         // Root layer is still in place.
         assert!(stack.is_ignored(&root.join("a.lock"), false));
+    }
+
+    /// A nested `!negation` cannot un-ignore a path whose ancestor
+    /// directory is itself excluded — the recursive walkers never
+    /// descend that subtree, so `is_ignored_at` must agree. (PR #50
+    /// review caught this gap.)
+    #[test]
+    fn is_ignored_at_short_circuits_on_ignored_ancestor() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        let keepers = root.join("home").join("keepers");
+        std::fs::create_dir_all(&keepers).unwrap();
+        // Root excludes the entire `home/keepers/` dir.
+        std::fs::write(root.join(".yuiignore"), "home/keepers/\n").unwrap();
+        // Inner negation tries to re-include a single file.
+        std::fs::write(keepers.join(".yuiignore"), "!wanted.lock\n").unwrap();
+        // The walkers never descend into keepers/, so manual absorb
+        // must agree the file is ignored.
+        assert!(is_ignored_at(&root, &keepers.join("wanted.lock"), false).unwrap());
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -40,56 +40,36 @@ pub fn home_dir() -> Option<Utf8PathBuf> {
         .map(Utf8PathBuf::from)
 }
 
-/// Load `$source/.yuiignore` as a gitignore-style matcher.
+/// One-shot `.yuiignore` test for a single path under `source`.
 ///
-/// Returns an empty matcher when the file is absent (so `is_ignored`
-/// becomes a no-op). Patterns use full gitignore syntax: glob (`*`,
-/// `**`), negation (`!`), trailing-slash dir-only matching, comments
-/// (`#`).
+/// Builds a fresh `YuiIgnoreStack`, pushes every directory between
+/// `source` and `path.parent()` (so a deeply-nested `.yuiignore`
+/// participates), then asks the stack. Use this when you have a
+/// single candidate path to check (e.g. manual `absorb`'s
+/// mount-derived candidate); for recursive walks, push/pop on the
+/// hot path with a single long-lived `YuiIgnoreStack` instead.
 ///
-/// Currently only the repo-root `.yuiignore` is honored — nested
-/// `.yuiignore` files inside subdirectories are not yet walked. (The
-/// 95% case is "exclude `**/lock.json` once at the top".) If you need
-/// per-subtree rules, file an issue with the use case.
-pub fn load_yuiignore(source: &Utf8Path) -> crate::Result<ignore::gitignore::Gitignore> {
-    let path = source.join(".yuiignore");
-    if !path.is_file() {
-        return Ok(ignore::gitignore::Gitignore::empty());
-    }
-    let mut builder = ignore::gitignore::GitignoreBuilder::new(source);
-    if let Some(e) = builder.add(path.as_std_path()) {
-        return Err(crate::Error::Config(format!("parsing {path}: {e}")));
-    }
-    builder
-        .build()
-        .map_err(|e| crate::Error::Config(format!("building .yuiignore: {e}")))
-}
-
-/// Test a path against the loaded `.yuiignore` matcher.
-///
-/// `path` is treated relative to `source` (gitignore convention). Paths
-/// that don't live under `source` can't possibly match a source-rooted
-/// rule, so they short-circuit to `false`. Without this guard, an
-/// absolute path passed through `unwrap_or(path)` would land on the
-/// matcher as an absolute, which `Gitignore` would test using its
-/// rightmost component — leading to spurious matches for paths outside
-/// the repo. (Caught in PR #19 review.)
-///
-/// Uses `matched_path_or_any_parents` so an ignored ancestor directory
-/// causes the descendant file to be ignored too.
-pub fn is_ignored(
-    gi: &ignore::gitignore::Gitignore,
-    source: &Utf8Path,
-    path: &Utf8Path,
-    is_dir: bool,
-) -> bool {
+/// Patterns use full gitignore syntax: glob (`*`, `**`), negation
+/// (`!`), trailing-slash dir-only matching, comments (`#`). Paths
+/// outside `source` short-circuit to `false`.
+pub fn is_ignored_at(source: &Utf8Path, path: &Utf8Path, is_dir: bool) -> crate::Result<bool> {
     let Ok(rel) = path.strip_prefix(source) else {
-        return false;
+        return Ok(false);
     };
-    matches!(
-        gi.matched_path_or_any_parents(rel.as_std_path(), is_dir),
-        ignore::Match::Ignore(_)
-    )
+    let mut stack = YuiIgnoreStack::new();
+    stack.push_dir(source)?;
+    let mut cur = source.to_owned();
+    for component in rel.components() {
+        let Utf8Component::Normal(c) = component else {
+            continue;
+        };
+        cur.push(c);
+        if cur == path {
+            break;
+        }
+        stack.push_dir(&cur)?;
+    }
+    Ok(stack.is_ignored(path, is_dir))
 }
 
 /// Build a source-tree walker that skips yui's internal `.yui/` directory.
@@ -100,11 +80,83 @@ pub fn is_ignored(
 /// `.gitignore` / `.ignore` filtering disabled (`git_ignore(false)`,
 /// `ignore(false)`) so a user's unrelated ignore rules don't swallow
 /// legitimate `.tera` / `.yuilink` files deeper in the tree.
+///
+/// `.yuiignore` is registered as a custom ignore filename so the
+/// walker honours nested rules (every subdir that has a `.yuiignore`
+/// adds its patterns scoped to that subtree, like git does with
+/// `.gitignore`). The manual recursive walks in `cmd.rs` use the
+/// `YuiIgnoreStack` companion type to get the same behaviour.
 pub fn source_walker(source: &Utf8Path) -> ignore::WalkBuilder {
     let mut b = ignore::WalkBuilder::new(source);
     b.hidden(false).git_ignore(false).ignore(false);
+    b.add_custom_ignore_filename(".yuiignore");
     b.filter_entry(|entry| entry.file_name() != ".yui");
     b
+}
+
+/// Stack of `.yuiignore` matchers for manual recursive walks. Each
+/// frame remembers the directory it was loaded from + the parsed
+/// matcher; testing a path walks innermost → outermost so a deeper
+/// `.yuiignore` overrides a shallower one (gitignore semantics).
+///
+/// Walkers `push_dir(d)` before iterating `d`'s entries and
+/// `pop_dir(d)` once they're done with the subtree. The same
+/// `YuiIgnoreStack` instance is threaded through the whole walk so
+/// the stack stays consistent across recursion.
+#[derive(Debug, Default)]
+pub struct YuiIgnoreStack {
+    layers: Vec<(Utf8PathBuf, ignore::gitignore::Gitignore)>,
+}
+
+impl YuiIgnoreStack {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Load `.yuiignore` from `dir` (if present) and push its rules
+    /// as a new layer. No-op when the file is absent.
+    pub fn push_dir(&mut self, dir: &Utf8Path) -> crate::Result<()> {
+        let path = dir.join(".yuiignore");
+        if !path.is_file() {
+            return Ok(());
+        }
+        let mut builder = ignore::gitignore::GitignoreBuilder::new(dir);
+        if let Some(e) = builder.add(path.as_std_path()) {
+            return Err(crate::Error::Config(format!("parsing {path}: {e}")));
+        }
+        let gi = builder
+            .build()
+            .map_err(|e| crate::Error::Config(format!("building {path}: {e}")))?;
+        self.layers.push((dir.to_owned(), gi));
+        Ok(())
+    }
+
+    /// Pop the top layer if it was loaded from `dir`. Pairs with
+    /// `push_dir` — calling it on a directory that didn't push a
+    /// layer is a no-op.
+    pub fn pop_dir(&mut self, dir: &Utf8Path) {
+        if matches!(self.layers.last(), Some((p, _)) if p == dir) {
+            self.layers.pop();
+        }
+    }
+
+    /// Decide whether `path` should be ignored. Walks frames inside
+    /// → outside; the first decisive match (Ignore or Whitelist)
+    /// wins, so a deeper `.yuiignore` can both exclude *and*
+    /// re-include paths the parent missed.
+    pub fn is_ignored(&self, path: &Utf8Path, is_dir: bool) -> bool {
+        for (anchor, gi) in self.layers.iter().rev() {
+            let Ok(rel) = path.strip_prefix(anchor) else {
+                continue;
+            };
+            match gi.matched_path_or_any_parents(rel.as_std_path(), is_dir) {
+                ignore::Match::Ignore(_) => return true,
+                ignore::Match::Whitelist(_) => return false,
+                ignore::Match::None => continue,
+            }
+        }
+        false
+    }
 }
 
 /// Mirror an absolute target path into a backup directory, dropping the drive
@@ -229,6 +281,78 @@ mod tests {
             expand_tilde_with("~root/foo", home),
             Utf8PathBuf::from("~root/foo")
         );
+    }
+
+    #[test]
+    fn yui_ignore_stack_root_only() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        std::fs::write(root.join(".yuiignore"), "*.lock\n").unwrap();
+        let mut stack = YuiIgnoreStack::new();
+        stack.push_dir(&root).unwrap();
+        assert!(stack.is_ignored(&root.join("foo.lock"), false));
+        assert!(!stack.is_ignored(&root.join("foo.txt"), false));
+        stack.pop_dir(&root);
+        // After pop the matcher is gone — same path is no longer ignored.
+        assert!(!stack.is_ignored(&root.join("foo.lock"), false));
+    }
+
+    #[test]
+    fn yui_ignore_stack_nested_overrides_parent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        let inner = root.join("inner");
+        std::fs::create_dir_all(&inner).unwrap();
+        std::fs::write(root.join(".yuiignore"), "*.lock\n").unwrap();
+        // Nested re-includes everything via `!*.lock`.
+        std::fs::write(inner.join(".yuiignore"), "!*.lock\n").unwrap();
+
+        let mut stack = YuiIgnoreStack::new();
+        stack.push_dir(&root).unwrap();
+        assert!(stack.is_ignored(&root.join("a.lock"), false));
+        stack.push_dir(&inner).unwrap();
+        assert!(
+            !stack.is_ignored(&inner.join("a.lock"), false),
+            "deeper layer's whitelist should win"
+        );
+        stack.pop_dir(&inner);
+        // After leaving inner, root rule applies again.
+        assert!(stack.is_ignored(&root.join("b.lock"), false));
+    }
+
+    #[test]
+    fn yui_ignore_stack_pop_only_matches_top() {
+        // pop_dir for a directory that didn't push anything is a no-op,
+        // so a missing `.yuiignore` doesn't desync the stack.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        std::fs::write(root.join(".yuiignore"), "*.lock\n").unwrap();
+        let no_ignore = root.join("plain");
+        std::fs::create_dir_all(&no_ignore).unwrap();
+
+        let mut stack = YuiIgnoreStack::new();
+        stack.push_dir(&root).unwrap();
+        stack.push_dir(&no_ignore).unwrap(); // no .yuiignore, no-op
+        stack.pop_dir(&no_ignore); // no-op
+        // Root layer is still in place.
+        assert!(stack.is_ignored(&root.join("a.lock"), false));
+    }
+
+    #[test]
+    fn is_ignored_at_walks_intermediate_yuiignores() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        let mid = root.join("mid");
+        let leaf = mid.join("leaf");
+        std::fs::create_dir_all(&leaf).unwrap();
+        std::fs::write(mid.join(".yuiignore"), "secret*\n").unwrap();
+        // mid/.yuiignore must be picked up when checking leaf/secret.txt
+        assert!(is_ignored_at(&root, &leaf.join("secret.txt"), false).unwrap());
+        assert!(!is_ignored_at(&root, &leaf.join("public.txt"), false).unwrap());
+        // Path outside the source root is not ignored.
+        let outside =
+            Utf8PathBuf::from_path_buf(tmp.path().parent().unwrap().to_path_buf()).unwrap();
+        assert!(!is_ignored_at(&root, &outside.join("anywhere"), false).unwrap());
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -54,7 +54,6 @@ pub fn render_all(
     source: &Utf8Path,
     config: &Config,
     yui: &YuiVars,
-    yuiignore: &ignore::gitignore::Gitignore,
     dry_run: bool,
 ) -> Result<RenderReport> {
     let mut engine = Engine::new();
@@ -65,8 +64,9 @@ pub fn render_all(
     // Walk every file under source. Filtering is centralized in
     // `paths::source_walker`: ignore-files OFF (so unrelated user rules
     // don't swallow `.tera`s) and `.yui/` skipped (backup mirrors etc.
-    // shouldn't be rendered). `.yuiignore` patterns are checked per
-    // entry below.
+    // shouldn't be rendered). `.yuiignore` is registered as a custom
+    // ignore filename, so nested `.yuiignore` files are honored
+    // automatically — no extra per-entry check needed here.
     let walker = paths::source_walker(source).build();
     for entry in walker {
         let entry = match entry {
@@ -87,11 +87,6 @@ pub fn render_all(
             Ok(p) => p,
             Err(_) => continue,
         };
-        // `.yuiignore` filter — also skip rendering the rendered counterpart
-        // (since that's what'd land in the user's tree).
-        if paths::is_ignored(yuiignore, source, &template_path, false) {
-            continue;
-        }
         process_template(
             &template_path,
             source,
@@ -404,14 +399,7 @@ mod tests {
             &r.join("home/.gitconfig.tera"),
             "[user]\n  os = {{ yui.os }}\n",
         );
-        let report = render_all(
-            &r,
-            &empty_config(),
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
         assert_eq!(report.written.len(), 1);
         assert_eq!(
             std::fs::read_to_string(r.join("home/.gitconfig")).unwrap(),
@@ -427,14 +415,7 @@ mod tests {
         let mut cfg = empty_config();
         cfg.vars
             .insert("greet".into(), toml::Value::String("hello".into()));
-        let _ = render_all(
-            &r,
-            &cfg,
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let _ = render_all(&r, &cfg, &yui_vars(&r), false).unwrap();
         assert_eq!(
             std::fs::read_to_string(r.join("home/foo")).unwrap(),
             "hello"
@@ -449,14 +430,7 @@ mod tests {
             &r.join("home/foo.tera"),
             "{# yui:when yui.os == 'windows' #}\nbody",
         );
-        let report = render_all(
-            &r,
-            &empty_config(),
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
         assert!(report.written.is_empty());
         assert_eq!(report.skipped_when_false.len(), 1);
         assert!(!r.join("home/foo").exists());
@@ -470,14 +444,7 @@ mod tests {
             &r.join("home/foo.tera"),
             "{# yui:when yui.os == 'linux' #}\nbody",
         );
-        let report = render_all(
-            &r,
-            &empty_config(),
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
         assert_eq!(report.written.len(), 1);
         assert_eq!(std::fs::read_to_string(r.join("home/foo")).unwrap(), "body");
     }
@@ -492,14 +459,7 @@ mod tests {
             r#match: "home/win/**".into(),
             when: Some("{{ yui.os == 'windows' }}".into()),
         });
-        let report = render_all(
-            &r,
-            &cfg,
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let report = render_all(&r, &cfg, &yui_vars(&r), false).unwrap();
         assert_eq!(report.skipped_when_false.len(), 1);
         assert!(report.written.is_empty());
     }
@@ -515,14 +475,7 @@ mod tests {
             r#match: "home/win/**".into(),
             when: Some("{{ yui.os == 'windows' }}".into()),
         });
-        let report = render_all(
-            &r,
-            &cfg,
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let report = render_all(&r, &cfg, &yui_vars(&r), false).unwrap();
         assert_eq!(report.written.len(), 1);
     }
 
@@ -532,14 +485,7 @@ mod tests {
         let r = root(&tmp);
         write(&r.join("home/foo.tera"), "body");
         write(&r.join("home/foo"), "body"); // already in sync
-        let report = render_all(
-            &r,
-            &empty_config(),
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
         assert!(report.written.is_empty());
         assert_eq!(report.unchanged.len(), 1);
     }
@@ -550,14 +496,7 @@ mod tests {
         let r = root(&tmp);
         write(&r.join("home/foo.tera"), "fresh body");
         write(&r.join("home/foo"), "manually edited");
-        let report = render_all(
-            &r,
-            &empty_config(),
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
         assert!(report.has_drift());
         assert_eq!(report.diverged.len(), 1);
         // existing content NOT overwritten
@@ -572,14 +511,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let r = root(&tmp);
         write(&r.join("home/foo.tera"), "body");
-        let _ = render_all(
-            &r,
-            &empty_config(),
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            true,
-        )
-        .unwrap();
+        let _ = render_all(&r, &empty_config(), &yui_vars(&r), true).unwrap();
         assert!(!r.join("home/foo").exists());
         assert!(!r.join(".gitignore").exists());
     }
@@ -590,14 +522,7 @@ mod tests {
         let r = root(&tmp);
         write(&r.join("home/foo.tera"), "body");
         write(&r.join("home/bar.tera"), "body2");
-        let _ = render_all(
-            &r,
-            &empty_config(),
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let _ = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
         let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
         assert!(gi.contains(GITIGNORE_BEGIN));
         assert!(gi.contains(GITIGNORE_END));
@@ -615,14 +540,7 @@ mod tests {
         let r = root(&tmp);
         write(&r.join(".gitignore"), "node_modules/\ntarget/\n");
         write(&r.join("home/foo.tera"), "body");
-        let _ = render_all(
-            &r,
-            &empty_config(),
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let _ = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
         let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
         assert!(gi.contains("node_modules/"));
         assert!(gi.contains("target/"));
@@ -639,14 +557,7 @@ mod tests {
             &format!("node_modules/\n\n{GITIGNORE_BEGIN}\nstale/path\n{GITIGNORE_END}\n\nfoo\n"),
         );
         write(&r.join("home/foo.tera"), "body");
-        let _ = render_all(
-            &r,
-            &empty_config(),
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let _ = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
         let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
         assert!(gi.contains("node_modules/"));
         assert!(gi.contains("home/foo"));
@@ -662,14 +573,7 @@ mod tests {
         // Pre-existing .gitignore that would normally hide `node_modules/`.
         write(&r.join(".gitignore"), "node_modules/\n");
         write(&r.join("node_modules/foo.tera"), "body");
-        let report = render_all(
-            &r,
-            &empty_config(),
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
         // Template under a gitignored dir is still discovered + rendered.
         assert_eq!(report.written.len(), 1);
         assert!(r.join("node_modules/foo").exists());
@@ -685,14 +589,7 @@ mod tests {
             "{# yui:when yui.os == 'windows' #}\nbody",
         );
         write(&r.join("home/foo"), "old rendered output");
-        let report = render_all(
-            &r,
-            &empty_config(),
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
         assert_eq!(report.skipped_when_false.len(), 1);
         // Stale sibling was cleaned up so apply won't link it.
         assert!(!r.join("home/foo").exists());
@@ -709,14 +606,7 @@ mod tests {
             r#match: "home/win/**".into(),
             when: Some("{{ yui.os == 'windows' }}".into()),
         });
-        let report = render_all(
-            &r,
-            &cfg,
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let report = render_all(&r, &cfg, &yui_vars(&r), false).unwrap();
         assert_eq!(report.skipped_when_false.len(), 1);
         assert!(!r.join("home/win/settings").exists());
     }
@@ -727,14 +617,7 @@ mod tests {
         let r = root(&tmp);
         write(&r.join("home/foo.tera"), "{# yui:when false #}\nbody");
         write(&r.join("home/foo"), "old rendered output");
-        let _ = render_all(
-            &r,
-            &empty_config(),
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            true,
-        )
-        .unwrap();
+        let _ = render_all(&r, &empty_config(), &yui_vars(&r), true).unwrap();
         // Dry-run leaves the on-disk file alone.
         assert_eq!(
             std::fs::read_to_string(r.join("home/foo")).unwrap(),
@@ -749,14 +632,7 @@ mod tests {
         write(&r.join("home/foo.tera"), "body");
         let mut cfg = empty_config();
         cfg.render.manage_gitignore = false;
-        let _ = render_all(
-            &r,
-            &cfg,
-            &yui_vars(&r),
-            &ignore::gitignore::Gitignore::empty(),
-            false,
-        )
-        .unwrap();
+        let _ = render_all(&r, &cfg, &yui_vars(&r), false).unwrap();
         assert!(r.join("home/foo").exists());
         assert!(!r.join(".gitignore").exists());
     }


### PR DESCRIPTION
Closes #47.

## Summary

- Nested `.yuiignore` files now scope rules to their subtree, matching `.gitignore` semantics: deeper layers override shallower ones, `!negation` re-includes, rules apply only below the file.
- `paths::source_walker` registers `.yuiignore` via `add_custom_ignore_filename`, so the `WalkBuilder`-driven flows (`render`, `list`, `find_source_for_target`'s marker scan) inherit nested behaviour for free.
- The manual recursive walks (`status` → `classify_walk`, `apply` → `walk_and_link`) thread a new `paths::YuiIgnoreStack` — push on dir entry, pop on exit — so the gitignore-style stack stays consistent across recursion.
- One-shot per-path checks (manual `absorb`'s mount candidate) go through a new `paths::is_ignored_at` helper that walks the candidate's parents on demand.
- README updated to drop the "only repo-root honored" caveat.

## Notes

`.yuiignore` placed inside a directory that's wholesale-junctioned via `.yuilink` cannot exclude individual files from the junctioned tree (the OS-level junction mirrors the whole dir); it can still affect nested marker discovery, `.tera` rendering, and per-file fallback links.

## Test plan

- [x] `cargo make check` (fmt + clippy `-D warnings` + locked check + tests)
- [x] New unit tests for `YuiIgnoreStack` and `is_ignored_at` in `paths`
- [x] New `apply` integration tests: nested ignore scoping, nested negation overriding root rule, `status` walk respects nested rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nested `.yuiignore` files are now discovered and applied during directory traversal with proper scoping—deeper rules override shallower ones, `!` negations re-include paths, and rules apply only within their subtree.

* **Documentation**
  * Updated README to clarify nested `.yuiignore` handling and rule scoping semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->