### PR TITLE
feat(gc-backup): survey + suffix-based prune for .yui/backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Need to absorb a single file regardless of policy? `yui absorb
 | `yui absorb <target> [--dry-run]` | manually pull a single target into source |
 | `yui unlink <path>...` | tear down a specific link |
 | `yui doctor` | environment sanity check |
-| `yui gc-backup [--older-than DUR]` | clean old backups (stub today — see [#46]) |
+| `yui gc-backup [--older-than DUR] [--dry-run]` | survey or prune `.yui/backup/` snapshots by suffix age |
 | `yui hooks list` | show configured `[[hook]]` entries + last-run state |
 | `yui hooks run [<name>] [--force]` | run hooks on demand (bypassing `when_run` with `--force`) |
 
@@ -325,11 +325,7 @@ Used in production for the author's own ~/dotfiles. Known gaps:
 
 - no built-in encryption (use `pass` / `1password-cli` from a Tera
   template instead)
-- `yui gc-backup` panics on call today (`todo!()`, tracked in [#46])
-  — prune `.yui/backup/` by hand for now
 
 ## License
 
 MIT
-
-[#46]: https://github.com/yukimemi/yui/issues/46

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -115,11 +115,30 @@ pub enum Command {
         no_color: bool,
     },
 
-    /// Garbage-collect old backups
+    /// Garbage-collect old backups under `$DOTFILES/.yui/backup/`.
+    ///
+    /// With no `--older-than`, prints every parsed backup with its
+    /// age + size and exits without deleting (a survey).
+    /// With `--older-than DUR`, deletes entries whose timestamp
+    /// suffix is older than DUR. Backups whose name doesn't match
+    /// yui's `<stem>_<YYYYMMDD_HHMMSSfff>[.<ext>]` shape are left
+    /// alone — anything you dropped into `.yui/backup/` by hand
+    /// stays there.
     GcBackup {
-        /// e.g. "30d", "6m"
-        #[arg(long)]
+        /// Age threshold; e.g. `30d`, `2w`, `12h`, `6mo`, `1y`.
+        /// Omit to run a non-destructive survey instead.
+        #[arg(long, value_name = "DUR")]
         older_than: Option<String>,
+        /// Preview the deletion (no files removed). Only meaningful
+        /// when `--older-than` is also given.
+        #[arg(long)]
+        dry_run: bool,
+        /// Override [ui] icons mode for this invocation
+        #[arg(long, value_name = "MODE")]
+        icons: Option<IconsMode>,
+        /// Disable color output (also respected via NO_COLOR env)
+        #[arg(long)]
+        no_color: bool,
     },
 
     /// Manage `[[hook]]` scripts
@@ -170,7 +189,12 @@ impl Cli {
             } => cmd::list(source, all, icons, no_color),
             Command::Absorb { target, dry_run } => cmd::absorb(source, target, dry_run),
             Command::Doctor { icons, no_color } => cmd::doctor(source, icons, no_color),
-            Command::GcBackup { older_than } => cmd::gc_backup(source, older_than),
+            Command::GcBackup {
+                older_than,
+                dry_run,
+                icons,
+                no_color,
+            } => cmd::gc_backup(source, older_than, dry_run, icons, no_color),
             Command::Hooks { action } => match action {
                 HookAction::List { icons, no_color } => cmd::hooks_list(source, icons, no_color),
                 HookAction::Run { name, force } => cmd::hooks_run(source, name, force),

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1546,7 +1546,7 @@ pub fn gc_backup(
         return Ok(());
     }
     // Oldest first — that's the natural "what should I prune?" order.
-    entries.sort_by(|a, b| a.ts.cmp(&b.ts));
+    entries.sort_by_key(|e| e.ts);
     let now = jiff::Zoned::now();
 
     match older_than {
@@ -1662,16 +1662,18 @@ fn walk_gc_backups_rec(dir: &Utf8Path, out: &mut Vec<BackupEntry>) -> Result<()>
             } else {
                 walk_gc_backups_rec(&path, out)?;
             }
-        } else if ft.is_file()
-            && let Some(ts) = parse_backup_suffix(name)
-        {
-            let size = entry.metadata()?.len();
-            out.push(BackupEntry {
-                path,
-                ts,
-                kind: BackupKind::File,
-                size_bytes: size,
-            });
+        } else if ft.is_file() {
+            // Nested ifs (not let-chains) so the crate's MSRV
+            // (rust-version = "1.85") stays buildable.
+            if let Some(ts) = parse_backup_suffix(name) {
+                let size = entry.metadata()?.len();
+                out.push(BackupEntry {
+                    path,
+                    ts,
+                    kind: BackupKind::File,
+                    size_bytes: size,
+                });
+            }
         }
     }
     Ok(())
@@ -1724,10 +1726,12 @@ fn parse_backup_suffix(name: &str) -> Option<jiff::civil::DateTime> {
     if let Some(ts) = parse_ts_at_end(name) {
         return Some(ts);
     }
-    if let Some((before, _ext)) = name.rsplit_once('.')
-        && let Some(ts) = parse_ts_at_end(before)
-    {
-        return Some(ts);
+    // Nested ifs (not let-chains) so the crate's MSRV
+    // (rust-version = "1.85") stays buildable.
+    if let Some((before, _ext)) = name.rsplit_once('.') {
+        if let Some(ts) = parse_ts_at_end(before) {
+            return Some(ts);
+        }
     }
     None
 }
@@ -1767,9 +1771,14 @@ fn parse_ts(s: &str) -> Option<jiff::civil::DateTime> {
     jiff::civil::DateTime::new(year, month, day, hour, minute, second, ms * 1_000_000).ok()
 }
 
-/// Parse a duration string in the shorthand the issue spec calls
-/// out: `30d`, `2w`, `12h`, `6m` / `6mo` (months), `1y`. Whitespace
-/// around the number is tolerated; the unit is case-insensitive.
+/// Parse a duration string in the shorthand `30d`, `2w`, `12h`,
+/// `6mo` (months), `1y`, `5m` (minutes). Whitespace around the
+/// number is tolerated; the unit is case-insensitive.
+///
+/// `m` means **minutes**, `mo` means **months** — bare `m` matches
+/// what `format_age` prints in the survey table, so a backup
+/// shown as "5m" is pruneable as `--older-than 5m`. Months take
+/// the explicit `mo` form. (Caught in PR #51 review.)
 fn parse_human_duration(s: &str) -> Result<jiff::Span> {
     let s = s.trim();
     let split = s
@@ -1786,12 +1795,16 @@ fn parse_human_duration(s: &str) -> Result<jiff::Span> {
     let unit = s[split..].to_ascii_lowercase();
     let span = match unit.as_str() {
         "y" | "yr" | "year" | "years" => jiff::Span::new().years(n),
-        "mo" | "m" | "month" | "months" => jiff::Span::new().months(n),
+        "mo" | "month" | "months" => jiff::Span::new().months(n),
         "w" | "wk" | "week" | "weeks" => jiff::Span::new().weeks(n),
         "d" | "day" | "days" => jiff::Span::new().days(n),
         "h" | "hr" | "hour" | "hours" => jiff::Span::new().hours(n),
+        "m" | "min" | "minute" | "minutes" => jiff::Span::new().minutes(n),
         other => {
-            anyhow::bail!("invalid duration {s:?}: unknown unit {other:?} (use y / m / w / d / h)")
+            anyhow::bail!(
+                "invalid duration {s:?}: unknown unit {other:?} \
+                 (use y / mo / w / d / h / m)"
+            )
         }
     };
     Ok(span)
@@ -1851,7 +1864,7 @@ fn print_gc_table(
     _icons: Icons,
     color: bool,
 ) {
-    use owo_colors::OwoColorize;
+    use owo_colors::OwoColorize as _;
 
     let rows: Vec<(String, String, String)> = entries
         .iter()
@@ -4393,8 +4406,9 @@ dst = "{}"
         assert_eq!(s.get_weeks(), 2);
         let s = parse_human_duration("12h").unwrap();
         assert_eq!(s.get_hours(), 12);
-        let s = parse_human_duration("6m").unwrap();
-        assert_eq!(s.get_months(), 6);
+        // `m` is minutes (matches what `format_age` prints), `mo` is months.
+        let s = parse_human_duration("5m").unwrap();
+        assert_eq!(s.get_minutes(), 5);
         let s = parse_human_duration("6mo").unwrap();
         assert_eq!(s.get_months(), 6);
         let s = parse_human_duration("1y").unwrap();

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1501,8 +1501,399 @@ fn plural(n: usize) -> &'static str {
     if n == 1 { "" } else { "s" }
 }
 
-pub fn gc_backup(_source: Option<Utf8PathBuf>, _older_than: Option<String>) -> Result<()> {
-    todo!("yui gc-backup — clean up old backups")
+/// `yui gc-backup [--older-than DUR] [--dry-run]` — prune snapshots
+/// under `$DOTFILES/.yui/backup/`.
+///
+/// With no `--older-than` we run a non-destructive *survey*: walk the
+/// backup tree, list every entry whose name carries yui's
+/// `_<YYYYMMDD_HHMMSSfff>[.<ext>]` suffix, and print AGE / SIZE / PATH
+/// sorted oldest-first plus a hint to pass `--older-than DUR` to
+/// actually delete. With `--older-than DUR` (e.g. `30d`, `2w`, `12h`,
+/// `6m`, `1y`) we delete every entry strictly older than the cutoff.
+/// `--dry-run` previews the same set without writing.
+///
+/// Two design points worth flagging:
+/// 1. *Suffix, not mtime.* `std::fs::copy` preserves source mtime on
+///    most platforms, so a backup of an old dotfile would look
+///    "old" by mtime even when freshly created. The suffix is the
+///    source of truth for "when did yui take this snapshot?".
+/// 2. *Defensive parse.* Anything in `.yui/backup/` whose name
+///    doesn't match the suffix shape is left alone — if you dropped
+///    a file there by hand, gc-backup isn't going to delete it.
+pub fn gc_backup(
+    source: Option<Utf8PathBuf>,
+    older_than: Option<String>,
+    dry_run: bool,
+    icons_override: Option<IconsMode>,
+    no_color: bool,
+) -> Result<()> {
+    let source = resolve_source(source)?;
+    let yui = YuiVars::detect(&source);
+    let config = config::load(&source, &yui)?;
+    let backup_root = source.join(&config.backup.dir);
+    let icons_mode = icons_override.unwrap_or(config.ui.icons);
+    let icons = Icons::for_mode(icons_mode);
+    let color = !no_color && supports_color_stdout();
+
+    if !backup_root.is_dir() {
+        println!("  no backup tree at {backup_root}");
+        return Ok(());
+    }
+
+    let mut entries = walk_gc_backups(&backup_root)?;
+    if entries.is_empty() {
+        println!("  no yui-stamped backups under {backup_root}");
+        return Ok(());
+    }
+    // Oldest first — that's the natural "what should I prune?" order.
+    entries.sort_by(|a, b| a.ts.cmp(&b.ts));
+    let now = jiff::Zoned::now();
+
+    match older_than {
+        None => {
+            let refs: Vec<&BackupEntry> = entries.iter().collect();
+            print_gc_table(&refs, &backup_root, &now, icons, color);
+            println!();
+            println!(
+                "  {} entries · {} total — pass --older-than DUR (e.g. 30d) to delete",
+                entries.len(),
+                format_bytes(entries.iter().map(|e| e.size_bytes).sum())
+            );
+            Ok(())
+        }
+        Some(dur_str) => {
+            let span = parse_human_duration(&dur_str)?;
+            let cutoff = now
+                .checked_sub(span)
+                .map_err(|e| anyhow::anyhow!("invalid duration {dur_str:?}: {e}"))?;
+            let cutoff_dt = cutoff.datetime();
+
+            let total_before: u64 = entries.iter().map(|e| e.size_bytes).sum();
+            let to_delete: Vec<&BackupEntry> =
+                entries.iter().filter(|e| e.ts < cutoff_dt).collect();
+
+            if to_delete.is_empty() {
+                println!(
+                    "  no backups older than {dur_str} (oldest: {})",
+                    format_age(entries[0].ts, &now)
+                );
+                return Ok(());
+            }
+
+            print_gc_table(&to_delete, &backup_root, &now, icons, color);
+            println!();
+            let total_freed: u64 = to_delete.iter().map(|e| e.size_bytes).sum();
+
+            if dry_run {
+                println!(
+                    "  [dry-run] would remove {} of {} entries · would free {} of {}",
+                    to_delete.len(),
+                    entries.len(),
+                    format_bytes(total_freed),
+                    format_bytes(total_before),
+                );
+                return Ok(());
+            }
+
+            for entry in &to_delete {
+                match entry.kind {
+                    BackupKind::File => std::fs::remove_file(&entry.path)?,
+                    BackupKind::Dir => std::fs::remove_dir_all(&entry.path)?,
+                }
+                if let Some(parent) = entry.path.parent() {
+                    cleanup_empty_parents(parent, &backup_root);
+                }
+            }
+            println!(
+                "  removed {} of {} entries · freed {} (was {}, now {})",
+                to_delete.len(),
+                entries.len(),
+                format_bytes(total_freed),
+                format_bytes(total_before),
+                format_bytes(total_before - total_freed),
+            );
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BackupEntry {
+    path: Utf8PathBuf,
+    ts: jiff::civil::DateTime,
+    kind: BackupKind,
+    size_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackupKind {
+    File,
+    Dir,
+}
+
+/// Recursive walk that recognises directory backups as one unit
+/// (so we don't descend into `<dirname>_<ts>/` and surface its
+/// individual files — the whole subtree is one snapshot). Files
+/// without a yui suffix are silently skipped.
+fn walk_gc_backups(root: &Utf8Path) -> Result<Vec<BackupEntry>> {
+    let mut out = Vec::new();
+    walk_gc_backups_rec(root, &mut out)?;
+    Ok(out)
+}
+
+fn walk_gc_backups_rec(dir: &Utf8Path, out: &mut Vec<BackupEntry>) -> Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let name_os = entry.file_name();
+        let Some(name) = name_os.to_str() else {
+            continue;
+        };
+        let path = dir.join(name);
+        let ft = entry.file_type()?;
+        if ft.is_dir() {
+            if let Some(ts) = parse_backup_suffix(name) {
+                let size = dir_size(&path)?;
+                out.push(BackupEntry {
+                    path,
+                    ts,
+                    kind: BackupKind::Dir,
+                    size_bytes: size,
+                });
+            } else {
+                walk_gc_backups_rec(&path, out)?;
+            }
+        } else if ft.is_file()
+            && let Some(ts) = parse_backup_suffix(name)
+        {
+            let size = entry.metadata()?.len();
+            out.push(BackupEntry {
+                path,
+                ts,
+                kind: BackupKind::File,
+                size_bytes: size,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn dir_size(dir: &Utf8Path) -> Result<u64> {
+    let mut total: u64 = 0;
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let ft = entry.file_type()?;
+        if ft.is_dir() {
+            let p = match Utf8PathBuf::from_path_buf(entry.path()) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            total = total.saturating_add(dir_size(&p)?);
+        } else if ft.is_file() {
+            total = total.saturating_add(entry.metadata()?.len());
+        }
+    }
+    Ok(total)
+}
+
+/// Walk up from `start` toward `root`, removing any directory that
+/// has become empty as a result of a deletion. Stops at the first
+/// non-empty parent and never touches `root` itself.
+fn cleanup_empty_parents(start: &Utf8Path, root: &Utf8Path) {
+    let mut cur = start.to_path_buf();
+    loop {
+        if cur == *root {
+            return;
+        }
+        // remove_dir succeeds only if the directory is empty.
+        if std::fs::remove_dir(&cur).is_err() {
+            return;
+        }
+        match cur.parent() {
+            Some(p) => cur = p.to_path_buf(),
+            None => return,
+        }
+    }
+}
+
+/// Parse a yui backup name. Two shapes:
+///   - `<stem>_<YYYYMMDD_HHMMSSfff>`            (dirs / dotfiles / no-ext)
+///   - `<stem>_<YYYYMMDD_HHMMSSfff>.<ext>`      (files with extension)
+///
+/// Returns the timestamp on success, `None` for anything else.
+fn parse_backup_suffix(name: &str) -> Option<jiff::civil::DateTime> {
+    if let Some(ts) = parse_ts_at_end(name) {
+        return Some(ts);
+    }
+    if let Some((before, _ext)) = name.rsplit_once('.')
+        && let Some(ts) = parse_ts_at_end(before)
+    {
+        return Some(ts);
+    }
+    None
+}
+
+fn parse_ts_at_end(s: &str) -> Option<jiff::civil::DateTime> {
+    // Need at least 1 stem char + `_` + 18-char timestamp.
+    if s.len() < 20 {
+        return None;
+    }
+    let split_at = s.len() - 19;
+    if s.as_bytes()[split_at] != b'_' {
+        return None;
+    }
+    parse_ts(&s[split_at + 1..])
+}
+
+/// Parse exactly `YYYYMMDD_HHMMSSfff`.
+fn parse_ts(s: &str) -> Option<jiff::civil::DateTime> {
+    if s.len() != 18 || s.as_bytes()[8] != b'_' {
+        return None;
+    }
+    for (i, &b) in s.as_bytes().iter().enumerate() {
+        if i == 8 {
+            continue;
+        }
+        if !b.is_ascii_digit() {
+            return None;
+        }
+    }
+    let year: i16 = s[0..4].parse().ok()?;
+    let month: i8 = s[4..6].parse().ok()?;
+    let day: i8 = s[6..8].parse().ok()?;
+    let hour: i8 = s[9..11].parse().ok()?;
+    let minute: i8 = s[11..13].parse().ok()?;
+    let second: i8 = s[13..15].parse().ok()?;
+    let ms: i32 = s[15..18].parse().ok()?;
+    jiff::civil::DateTime::new(year, month, day, hour, minute, second, ms * 1_000_000).ok()
+}
+
+/// Parse a duration string in the shorthand the issue spec calls
+/// out: `30d`, `2w`, `12h`, `6m` / `6mo` (months), `1y`. Whitespace
+/// around the number is tolerated; the unit is case-insensitive.
+fn parse_human_duration(s: &str) -> Result<jiff::Span> {
+    let s = s.trim();
+    let split = s
+        .bytes()
+        .position(|b| b.is_ascii_alphabetic())
+        .ok_or_else(|| anyhow::anyhow!("invalid duration {s:?}: missing unit (e.g. 30d, 2w)"))?;
+    let n: i64 = s[..split]
+        .trim()
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid duration {s:?}: bad leading number"))?;
+    if n < 0 {
+        anyhow::bail!("invalid duration {s:?}: negative durations don't make sense");
+    }
+    let unit = s[split..].to_ascii_lowercase();
+    let span = match unit.as_str() {
+        "y" | "yr" | "year" | "years" => jiff::Span::new().years(n),
+        "mo" | "m" | "month" | "months" => jiff::Span::new().months(n),
+        "w" | "wk" | "week" | "weeks" => jiff::Span::new().weeks(n),
+        "d" | "day" | "days" => jiff::Span::new().days(n),
+        "h" | "hr" | "hour" | "hours" => jiff::Span::new().hours(n),
+        other => {
+            anyhow::bail!("invalid duration {s:?}: unknown unit {other:?} (use y / m / w / d / h)")
+        }
+    };
+    Ok(span)
+}
+
+fn format_bytes(n: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = KIB * 1024;
+    const GIB: u64 = MIB * 1024;
+    if n >= GIB {
+        format!("{:.1} GiB", n as f64 / GIB as f64)
+    } else if n >= MIB {
+        format!("{:.1} MiB", n as f64 / MIB as f64)
+    } else if n >= KIB {
+        format!("{:.1} KiB", n as f64 / KIB as f64)
+    } else {
+        format!("{n} B")
+    }
+}
+
+fn format_age(ts: jiff::civil::DateTime, now: &jiff::Zoned) -> String {
+    let Ok(ts_zoned) = ts.to_zoned(now.time_zone().clone()) else {
+        return "?".into();
+    };
+    let secs = match (now - &ts_zoned).total(jiff::Unit::Second) {
+        Ok(s) => s as i64,
+        Err(_) => return "?".into(),
+    };
+    if secs < 0 {
+        return "future".into();
+    }
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else if secs < 86_400 {
+        format!("{}h", secs / 3600)
+    } else if secs < 86_400 * 30 {
+        format!("{}d", secs / 86_400)
+    } else if secs < 86_400 * 365 {
+        format!("{}mo", secs / (86_400 * 30))
+    } else {
+        format!("{}y", secs / (86_400 * 365))
+    }
+}
+
+/// Render a borrowed slice of `BackupEntry`s as an AGE / SIZE / PATH
+/// table. Trailing `/` on the path marks dir backups (filesystem
+/// convention) so the kind is visible without a dedicated column.
+/// `_icons` is currently unused but kept on the signature so future
+/// table changes can adopt new glyphs without rippling through every
+/// caller.
+fn print_gc_table(
+    entries: &[&BackupEntry],
+    backup_root: &Utf8Path,
+    now: &jiff::Zoned,
+    _icons: Icons,
+    color: bool,
+) {
+    use owo_colors::OwoColorize;
+
+    let rows: Vec<(String, String, String)> = entries
+        .iter()
+        .map(|e| {
+            let rel = e
+                .path
+                .strip_prefix(backup_root)
+                .map(Utf8PathBuf::from)
+                .unwrap_or_else(|_| e.path.clone());
+            let path_disp = match e.kind {
+                BackupKind::Dir => format!("{rel}/"),
+                BackupKind::File => rel.to_string(),
+            };
+            (format_age(e.ts, now), format_bytes(e.size_bytes), path_disp)
+        })
+        .collect();
+
+    let age_w = rows.iter().map(|r| r.0.len()).max().unwrap_or(3);
+    let size_w = rows.iter().map(|r| r.1.len()).max().unwrap_or(4);
+
+    if color {
+        println!(
+            "  {:<age_w$}  {:>size_w$}  {}",
+            "AGE".dimmed(),
+            "SIZE".dimmed(),
+            "PATH".dimmed(),
+        );
+    } else {
+        println!("  {:<age_w$}  {:>size_w$}  PATH", "AGE", "SIZE");
+    }
+    for (age, size, path) in &rows {
+        if color {
+            println!(
+                "  {:<age_w$}  {:>size_w$}  {}",
+                age.yellow(),
+                size,
+                path.cyan(),
+            );
+        } else {
+            println!("  {:<age_w$}  {:>size_w$}  {}", age, size, path);
+        }
+    }
 }
 
 /// `yui hooks list` — show every configured hook + its last-run state.
@@ -3948,5 +4339,229 @@ dst = "{}"
             }
         }
         out
+    }
+
+    // -----------------------------------------------------------------
+    // gc-backup
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn parse_backup_suffix_recognises_file_with_extension() {
+        let dt = parse_backup_suffix("foo_20260429_143022123.yml").unwrap();
+        assert_eq!(dt.year(), 2026);
+        assert_eq!(dt.month(), 4);
+        assert_eq!(dt.day(), 29);
+        assert_eq!(dt.hour(), 14);
+        assert_eq!(dt.minute(), 30);
+        assert_eq!(dt.second(), 22);
+    }
+
+    #[test]
+    fn parse_backup_suffix_recognises_dotfile_no_extension() {
+        let dt = parse_backup_suffix(".gitconfig_20260429_143022123").unwrap();
+        assert_eq!(dt.year(), 2026);
+    }
+
+    #[test]
+    fn parse_backup_suffix_recognises_directory_form() {
+        let dt = parse_backup_suffix("nvim_20260429_143022123").unwrap();
+        assert_eq!(dt.day(), 29);
+    }
+
+    #[test]
+    fn parse_backup_suffix_recognises_multi_dot_filename() {
+        // archive.tar.gz_<ts>.gz round-trips back through the rsplit-on-dot fallback.
+        let dt = parse_backup_suffix("archive.tar.gz_20260429_143022123.gz").unwrap();
+        assert_eq!(dt.month(), 4);
+    }
+
+    #[test]
+    fn parse_backup_suffix_rejects_non_yui_names() {
+        assert!(parse_backup_suffix("README.md").is_none());
+        assert!(parse_backup_suffix("notes_2026.txt").is_none());
+        assert!(parse_backup_suffix("almost_20260429_14302212").is_none()); // 17 digits
+        assert!(parse_backup_suffix("almost_20260429-143022123").is_none()); // wrong sep
+        // Bare timestamp with no stem is rejected (defensive — yui never produces these).
+        assert!(parse_backup_suffix("_20260429_143022123").is_none());
+    }
+
+    #[test]
+    fn parse_human_duration_basic_units() {
+        let s = parse_human_duration("30d").unwrap();
+        assert_eq!(s.get_days(), 30);
+        let s = parse_human_duration("2w").unwrap();
+        assert_eq!(s.get_weeks(), 2);
+        let s = parse_human_duration("12h").unwrap();
+        assert_eq!(s.get_hours(), 12);
+        let s = parse_human_duration("6m").unwrap();
+        assert_eq!(s.get_months(), 6);
+        let s = parse_human_duration("6mo").unwrap();
+        assert_eq!(s.get_months(), 6);
+        let s = parse_human_duration("1y").unwrap();
+        assert_eq!(s.get_years(), 1);
+    }
+
+    #[test]
+    fn parse_human_duration_case_insensitive_and_whitespace() {
+        let s = parse_human_duration("  90D  ").unwrap();
+        assert_eq!(s.get_days(), 90);
+        let s = parse_human_duration("3WEEKS").unwrap();
+        assert_eq!(s.get_weeks(), 3);
+    }
+
+    #[test]
+    fn parse_human_duration_rejects_garbage() {
+        assert!(parse_human_duration("").is_err());
+        assert!(parse_human_duration("d30").is_err());
+        assert!(parse_human_duration("30").is_err()); // no unit
+        assert!(parse_human_duration("30x").is_err()); // unknown unit
+        assert!(parse_human_duration("-1d").is_err()); // negative
+    }
+
+    /// Plant a real-shaped backup tree and confirm `walk_gc_backups`
+    /// finds both files and dir-snapshots, treats dirs as one unit
+    /// (no descent), and ignores anything without yui's suffix.
+    #[test]
+    fn walk_gc_backups_collects_files_and_dir_snapshots() {
+        let tmp = TempDir::new().unwrap();
+        let root = utf8(tmp.path().to_path_buf()).join(".yui/backup");
+        std::fs::create_dir_all(root.join("C/Users/u/.config")).unwrap();
+        // File-style backup.
+        std::fs::write(
+            root.join("C/Users/u/.config/foo_20260429_143022123.yml"),
+            "old yml",
+        )
+        .unwrap();
+        // Dir-style backup with internal files (must not be surfaced individually).
+        std::fs::create_dir_all(root.join("C/Users/u/nvim_20260101_000000000/lua")).unwrap();
+        std::fs::write(
+            root.join("C/Users/u/nvim_20260101_000000000/init.lua"),
+            "ok",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("C/Users/u/nvim_20260101_000000000/lua/x.lua"),
+            "kk",
+        )
+        .unwrap();
+        // User-dropped file with no yui suffix — must stay out of the survey.
+        std::fs::write(root.join("C/Users/u/.config/README.md"), "user note").unwrap();
+
+        let entries = walk_gc_backups(&root).unwrap();
+        assert_eq!(entries.len(), 2, "two backup roots, not three");
+        let kinds: Vec<_> = entries.iter().map(|e| e.kind).collect();
+        assert!(kinds.contains(&BackupKind::File));
+        assert!(kinds.contains(&BackupKind::Dir));
+        // Dir-size aggregates contents.
+        let dir_entry = entries.iter().find(|e| e.kind == BackupKind::Dir).unwrap();
+        assert!(dir_entry.size_bytes >= 4); // "ok" + "kk"
+    }
+
+    #[test]
+    fn cleanup_empty_parents_stops_at_root_and_at_non_empty() {
+        let tmp = TempDir::new().unwrap();
+        let root = utf8(tmp.path().to_path_buf()).join(".yui/backup");
+        std::fs::create_dir_all(root.join("C/Users/u/.config")).unwrap();
+        std::fs::write(root.join("C/Users/u/sibling_keep"), "x").unwrap();
+
+        // Pretend we just deleted everything under .config/, the parent
+        // is now empty and walks up — but Users/ has `sibling_keep` so
+        // we must stop there. .yui/backup itself must never be removed.
+        cleanup_empty_parents(&root.join("C/Users/u/.config"), &root);
+
+        assert!(!root.join("C/Users/u/.config").exists(), "empty leaf gone");
+        assert!(root.join("C/Users/u").exists(), "stops at non-empty parent");
+        assert!(root.exists(), "backup root preserved");
+    }
+
+    /// Survey mode (no `--older-than`) lists everything and deletes nothing.
+    #[test]
+    fn gc_backup_survey_keeps_all_entries() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        std::fs::create_dir_all(source.join(".yui/backup")).unwrap();
+        std::fs::write(source.join("config.toml"), "").unwrap();
+        let backup = source.join(".yui/backup");
+        std::fs::write(backup.join("a_20260101_000000000.txt"), "old").unwrap();
+        std::fs::write(backup.join("b_20260415_120000000.txt"), "fresh").unwrap();
+
+        gc_backup(Some(source.clone()), None, false, None, true).unwrap();
+
+        // Both still present.
+        assert!(backup.join("a_20260101_000000000.txt").exists());
+        assert!(backup.join("b_20260415_120000000.txt").exists());
+    }
+
+    /// Prune mode deletes entries strictly older than the cutoff and
+    /// leaves newer ones plus user-dropped files alone.
+    #[test]
+    fn gc_backup_prune_removes_old_files_only() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        std::fs::create_dir_all(source.join(".yui/backup/sub")).unwrap();
+        std::fs::write(source.join("config.toml"), "").unwrap();
+        let backup = source.join(".yui/backup");
+
+        // Far-past file (will be older than 30d unless this test runs in 2026-01).
+        std::fs::write(backup.join("sub/old_20200101_000000000.txt"), "old").unwrap();
+        // Tomorrow → ts > now → never older than any positive cutoff.
+        let tomorrow = jiff::Zoned::now()
+            .checked_add(jiff::Span::new().days(1))
+            .unwrap();
+        let bdt = jiff::fmt::strtime::BrokenDownTime::from(&tomorrow);
+        let future_ts = bdt.to_string("%Y%m%d_%H%M%S%3f").unwrap();
+        std::fs::write(backup.join(format!("fresh_{future_ts}.txt")), "fresh").unwrap();
+        // User-dropped file — not in yui shape.
+        std::fs::write(backup.join("notes.md"), "mine").unwrap();
+
+        gc_backup(Some(source.clone()), Some("30d".into()), false, None, true).unwrap();
+
+        assert!(!backup.join("sub/old_20200101_000000000.txt").exists());
+        // Empty parent dir got cleaned up too.
+        assert!(!backup.join("sub").exists(), "empty parent removed");
+        // Backup root itself is preserved even after losing children.
+        assert!(backup.exists());
+        assert!(backup.join(format!("fresh_{future_ts}.txt")).exists());
+        assert!(backup.join("notes.md").exists(), "user file untouched");
+    }
+
+    /// `--dry-run` prints the same set but mutates nothing.
+    #[test]
+    fn gc_backup_dry_run_does_not_delete() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        std::fs::create_dir_all(source.join(".yui/backup")).unwrap();
+        std::fs::write(source.join("config.toml"), "").unwrap();
+        let backup = source.join(".yui/backup");
+        std::fs::write(backup.join("old_20200101_000000000.txt"), "old").unwrap();
+
+        gc_backup(Some(source.clone()), Some("30d".into()), true, None, true).unwrap();
+
+        assert!(
+            backup.join("old_20200101_000000000.txt").exists(),
+            "dry-run keeps everything in place"
+        );
+    }
+
+    /// Dir-snapshots are removed wholesale (no per-file judgment) and
+    /// the now-empty mirror parents collapse up to (but not past) the
+    /// backup root.
+    #[test]
+    fn gc_backup_prune_handles_directory_snapshot() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        std::fs::create_dir_all(source.join(".yui/backup/mirror/u")).unwrap();
+        std::fs::write(source.join("config.toml"), "").unwrap();
+        let backup = source.join(".yui/backup");
+        let snap = backup.join("mirror/u/nvim_20200101_000000000");
+        std::fs::create_dir_all(snap.join("lua")).unwrap();
+        std::fs::write(snap.join("init.lua"), "x").unwrap();
+        std::fs::write(snap.join("lua/y.lua"), "y").unwrap();
+
+        gc_backup(Some(source.clone()), Some("30d".into()), false, None, true).unwrap();
+
+        assert!(!snap.exists(), "dir snapshot removed wholesale");
+        assert!(!backup.join("mirror").exists(), "empty mirror chain pruned");
+        assert!(backup.exists(), "backup root preserved");
     }
 }


### PR DESCRIPTION
Closes #46.

## Summary

`yui gc-backup` was a `todo!()` (panic on call). Implements the spec from #46:

- **No `--older-than`** → non-destructive **survey**. Walks `$DOTFILES/.yui/backup/`, lists every yui-stamped entry oldest first with `AGE / SIZE / PATH`, and hints at `--older-than DUR`.
- **`--older-than DUR`** → delete entries strictly older than the cutoff. Accepts `30d`, `2w`, `12h`, `6m` / `6mo`, `1y` (case-insensitive, surrounding whitespace tolerated).
- **`--dry-run`** → preview the same set without touching disk.

## Design points

1. **Suffix, not mtime.** `std::fs::copy` preserves source mtime on most platforms, so a backup of an old dotfile would look "old" by mtime even when freshly created. The yui-stamped suffix is the only true "snapshot taken at" marker.
2. **Defensive parse.** Anything in `.yui/backup/` whose name doesn't match yui's `<stem>_<YYYYMMDD_HHMMSSfff>[.<ext>]` shape is left alone — files dropped in by hand stay there, even on a real prune.
3. **Dir-snapshots are one unit.** `<dirname>_<ts>/` matches once at the directory level; the walker doesn't descend into it. Prune uses `remove_dir_all`, with `cleanup_empty_parents` collapsing the now-empty mirror chain back up to (but never past) the backup root.

## Smoke test on author's actual dotfiles

```
$ yui gc-backup
  AGE      SIZE  PATH
  1d   10.5 MiB  C\Users\.../.config_20260429_213222369/
  1d   10.5 MiB  C\Users\.../.config_20260429_213627994/
  ...
  5 entries · 31.5 MiB total — pass --older-than DUR (e.g. 30d) to delete

$ yui gc-backup --older-than 12h --dry-run
  ...
  [dry-run] would remove 4 of 5 entries · would free 31.5 MiB of 31.5 MiB
```

## Test plan

- [x] Suffix parser: file with extension / dotfile / multi-dot filename / dir form / non-yui rejection
- [x] Duration parser: every unit (`y`, `m`/`mo`, `w`, `d`, `h`), case-insensitive, whitespace tolerance, garbage rejection (negative, missing unit, unknown unit)
- [x] Walker: surfaces files + dir-snapshots once, ignores user-dropped files, skips descent into dir-snapshots
- [x] Survey: lists everything, deletes nothing
- [x] Prune: removes only entries older than cutoff, preserves user files, collapses empty parents up to backup root
- [x] Dry-run: prints the prune set without writing
- [x] Dir-snapshot prune: `remove_dir_all` + parent-chain cleanup
- [x] `cargo make check` green (fmt + clippy `-D warnings` + locked check + 143 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)