### PR TITLE
feat(mount): src accepts absolute / ~/ / Tera-rendered paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ file to a directory to junction the whole directory as one unit (so
 files an app creates inside that dir land back in source
 automatically).
 
+`src` is the path *to* yui's source for that mount; it accepts
+relative paths (resolved against `$DOTFILES`), absolute paths, `~`
+/ `~/...`, and Tera tags. So a private clone outside `$DOTFILES`
+can participate as its own mount:
+
+```toml
+[[mount.entry]]
+src = "~/.dotfiles-private/home"
+dst = "~"
+```
+
 ## Templates (`*.tera`)
 
 Files ending in `.tera` are rendered with [Tera] before linking; the

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -223,6 +223,7 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
 
     // 2. Resolve mounts and link.
     let mounts = mount::resolve(
+        &source,
         &config.mount.entry,
         config.mount.default_strategy,
         &mut engine,
@@ -253,7 +254,7 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
     let walk_result = (|| -> Result<()> {
         for m in &mounts {
             info!("mount: {} → {}", m.src, m.dst);
-            process_mount(&source, m, &ctx, &mut engine, &tera_ctx, &mut yuiignore)?;
+            process_mount(m, &ctx, &mut engine, &tera_ctx, &mut yuiignore)?;
         }
         Ok(())
     })();
@@ -691,11 +692,15 @@ pub fn unmanaged(
     // platform) still own their files on principle, and surfacing
     // them as "unmanaged" would just be confusing. (Caught in
     // PR #53 review.)
+    // Raw `config.mount.entry` (not `mount::resolve`) so inactive
+    // mounts still claim their files; `paths::resolve_mount_src`
+    // applies `~`/absolute handling so private clones outside
+    // `$DOTFILES` participate too.
     let mount_srcs: Vec<Utf8PathBuf> = config
         .mount
         .entry
         .iter()
-        .map(|e| source.join(&e.src))
+        .map(|e| paths::resolve_mount_src(&source, e.src.as_str()))
         .collect();
 
     let mut items: Vec<Utf8PathBuf> = Vec::new();
@@ -817,6 +822,7 @@ pub fn diff(
     let mut engine = template::Engine::new();
     let tera_ctx = template::template_context(&yui, &config.vars);
     let mounts = mount::resolve(
+        &source,
         &config.mount.entry,
         config.mount.default_strategy,
         &mut engine,
@@ -832,7 +838,7 @@ pub fn diff(
     yuiignore.push_dir(&source)?;
     let walk_result = (|| -> Result<()> {
         for m in &mounts {
-            let src_root = source.join(&m.src);
+            let src_root = m.src.clone();
             if !src_root.is_dir() {
                 continue;
             }
@@ -1075,6 +1081,7 @@ pub fn status(
     let mut engine = template::Engine::new();
     let tera_ctx = template::template_context(&yui, &config.vars);
     let mounts = mount::resolve(
+        &source,
         &config.mount.entry,
         config.mount.default_strategy,
         &mut engine,
@@ -1109,7 +1116,7 @@ pub fn status(
     yuiignore.push_dir(&source)?;
     let walk_result = (|| -> Result<()> {
         for m in &mounts {
-            let src_root = source.join(&m.src);
+            let src_root = m.src.clone();
             if !src_root.is_dir() {
                 warn!("mount src missing: {src_root}");
                 continue;
@@ -1628,7 +1635,8 @@ fn find_source_for_target(
         let dst_str = engine.render(&entry.dst, tera_ctx)?;
         let dst_root = paths::expand_tilde(dst_str.trim());
         if let Ok(rel) = target.strip_prefix(&dst_root) {
-            let candidate = source.join(&entry.src).join(rel);
+            let src_str = engine.render(entry.src.as_str(), tera_ctx)?;
+            let candidate = paths::resolve_mount_src(source, src_str.trim()).join(rel);
             // Honor `.yuiignore` even on manual absorb — if you've
             // ignored a path, you've explicitly opted out of yui's
             // managing it. One-shot stack walk along the candidate's
@@ -2685,14 +2693,15 @@ pub fn hooks_run(source: Option<Utf8PathBuf>, name: Option<String>, force: bool)
 
 #[allow(clippy::too_many_arguments)]
 fn process_mount(
-    source: &Utf8Path,
     m: &ResolvedMount,
     ctx: &ApplyCtx<'_>,
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
     yuiignore: &mut paths::YuiIgnoreStack,
 ) -> Result<()> {
-    let src_root = source.join(&m.src);
+    // `m.src` is already absolute (resolved by `mount::resolve`),
+    // so we don't need the source-root anymore.
+    let src_root = m.src.clone();
     if !src_root.is_dir() {
         warn!("mount src missing: {src_root}");
         return Ok(());

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -684,24 +684,31 @@ pub fn unmanaged(
     let _icons = Icons::for_mode(icons_override.unwrap_or(config.ui.icons));
     let color = !no_color && supports_color_stdout();
 
-    // Resolve every mount.src to an absolute path under source so a
-    // simple `path.starts_with(&mount_src)` test can answer
-    // "claimed?". We use the *raw* config entries instead of
-    // `mount::resolve` because the latter filters by `when` —
-    // inactive mounts (e.g. an OS-specific mount for a different
-    // platform) still own their files on principle, and surfacing
-    // them as "unmanaged" would just be confusing. (Caught in
-    // PR #53 review.)
-    // Raw `config.mount.entry` (not `mount::resolve`) so inactive
-    // mounts still claim their files; `paths::resolve_mount_src`
-    // applies `~`/absolute handling so private clones outside
-    // `$DOTFILES` participate too.
+    // Resolve every mount.src to an absolute path so a simple
+    // `path.starts_with(&mount_src)` test can answer "claimed?".
+    //
+    //   - Iterate raw `config.mount.entry` (NOT `mount::resolve`)
+    //     so a `when=false` mount still claims its files — surfacing
+    //     them as "unmanaged" because they're inactive on this host
+    //     would be confusing. (PR #53 review.)
+    //   - Tera-render `entry.src` first so a templated path like
+    //     `"private/{{ yui.host }}/home"` claims its files on
+    //     this host rather than landing in `mount_srcs` as the
+    //     literal raw string. (PR #56 review.)
+    //   - `paths::resolve_mount_src` then applies tilde / absolute
+    //     handling so private clones outside `$DOTFILES`
+    //     participate too.
+    let mut engine = template::Engine::new();
+    let tera_ctx = template::template_context(&yui, &config.vars);
     let mount_srcs: Vec<Utf8PathBuf> = config
         .mount
         .entry
         .iter()
-        .map(|e| paths::resolve_mount_src(&source, e.src.as_str()))
-        .collect();
+        .map(|e| -> Result<Utf8PathBuf> {
+            let rendered = engine.render(e.src.as_str(), &tera_ctx)?;
+            Ok(paths::resolve_mount_src(&source, rendered.trim()))
+        })
+        .collect::<Result<_>>()?;
 
     let mut items: Vec<Utf8PathBuf> = Vec::new();
     let walker = paths::source_walker(&source).build();

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -1,7 +1,7 @@
-//! Resolve `[[mount.entry]]` definitions: render `dst` via Tera, evaluate
-//! `when`, drop disabled entries.
+//! Resolve `[[mount.entry]]` definitions: render `src` and `dst` via
+//! Tera, evaluate `when`, drop disabled entries.
 
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use tera::Context;
 
 use crate::Result;
@@ -9,15 +9,23 @@ use crate::config::{MountEntry, MountStrategy};
 use crate::paths;
 use crate::template::{self, Engine};
 
-/// A mount entry after Tera rendering of `dst` and `when`-filtering.
+/// A mount entry after Tera rendering, tilde expansion, and
+/// `when`-filtering. Both `src` and `dst` are absolute paths.
 #[derive(Debug, Clone)]
 pub struct ResolvedMount {
+    /// Absolute path to the source subtree. For relative inputs this
+    /// is `<source>/<entry.src>`; absolute / `~`-relative inputs land
+    /// where the user pointed. Letting `src` escape the dotfiles repo
+    /// is intentional — it's how a separate private clone (e.g.
+    /// `~/.dotfiles-private/home`) participates as a mount without
+    /// having to live under `$DOTFILES`.
     pub src: Utf8PathBuf,
     pub dst: Utf8PathBuf,
     pub strategy: MountStrategy,
 }
 
 pub fn resolve(
+    source: &Utf8Path,
     entries: &[MountEntry],
     default_strategy: MountStrategy,
     engine: &mut Engine,
@@ -36,10 +44,12 @@ pub fn resolve(
                 continue;
             }
         }
+        let src_str = engine.render(e.src.as_str(), ctx)?;
+        let src = paths::resolve_mount_src(source, src_str.trim());
         let dst_str = engine.render(&e.dst, ctx)?;
         let dst = paths::expand_tilde(dst_str.trim());
         out.push(ResolvedMount {
-            src: e.src.clone(),
+            src,
             dst,
             strategy: e.strategy.unwrap_or(default_strategy),
         });
@@ -63,6 +73,10 @@ mod tests {
         }
     }
 
+    fn source() -> Utf8PathBuf {
+        Utf8PathBuf::from("/dotfiles")
+    }
+
     #[test]
     fn renders_dst_and_filters_when_false() {
         let entries = vec![
@@ -81,9 +95,11 @@ mod tests {
         ];
         let mut e = Engine::new();
         let ctx = template::config_context(&vars());
-        let resolved = resolve(&entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
+        let s = source();
+        let resolved = resolve(&s, &entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
         assert_eq!(resolved.len(), 1);
-        assert_eq!(resolved[0].src, Utf8PathBuf::from("home"));
+        // Relative `src` is resolved against the source root.
+        assert_eq!(resolved[0].src, Utf8PathBuf::from("/dotfiles/home"));
         assert_eq!(resolved[0].dst, Utf8PathBuf::from("/linux/u"));
         assert_eq!(resolved[0].strategy, MountStrategy::Marker);
     }
@@ -98,7 +114,8 @@ mod tests {
         }];
         let mut e = Engine::new();
         let ctx = template::config_context(&vars());
-        let resolved = resolve(&entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
+        let s = source();
+        let resolved = resolve(&s, &entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
         assert_eq!(resolved.len(), 1);
     }
 
@@ -116,7 +133,8 @@ mod tests {
         }];
         let mut e = Engine::new();
         let ctx = template::config_context(&vars());
-        let resolved = resolve(&entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
+        let s = source();
+        let resolved = resolve(&s, &entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
         assert_eq!(resolved.len(), 1);
     }
 
@@ -130,7 +148,8 @@ mod tests {
         }];
         let mut e = Engine::new();
         let ctx = template::config_context(&vars());
-        let resolved = resolve(&entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
+        let s = source();
+        let resolved = resolve(&s, &entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
         assert!(resolved.is_empty());
     }
 
@@ -144,7 +163,48 @@ mod tests {
         }];
         let mut e = Engine::new();
         let ctx = template::config_context(&vars());
-        let resolved = resolve(&entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
+        let s = source();
+        let resolved = resolve(&s, &entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
         assert_eq!(resolved[0].strategy, MountStrategy::PerFile);
+    }
+
+    /// Absolute `src` lets a separate (e.g. private) clone outside
+    /// `$DOTFILES` participate as a mount without symlinking. The
+    /// resolver returns the absolute path verbatim.
+    #[test]
+    fn absolute_src_is_returned_verbatim() {
+        let entries = vec![MountEntry {
+            src: "/abs/private/home".into(),
+            dst: "/h".into(),
+            when: None,
+            strategy: None,
+        }];
+        let mut e = Engine::new();
+        let ctx = template::config_context(&vars());
+        let s = source();
+        let resolved = resolve(&s, &entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
+        assert_eq!(resolved[0].src, Utf8PathBuf::from("/abs/private/home"));
+    }
+
+    /// Tera renders against the same context the call site builds
+    /// (yui.* + vars.*). Letting `src` use `{{ yui.host }}` etc.
+    /// makes per-machine source dirs trivial.
+    #[test]
+    fn src_renders_via_tera() {
+        let entries = vec![MountEntry {
+            src: "private/{{ yui.host }}/home".into(),
+            dst: "/h".into(),
+            when: None,
+            strategy: None,
+        }];
+        let mut e = Engine::new();
+        let ctx = template::config_context(&vars());
+        let s = source();
+        let resolved = resolve(&s, &entries, MountStrategy::Marker, &mut e, &ctx).unwrap();
+        // vars().host is "test"
+        assert_eq!(
+            resolved[0].src,
+            Utf8PathBuf::from("/dotfiles/private/test/home")
+        );
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -50,8 +50,37 @@ pub fn home_dir() -> Option<Utf8PathBuf> {
 /// Implementation detail: `Utf8PathBuf::join` already replaces the
 /// base with absolute arguments, so we just need `expand_tilde`
 /// first to handle the `~` form.
+///
+/// If `expand_tilde` couldn't resolve `~` (both `HOME` and
+/// `USERPROFILE` unset), it returns the input verbatim — in that
+/// case we MUST NOT rebase it under `source`, because
+/// `<source>/~/foo` silently resolves to a wrong tree instead of
+/// surfacing the unset-home configuration error. Return the
+/// unresolved `~` form so the caller hits a clear "no such path"
+/// later. (Caught in PR #56 review by coderabbitai.)
 pub fn resolve_mount_src(source: &Utf8Path, src: &str) -> Utf8PathBuf {
-    let expanded = expand_tilde(src);
+    resolve_mount_src_with(source, src, home_dir().as_deref())
+}
+
+/// `resolve_mount_src` with an explicit home — used in tests so we
+/// don't mutate the process-wide `HOME` env var (which races with
+/// parallel tests). Production code goes through `resolve_mount_src`.
+pub fn resolve_mount_src_with(
+    source: &Utf8Path,
+    src: &str,
+    home: Option<&Utf8Path>,
+) -> Utf8PathBuf {
+    let expanded = match home {
+        Some(h) => expand_tilde_with(src, h),
+        None => Utf8PathBuf::from(src),
+    };
+    let is_tilde_form = src == "~" || src.starts_with("~/") || src.starts_with("~\\");
+    if is_tilde_form && expanded.as_str() == src {
+        // No home to resolve against — return the unresolved form
+        // verbatim so the caller surfaces a clear "no such path"
+        // rather than a silent rebase under `source`.
+        return expanded;
+    }
     source.join(expanded)
 }
 
@@ -312,6 +341,66 @@ mod tests {
         assert_eq!(
             expand_tilde_with("~root/foo", home),
             Utf8PathBuf::from("~root/foo")
+        );
+    }
+
+    /// Regression for PR #56 review: when neither `HOME` nor
+    /// `USERPROFILE` is set, `expand_tilde` is a no-op and returns
+    /// `~/foo` verbatim. `resolve_mount_src` must NOT then rebase
+    /// it under `source` (which would yield `<source>/~/foo`,
+    /// silently pointing at a wrong tree). Instead, return the
+    /// unresolved `~/foo` so the caller's "no such path" error is
+    /// the clear failure mode.
+    #[test]
+    fn resolve_mount_src_preserves_unresolved_tilde() {
+        let source = Utf8Path::new("/dot");
+        // `home: None` simulates HOME / USERPROFILE both unset.
+        assert_eq!(
+            resolve_mount_src_with(source, "~/foo", None),
+            Utf8PathBuf::from("~/foo"),
+        );
+        assert_eq!(
+            resolve_mount_src_with(source, "~", None),
+            Utf8PathBuf::from("~"),
+        );
+    }
+
+    /// When home is available, `~/foo` resolves to the absolute
+    /// `<HOME>/foo` and `Utf8PathBuf::join` correctly drops
+    /// `source` (absolute argument replaces the base).
+    #[test]
+    fn resolve_mount_src_expands_tilde_when_home_set() {
+        let source = Utf8Path::new("/dot");
+        let home = Utf8Path::new("/h/u");
+        assert_eq!(
+            resolve_mount_src_with(source, "~/private/home", Some(home)),
+            Utf8PathBuf::from("/h/u/private/home"),
+        );
+        assert_eq!(
+            resolve_mount_src_with(source, "~", Some(home)),
+            Utf8PathBuf::from("/h/u"),
+        );
+    }
+
+    /// Plain relative input keeps the historical "join under
+    /// source" behaviour.
+    #[test]
+    fn resolve_mount_src_relative_joins_under_source() {
+        let source = Utf8Path::new("/dot");
+        assert_eq!(
+            resolve_mount_src_with(source, "home", Some(Utf8Path::new("/h/u"))),
+            Utf8PathBuf::from("/dot/home"),
+        );
+    }
+
+    /// Absolute input is returned verbatim (Path::join with
+    /// absolute replaces the base).
+    #[test]
+    fn resolve_mount_src_absolute_returns_verbatim() {
+        let source = Utf8Path::new("/dot");
+        assert_eq!(
+            resolve_mount_src_with(source, "/abs/private/home", Some(Utf8Path::new("/h/u"))),
+            Utf8PathBuf::from("/abs/private/home"),
         );
     }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -40,6 +40,21 @@ pub fn home_dir() -> Option<Utf8PathBuf> {
         .map(Utf8PathBuf::from)
 }
 
+/// Resolve a `[[mount.entry]] src = "..."` value to an absolute
+/// path. `~` and `~/...` expand to the home directory; absolute
+/// inputs are returned verbatim (so a private clone at
+/// `~/.dotfiles-private/home` mounts directly without symlinking).
+/// Anything else is treated as relative to `source` (the dotfiles
+/// repo root) — the historical default.
+///
+/// Implementation detail: `Utf8PathBuf::join` already replaces the
+/// base with absolute arguments, so we just need `expand_tilde`
+/// first to handle the `~` form.
+pub fn resolve_mount_src(source: &Utf8Path, src: &str) -> Utf8PathBuf {
+    let expanded = expand_tilde(src);
+    source.join(expanded)
+}
+
 /// One-shot `.yuiignore` test for a single path under `source`.
 ///
 /// Builds a fresh `YuiIgnoreStack`, pushes every directory between


### PR DESCRIPTION
First half of the secret-management work — independent of secrets, useful on its own. Splitting the secret feature (PR-to-come) from this so the mount-src lift can land + ship without waiting on the crypto work.

## Why

`mount.entry.src` was always joined to `\$DOTFILES`, forcing any private / external dotfiles tree to live as a subdir or symlink under the main repo. Lifting that restriction unlocks the natural multi-repo layout (e.g. a separate private clone at `~/.dotfiles-private/`).

## What

- `mount::resolve` Tera-renders `src` (same context as `dst`) and routes through a new `paths::resolve_mount_src` helper that does tilde expansion + `Utf8PathBuf::join`. Absolute inputs survive verbatim; relative inputs land under `<source>/<src>` (historical default).
- `ResolvedMount.src` is now always absolute. `process_mount`, status's `classify_walk` setup, and `cmd::diff`'s walk drop their redundant `source.join(&m.src)`.
- `cmd::unmanaged` and `find_source_for_target` iterate raw `config.mount.entry` (deliberately — to include `when=false` mounts); both routed through `paths::resolve_mount_src` so they inherit the same handling.
- `cmd::list` keeps showing the user's raw `src` string in the table.

## Example

```toml
[[mount.entry]]
src = "~/.dotfiles-private/home"
dst = "~"
```

## Test plan

- [x] 154 unit tests passing (`absolute_src_is_returned_verbatim`, `src_renders_via_tera` added to mount.rs)
- [x] `cargo make check` (fmt + clippy `-D warnings` + locked check + tests)
- [x] Smoke: `apply` / `status` / `list` against author's real dotfiles still in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mount entry source paths now support Tera template rendering with `yui.*` variables and context tags.
  * Improved path resolution for mount sources with consistent handling of `~`, relative, and absolute paths.

* **Documentation**
  * Updated README with detailed documentation of `mount.entry.src` path resolution behavior and configuration example showing external private clones as mounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->