### PR TITLE
feat(secrets): age-encrypted *.age files in the apply pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,10 +2015,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2031,12 +2040,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -2456,6 +2478,15 @@ dependencies = [
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
@@ -2593,6 +2624,7 @@ dependencies = [
  "tera",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
  "whoami",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,59 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "age"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07d86e4272c093c88caf7864a2d09af52a5159180848ca4832a3cdbd7d014d5"
+dependencies = [
+ "age-core",
+ "base64",
+ "bech32",
+ "chacha20poly1305",
+ "cookie-factory",
+ "hmac",
+ "i18n-embed",
+ "i18n-embed-fl",
+ "lazy_static",
+ "nom",
+ "pin-project",
+ "rand",
+ "rust-embed",
+ "scrypt",
+ "sha2 0.10.9",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "age-core"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99"
+dependencies = [
+ "base64",
+ "chacha20poly1305",
+ "cookie-factory",
+ "hkdf",
+ "io_tee",
+ "nom",
+ "rand",
+ "secrecy",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +130,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +173,27 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bitflags"
@@ -179,6 +262,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +316,17 @@ dependencies = [
  "parse-zoneinfo",
  "phf",
  "phf_codegen",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -285,6 +403,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
+dependencies = [
+ "futures",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +480,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deunicode"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +525,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -383,6 +537,17 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
  "crypto-common 0.2.1",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -420,6 +585,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-crate"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+dependencies = [
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,16 +615,119 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash 1.1.0",
+ "self_cell 0.10.3",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -458,8 +741,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -544,6 +832,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "humansize"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +865,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "i18n-config"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef"
+dependencies = [
+ "basic-toml",
+ "log",
+ "serde",
+ "serde_derive",
+ "thiserror 1.0.69",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669ffc2c93f97e6ddf06ddbe999fcd6782e3342978bb85f7d3c087c7978404c4"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-langneg",
+ "fluent-syntax",
+ "i18n-embed-impl",
+ "intl-memoizer",
+ "log",
+ "parking_lot",
+ "rust-embed",
+ "thiserror 1.0.69",
+ "unic-langid",
+ "walkdir",
+]
+
+[[package]]
+name = "i18n-embed-fl"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04b2969d0b3fc6143776c535184c19722032b43e6a642d710fa3f88faec53c2d"
+dependencies = [
+ "find-crate",
+ "fluent",
+ "fluent-syntax",
+ "i18n-config",
+ "i18n-embed",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed-impl"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2"
+dependencies = [
+ "find-crate",
+ "i18n-config",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -631,6 +1003,40 @@ dependencies = [
  "unit-prefix",
  "web-time",
 ]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "io_tee"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -747,6 +1153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +1181,22 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -822,10 +1253,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "parse-zoneinfo"
@@ -834,6 +1294,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
 ]
 
 [[package]]
@@ -924,10 +1394,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -994,6 +1495,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,6 +1571,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1609,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2 0.10.9",
+ "walkdir",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1683,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1705,41 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "self_cell"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
+dependencies = [
+ "self_cell 1.2.2",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -1249,6 +1880,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,11 +1939,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1327,6 +1984,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "serde_core",
+ "zerovec",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1430,6 +2107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,6 +2126,25 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "serde",
+ "tinystr",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1470,6 +2175,16 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "utf8parse"
@@ -1840,9 +2555,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "yui-cli"
 version = "0.7.10"
 dependencies = [
+ "age",
  "anyhow",
  "assert_cmd",
  "assert_fs",
@@ -1863,8 +2591,8 @@ dependencies = [
  "similar",
  "tempfile",
  "tera",
- "thiserror",
- "toml",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "whoami",
@@ -1888,6 +2616,42 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "serde",
+ "zerofrom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ name = "yui"
 path = "src/lib.rs"
 
 [dependencies]
+age = "0.11.1"
 anyhow = "1.0.102"
 camino = { version = "1.2.2", features = ["serde1"] }
 clap = { version = "4.6.1", features = ["derive", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ similar = "3"
 tera = "1.20.1"
 thiserror = "2.0.18"
 toml = "1.1.2"
+toml_edit = "0.23"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 whoami = "2"

--- a/README.md
+++ b/README.md
@@ -230,6 +230,69 @@ shallower ones, `!negation` re-includes paths, and rules apply only to
 the subtree below the file. Put repo-wide rules at `$DOTFILES/.yuiignore`
 and per-tree rules where they belong.
 
+## Secrets (`*.age` — opt-in)
+
+Files ending in `.age` are encrypted with [age]; on every `apply` the
+ciphertext is decrypted to a sibling file without the suffix, exactly
+like `*.tera` rendering. The plaintext sibling is added to the managed
+`.gitignore` section so it never gets committed.
+
+```
+home/.ssh/id_ed25519.age   →  home/.ssh/id_ed25519   →  ~/.ssh/id_ed25519
+       ↑ committed                  ↑ gitignored               ↑ linked
+```
+
+### Bootstrap
+
+```sh
+yui secret init        # generates ~/.config/yui/age.txt
+                       # appends the public key to $DOTFILES/config.local.toml
+yui secret encrypt home/.ssh/id_ed25519
+                       # produces home/.ssh/id_ed25519.age, ready to commit
+```
+
+`config.toml` after `init`:
+
+```toml
+[secrets]
+identity = "~/.config/yui/age.txt"          # picked up automatically
+recipients = [
+  "age1abc...",   # this machine's public key
+  # add more entries to grant other machines access
+]
+```
+
+The feature is **off** until `recipients` has at least one entry — old
+repos without `[secrets]` keep behaving exactly as before.
+
+### Multi-machine
+
+age supports multiple recipients per file. To grant a new machine
+access:
+
+1. On the new machine: `yui secret init` → generates a per-machine key,
+   appends its public key to `config.local.toml` `[secrets].recipients`.
+   Move that public-key line to `config.toml` (the committed one) so
+   other machines see it too.
+2. On a machine that already has the secret: re-encrypt every `.age`
+   so its recipient list includes the new public key. (For now: run
+   `yui secret encrypt --force <path>` per file. A `yui secret reencrypt`
+   helper is planned.)
+
+### Roadmap: hardware MFA / passkey
+
+age has a plugin ecosystem (YubiKey, FIDO2 incl. Pixel 10 Pro
+cross-device passkeys, Touch ID via Secure Enclave, Windows Hello,
+TPM, 1Password). yui v1's identity / recipient parsing is X25519-only
+to keep the bootstrap flow simple, but the data model is plugin-ready;
+plugin support (with the callback plumbing those interactive flows
+need) is planned as a follow-up. Until then you can interoperate at
+the file level by encrypting `.age` files outside yui via `rage` /
+`age-plugin-*` and committing them — yui's X25519 identity can still
+decrypt files that were also wrapped to your X25519 recipient.
+
+[age]: https://age-encryption.org/
+
 ## Hooks — run scripts around `apply`
 
 Drop a script under `$DOTFILES/.yui/bin/` and reference it with a

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,6 +195,12 @@ pub enum Command {
         no_color: bool,
     },
 
+    /// Manage secret files (`*.age`, encrypted with age).
+    Secret {
+        #[command(subcommand)]
+        action: SecretAction,
+    },
+
     /// Generate shell completion script for `<shell>` to stdout.
     ///
     /// Pipe into the right place for your shell, e.g.
@@ -204,6 +210,36 @@ pub enum Command {
     Completion {
         /// Target shell (bash / zsh / fish / powershell / elvish).
         shell: Shell,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SecretAction {
+    /// Generate an X25519 keypair, write the secret to
+    /// `[secrets] identity` (`~/.config/yui/age.txt` by default),
+    /// and append the public key to `[secrets] recipients` in
+    /// `$DOTFILES/config.local.toml`. Idempotent — refuses to
+    /// overwrite an existing identity file.
+    Init {
+        /// Append a comment block above the new recipient entry
+        /// (defaults to "<host> <user>" — yui.host / yui.user).
+        #[arg(long, value_name = "TEXT")]
+        comment: Option<String>,
+    },
+    /// Read `<path>` (absolute or relative to `$DOTFILES`) as
+    /// plaintext, encrypt it to every recipient in
+    /// `[secrets] recipients`, and write the ciphertext as
+    /// `<path>.age` next to it. Refuses to clobber an existing
+    /// `.age` without `--force`.
+    Encrypt {
+        path: Utf8PathBuf,
+        /// Replace an existing `<path>.age`.
+        #[arg(long)]
+        force: bool,
+        /// Delete the plaintext after a successful encryption
+        /// (only works when the plaintext lives under `$DOTFILES`).
+        #[arg(long)]
+        rm_plaintext: bool,
     },
 }
 
@@ -265,6 +301,14 @@ impl Cli {
             Command::Update { dry_run } => cmd::update(source, dry_run),
             Command::Unmanaged { icons, no_color } => cmd::unmanaged(source, icons, no_color),
             Command::Diff { icons, no_color } => cmd::diff(source, icons, no_color),
+            Command::Secret { action } => match action {
+                SecretAction::Init { comment } => cmd::secret_init(source, comment),
+                SecretAction::Encrypt {
+                    path,
+                    force,
+                    rm_plaintext,
+                } => cmd::secret_encrypt(source, path, force, rm_plaintext),
+            },
             Command::Completion { shell } => {
                 let mut cmd = Cli::command();
                 clap_complete::generate(shell, &mut cmd, "yui", &mut std::io::stdout());

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -238,19 +238,16 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
         );
     }
 
-    // 1c. Both pipelines write sibling files; their union goes in
-    //     the `.gitignore` managed section. `render::render_all`
-    //     already wrote the section once with its own paths;
-    //     re-write with the combined set so age plaintext files
-    //     are also covered.
+    // 1c. Single deterministic write of the `.gitignore` managed
+    //     section, covering both `*.tera` outputs and `*.age`
+    //     plaintext siblings. (Earlier this was two writes — once
+    //     inside `render_all`, once here — which made the managed
+    //     section flicker if a reader read between them. PR #57
+    //     review caught it; render_all no longer touches gitignore.)
     if !dry_run && config.render.manage_gitignore {
-        let mut managed: Vec<Utf8PathBuf> = render_report
-            .written
-            .iter()
-            .chain(render_report.unchanged.iter())
-            .chain(render_report.diverged.iter())
-            .chain(secret_report.managed_paths())
-            .cloned()
+        let mut managed: Vec<Utf8PathBuf> = render::report_managed_paths(&render_report)
+            .into_iter()
+            .chain(secret_report.managed_paths().cloned())
             .collect();
         managed.sort();
         managed.dedup();
@@ -650,8 +647,17 @@ pub fn render(source: Option<Utf8PathBuf>, check: bool, dry_run: bool) -> Result
     let yui = YuiVars::detect(&source);
     let config = config::load(&source, &yui)?;
     // --check is a stricter dry-run: never writes, exits non-zero on drift.
-    let report = render::render_all(&source, &config, &yui, dry_run || check)?;
+    let effective_dry_run = dry_run || check;
+    let report = render::render_all(&source, &config, &yui, effective_dry_run)?;
     log_render_report(&report);
+    // Stand-alone `yui render` has no secrets pipeline running
+    // alongside, so the managed section here just covers `*.tera`
+    // outputs. (Use `yui apply` if you need both rendered AND
+    // decrypted siblings to land in the same write.)
+    if !effective_dry_run && config.render.manage_gitignore {
+        let managed = render::report_managed_paths(&report);
+        render::write_managed_section(&source, &managed)?;
+    }
     if check && report.has_drift() {
         anyhow::bail!("render drift detected ({} file(s))", report.diverged.len());
     }
@@ -723,13 +729,13 @@ pub fn secret_init(source: Option<Utf8PathBuf>, comment: Option<String>) -> Resu
     //    is the per-machine layer the user explicitly owns.
     let local_path = source.join("config.local.toml");
     let comment = comment.unwrap_or_else(|| format!("{} {}", yui.host, yui.user));
-    let entry = format!("\n# {comment}\n# (added by `yui secret init` on {now})\n");
+    let entry_comment = format!("{comment} — added by `yui secret init` on {now}");
     let local_existing = match std::fs::read_to_string(&local_path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
         Err(e) => anyhow::bail!("read {local_path}: {e}"),
     };
-    let updated_local = append_recipient_to_local(&local_existing, &entry, &public);
+    let updated_local = append_recipient_to_local(&local_existing, &entry_comment, &public)?;
     std::fs::write(&local_path, updated_local)?;
     info!("appended public key to {local_path}");
     println!();
@@ -743,47 +749,68 @@ pub fn secret_init(source: Option<Utf8PathBuf>, comment: Option<String>) -> Resu
     Ok(())
 }
 
-/// Append a `recipient = "..."` entry to the user's
-/// `config.local.toml`, creating a `[secrets]` table header on
-/// the way if it isn't there yet. Idempotent in the sense of
-/// "doesn't double-write the same key" — but only when called
-/// with the same `public` string twice. The caller (`secret_init`)
-/// generates a fresh keypair every time, so this isn't load-
-/// bearing in normal use.
-fn append_recipient_to_local(existing: &str, comment_block: &str, public: &str) -> String {
-    if existing.contains(public) {
-        return existing.to_string();
-    }
-    let mut out = existing.to_string();
-    if !out.is_empty() && !out.ends_with('\n') {
-        out.push('\n');
-    }
-    if !out.contains("[secrets]") {
-        if !out.is_empty() {
-            out.push('\n');
-        }
-        out.push_str("[secrets]\n");
-        out.push_str("recipients = [\n");
-        out.push_str(comment_block);
-        out.push_str(&format!("  \"{public}\",\n"));
-        out.push_str("]\n");
+/// Append a recipient entry to the user's `config.local.toml`.
+///
+/// Uses `toml_edit` to parse the file into an in-memory document
+/// tree, modify the `[secrets].recipients` array, then serialise
+/// back. This preserves user comments / spacing / table ordering,
+/// and survives quirky inputs (other tables after `[secrets]`,
+/// trailing comments, multi-line arrays, etc.) — string-pasting
+/// the same shape used to land tokens in the wrong place when the
+/// file's layout deviated from the most common case. (Caught in
+/// PR #57 review by gemini-code-assist.)
+///
+/// Returns the file unchanged when the public key is already in
+/// the recipients list (idempotent re-init).
+fn append_recipient_to_local(existing: &str, comment: &str, public: &str) -> Result<String> {
+    use toml_edit::{Array, DocumentMut, Item, Table, Value};
+
+    let mut doc: DocumentMut = if existing.trim().is_empty() {
+        DocumentMut::new()
     } else {
-        // Crude but adequate: the user's config.local.toml usually
-        // has only the `[secrets]` table near the bottom. Insert
-        // a new entry right after the line that opens the array.
-        let needle = "recipients = [";
-        if let Some(idx) = out.find(needle) {
-            let insertion = idx + needle.len();
-            let before = &out[..insertion];
-            let after = &out[insertion..];
-            out = format!("{before}{comment_block}  \"{public}\",\n{after}");
-        } else {
-            // `[secrets]` exists but no `recipients = [...]` array yet.
-            out.push_str(comment_block);
-            out.push_str(&format!("recipients = [\"{public}\"]\n"));
-        }
+        existing
+            .parse()
+            .map_err(|e| anyhow::anyhow!("config.local.toml is not valid TOML: {e}"))?
+    };
+
+    // Make sure `[secrets]` exists as a table.
+    if !doc.contains_key("secrets") {
+        let mut t = Table::new();
+        t.set_implicit(false);
+        doc.insert("secrets", Item::Table(t));
     }
-    out
+    let secrets = doc["secrets"].as_table_mut().ok_or_else(|| {
+        anyhow::anyhow!("[secrets] in config.local.toml is not a table — refusing to clobber")
+    })?;
+
+    // Make sure `recipients` is an array.
+    if !secrets.contains_key("recipients") {
+        secrets.insert("recipients", Item::Value(Value::Array(Array::new())));
+    }
+    let recipients = secrets["recipients"]
+        .as_array_mut()
+        .ok_or_else(|| anyhow::anyhow!("[secrets].recipients is not an array"))?;
+
+    // Idempotent: if the public key already appears, we're done.
+    let already_present = recipients.iter().any(|v| v.as_str() == Some(public));
+    if already_present {
+        return Ok(doc.to_string());
+    }
+
+    // Append the new entry with a leading-comment decor block so
+    // the user can tell which key belongs to which machine just by
+    // reading the file.
+    let mut value = Value::from(public);
+    let prefix = format!("\n  # {comment}\n  ");
+    *value.decor_mut() = toml_edit::Decor::new(prefix, "");
+    recipients.push_formatted(value);
+    // Force the array onto multiple lines so the comments above
+    // entries actually have a place to live (a single-line array
+    // can't carry per-element comments).
+    recipients.set_trailing("\n");
+    recipients.set_trailing_comma(true);
+
+    Ok(doc.to_string())
 }
 
 /// `yui secret encrypt <path> [--force] [--rm-plaintext]` — encrypt
@@ -4994,6 +5021,83 @@ recipients = ["{}"]
             format!("{err:#}").contains("secret drift"),
             "expected secret drift error, got: {err:#}"
         );
+    }
+
+    // -- append_recipient_to_local (PR #57 review: toml_edit) --
+
+    #[test]
+    fn append_recipient_creates_secrets_table_when_missing() {
+        let result =
+            append_recipient_to_local("", "host alice", "age1abcrecipientpublickey").unwrap();
+        // Round-trip parse — must be valid TOML.
+        let parsed: toml::Table = toml::from_str(&result).unwrap();
+        let secrets = parsed.get("secrets").and_then(|v| v.as_table()).unwrap();
+        let recipients = secrets
+            .get("recipients")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(recipients.len(), 1);
+        assert_eq!(recipients[0].as_str(), Some("age1abcrecipientpublickey"));
+    }
+
+    #[test]
+    fn append_recipient_preserves_existing_other_tables() {
+        // Crude string-pasting used to put a new recipient in the
+        // wrong place when other tables followed `[secrets]`.
+        // toml_edit handles arbitrary table ordering.
+        let existing = r#"
+[vars]
+greet = "hi"
+
+[secrets]
+recipients = ["age1machine_a"]
+
+[ui]
+icons = "ascii"
+"#;
+        let result = append_recipient_to_local(existing, "host b", "age1machine_b").unwrap();
+        let parsed: toml::Table = toml::from_str(&result).unwrap();
+        // All three tables still there.
+        assert!(parsed.get("vars").is_some());
+        assert!(parsed.get("secrets").is_some());
+        assert!(parsed.get("ui").is_some());
+        // Both recipients in the array.
+        let recipients = parsed["secrets"]["recipients"].as_array().unwrap();
+        assert_eq!(recipients.len(), 2);
+        let pubs: Vec<&str> = recipients.iter().filter_map(|v| v.as_str()).collect();
+        assert!(pubs.contains(&"age1machine_a"));
+        assert!(pubs.contains(&"age1machine_b"));
+    }
+
+    #[test]
+    fn append_recipient_is_idempotent_on_duplicate() {
+        let existing = r#"[secrets]
+recipients = ["age1same"]
+"#;
+        let result = append_recipient_to_local(existing, "anyone", "age1same").unwrap();
+        let parsed: toml::Table = toml::from_str(&result).unwrap();
+        let recipients = parsed["secrets"]["recipients"].as_array().unwrap();
+        assert_eq!(recipients.len(), 1, "duplicate must not be appended twice");
+    }
+
+    #[test]
+    fn append_recipient_creates_recipients_array_when_secrets_table_empty() {
+        // `[secrets]` exists but no recipients yet (e.g. user hand-
+        // initialised a different field first).
+        let existing = r#"[secrets]
+identity = "~/.config/yui/age.txt"
+"#;
+        let result = append_recipient_to_local(existing, "h", "age1new").unwrap();
+        let parsed: toml::Table = toml::from_str(&result).unwrap();
+        let secrets = parsed["secrets"].as_table().unwrap();
+        assert_eq!(
+            secrets["identity"].as_str(),
+            Some("~/.config/yui/age.txt"),
+            "existing identity field must survive"
+        );
+        let recipients = secrets["recipients"].as_array().unwrap();
+        assert_eq!(recipients.len(), 1);
+        assert_eq!(recipients[0].as_str(), Some("age1new"));
     }
 
     /// Secrets feature is opt-in: an empty `[secrets] recipients`

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -16,6 +16,7 @@ use crate::link::{self, EffectiveDirMode, EffectiveFileMode, resolve_dir_mode, r
 use crate::marker::{self, MarkerSpec};
 use crate::mount::{self, ResolvedMount};
 use crate::render::{self, RenderReport};
+use crate::secret;
 use crate::template;
 use crate::vars::YuiVars;
 use crate::{absorb, backup, paths};
@@ -211,7 +212,23 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
         dry_run,
     )?;
 
-    // 1. Render templates first so the link walk picks up rendered files.
+    // 1a. Decrypt `*.age` files first — the rendered templates
+    //     might `{{ ... }}`-reference plaintext siblings indirectly
+    //     (via env vars set by hooks), and even when they don't,
+    //     decrypting first keeps the order of "physical sibling
+    //     files appear" predictable.
+    let secret_report = secret::decrypt_all(&source, &config, dry_run)?;
+    log_secret_report(&secret_report);
+    if secret_report.has_drift() {
+        anyhow::bail!(
+            "secret drift detected ({} file(s)); the plaintext sibling diverged \
+             from the canonical .age — run `yui secret encrypt <path>` to roll \
+             the edit back into ciphertext before re-running apply",
+            secret_report.diverged.len()
+        );
+    }
+
+    // 1b. Render templates so the link walk picks up rendered files.
     let render_report = render::render_all(&source, &config, &yui, dry_run)?;
     log_render_report(&render_report);
     if render_report.has_drift() {
@@ -219,6 +236,25 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
             "render drift detected ({} file(s)); reflect target edits back into the .tera before re-running apply",
             render_report.diverged.len()
         );
+    }
+
+    // 1c. Both pipelines write sibling files; their union goes in
+    //     the `.gitignore` managed section. `render::render_all`
+    //     already wrote the section once with its own paths;
+    //     re-write with the combined set so age plaintext files
+    //     are also covered.
+    if !dry_run && config.render.manage_gitignore {
+        let mut managed: Vec<Utf8PathBuf> = render_report
+            .written
+            .iter()
+            .chain(render_report.unchanged.iter())
+            .chain(render_report.diverged.iter())
+            .chain(secret_report.managed_paths())
+            .cloned()
+            .collect();
+        managed.sort();
+        managed.dedup();
+        render::write_managed_section(&source, &managed)?;
     }
 
     // 2. Resolve mounts and link.
@@ -289,6 +325,18 @@ fn log_render_report(r: &RenderReport) {
     }
     for d in &r.diverged {
         warn!("rendered file diverged from template: {d}");
+    }
+}
+
+fn log_secret_report(r: &secret::SecretReport) {
+    if !r.written.is_empty() {
+        info!("decrypted {} secret file(s)", r.written.len());
+    }
+    if !r.unchanged.is_empty() {
+        info!("decrypted {} secret(s) unchanged", r.unchanged.len());
+    }
+    for d in &r.diverged {
+        warn!("plaintext sibling diverged from .age: {d}");
     }
 }
 
@@ -624,6 +672,179 @@ pub fn unlink(source: Option<Utf8PathBuf>, paths_arg: Vec<Utf8PathBuf>) -> Resul
         let abs = absolutize(&p)?;
         info!("unlink: {abs}");
         link::unlink(&abs)?;
+    }
+    Ok(())
+}
+
+/// `yui secret init [--comment TEXT]` — generate an age X25519
+/// keypair on this machine, write the secret to the configured
+/// identity path, and append the public key to
+/// `$DOTFILES/config.local.toml` `[secrets] recipients`.
+///
+/// `config.local.toml` is the right place because it's
+/// machine-local and gitignored — committing per-machine recipient
+/// keys to the public repo is fine in principle (recipients are
+/// public information) but the convention has the keys live in
+/// the local file alongside other host-specific config.
+pub fn secret_init(source: Option<Utf8PathBuf>, comment: Option<String>) -> Result<()> {
+    let source = resolve_source(source)?;
+    let yui = YuiVars::detect(&source);
+    let config = config::load(&source, &yui)?;
+
+    // 1. Resolve identity path (default: ~/.config/yui/age.txt).
+    let identity_path = paths::expand_tilde(&config.secrets.identity);
+    if identity_path.exists() {
+        anyhow::bail!(
+            "identity file already exists at {identity_path}; \
+             refusing to overwrite. Delete it first if you really \
+             mean to start fresh (you'll lose access to existing \
+             .age files encrypted to its public key)."
+        );
+    }
+
+    // 2. Generate the keypair + serialise the identity file with
+    //    the same header age-keygen uses, so the file is
+    //    interoperable with the standalone CLI tools.
+    let (secret, public) = secret::generate_x25519_keypair();
+    if let Some(parent) = identity_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let now = jiff::Zoned::now().to_string();
+    let body = format!(
+        "# created: {now}\n\
+         # public key: {public}\n\
+         {secret}\n"
+    );
+    std::fs::write(&identity_path, body)?;
+    info!("wrote identity file: {identity_path}");
+
+    // 3. Append the public key to `[secrets] recipients` in
+    //    config.local.toml — appending is safe because that file
+    //    is the per-machine layer the user explicitly owns.
+    let local_path = source.join("config.local.toml");
+    let comment = comment.unwrap_or_else(|| format!("{} {}", yui.host, yui.user));
+    let entry = format!("\n# {comment}\n# (added by `yui secret init` on {now})\n");
+    let local_existing = match std::fs::read_to_string(&local_path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => anyhow::bail!("read {local_path}: {e}"),
+    };
+    let updated_local = append_recipient_to_local(&local_existing, &entry, &public);
+    std::fs::write(&local_path, updated_local)?;
+    info!("appended public key to {local_path}");
+    println!();
+    println!("  age identity:  {identity_path}");
+    println!("  public key:    {public}");
+    println!();
+    println!(
+        "  Next: encrypt a file with `yui secret encrypt <path>`. \
+         The plaintext sibling will be auto-decrypted on every `yui apply`."
+    );
+    Ok(())
+}
+
+/// Append a `recipient = "..."` entry to the user's
+/// `config.local.toml`, creating a `[secrets]` table header on
+/// the way if it isn't there yet. Idempotent in the sense of
+/// "doesn't double-write the same key" — but only when called
+/// with the same `public` string twice. The caller (`secret_init`)
+/// generates a fresh keypair every time, so this isn't load-
+/// bearing in normal use.
+fn append_recipient_to_local(existing: &str, comment_block: &str, public: &str) -> String {
+    if existing.contains(public) {
+        return existing.to_string();
+    }
+    let mut out = existing.to_string();
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    if !out.contains("[secrets]") {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str("[secrets]\n");
+        out.push_str("recipients = [\n");
+        out.push_str(comment_block);
+        out.push_str(&format!("  \"{public}\",\n"));
+        out.push_str("]\n");
+    } else {
+        // Crude but adequate: the user's config.local.toml usually
+        // has only the `[secrets]` table near the bottom. Insert
+        // a new entry right after the line that opens the array.
+        let needle = "recipients = [";
+        if let Some(idx) = out.find(needle) {
+            let insertion = idx + needle.len();
+            let before = &out[..insertion];
+            let after = &out[insertion..];
+            out = format!("{before}{comment_block}  \"{public}\",\n{after}");
+        } else {
+            // `[secrets]` exists but no `recipients = [...]` array yet.
+            out.push_str(comment_block);
+            out.push_str(&format!("recipients = [\"{public}\"]\n"));
+        }
+    }
+    out
+}
+
+/// `yui secret encrypt <path> [--force] [--rm-plaintext]` — encrypt
+/// a plaintext file to every recipient in `[secrets] recipients`
+/// and write the ciphertext alongside as `<path>.age`.
+pub fn secret_encrypt(
+    source: Option<Utf8PathBuf>,
+    path: Utf8PathBuf,
+    force: bool,
+    rm_plaintext: bool,
+) -> Result<()> {
+    let source = resolve_source(source)?;
+    let yui = YuiVars::detect(&source);
+    let config = config::load(&source, &yui)?;
+
+    if !config.secrets.enabled() {
+        anyhow::bail!(
+            "no recipients configured — run `yui secret init` to generate \
+             a keypair, or add at least one entry to `[secrets] recipients`."
+        );
+    }
+
+    // Resolve the plaintext path: absolute as-is, relative against
+    // CWD (so the user can `yui secret encrypt home/.ssh/id_ed25519`
+    // from inside `$DOTFILES`).
+    let plaintext_path = if path.is_absolute() {
+        path.clone()
+    } else {
+        absolutize(&path)?
+    };
+    if !plaintext_path.is_file() {
+        anyhow::bail!("plaintext file not found: {plaintext_path}");
+    }
+    let cipher_path = Utf8PathBuf::from(format!("{plaintext_path}.age"));
+    if cipher_path.exists() && !force {
+        anyhow::bail!("{cipher_path} already exists; pass --force to overwrite");
+    }
+
+    let plaintext = std::fs::read(&plaintext_path)?;
+    let recipients: Vec<age::x25519::Recipient> = config
+        .secrets
+        .recipients
+        .iter()
+        .map(|s| secret::parse_recipient(s))
+        .collect::<crate::Result<_>>()?;
+    let cipher = secret::encrypt(&plaintext, &recipients)?;
+    std::fs::write(&cipher_path, &cipher)?;
+    info!("encrypted {plaintext_path} → {cipher_path}");
+
+    if rm_plaintext {
+        // Only remove plaintext when it lives under `$DOTFILES` —
+        // erasing files outside the repo on a typo would be cruel.
+        if plaintext_path.starts_with(&source) {
+            std::fs::remove_file(&plaintext_path)?;
+            info!("removed plaintext: {plaintext_path}");
+        } else {
+            warn!(
+                "plaintext lives outside source ({plaintext_path}); \
+                 skipping --rm-plaintext as a safety check"
+            );
+        }
     }
     Ok(())
 }
@@ -4667,6 +4888,128 @@ dst = "{}"
         assert!(!source.join("home/note").exists());
         assert!(!target.join("note").exists());
         assert!(!target.join("note.tera").exists());
+    }
+
+    // -----------------------------------------------------------------
+    // secrets (age) end-to-end
+    // -----------------------------------------------------------------
+
+    /// `yui apply` decrypts every `*.age` to its sibling and the
+    /// sibling lands in target as a regular file. The plaintext is
+    /// also added to the managed `.gitignore` section so it doesn't
+    /// get committed.
+    #[test]
+    fn apply_decrypts_age_files_to_sibling_and_links() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        let target = utf8(tmp.path().join("target"));
+        std::fs::create_dir_all(source.join("home/.ssh")).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+
+        // 1. Generate a keypair, write identity file inside the test
+        //    sandbox so we don't touch the user's real `~/.config/yui/`.
+        let identity_path = utf8(tmp.path().join("age.txt"));
+        let (secret, public) = secret::generate_x25519_keypair();
+        std::fs::write(&identity_path, format!("{secret}\n")).unwrap();
+
+        // 2. Encrypt a fake private key into source as `.age`.
+        let recipient = secret::parse_recipient(&public).unwrap();
+        let cipher = secret::encrypt(b"-- super secret key --\n", &[recipient]).unwrap();
+        std::fs::write(source.join("home/.ssh/id_ed25519.age"), &cipher).unwrap();
+
+        // 3. config.toml: mount + secrets pointing at the test identity.
+        let cfg = format!(
+            r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+
+[secrets]
+identity = "{}"
+recipients = ["{}"]
+"#,
+            toml_path(&target),
+            toml_path(&identity_path),
+            public
+        );
+        std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+        apply(Some(source.clone()), false).unwrap();
+
+        // Plaintext sibling appeared.
+        assert!(source.join("home/.ssh/id_ed25519").exists());
+        // Target got the linked file with decrypted content.
+        let target_bytes = std::fs::read(target.join(".ssh/id_ed25519")).unwrap();
+        assert_eq!(target_bytes, b"-- super secret key --\n");
+        // Plaintext path is in the managed .gitignore section.
+        let gi = std::fs::read_to_string(source.join(".gitignore")).unwrap();
+        assert!(
+            gi.contains("home/.ssh/id_ed25519"),
+            ".gitignore should list the decrypted plaintext sibling: {gi}"
+        );
+        // The .age ciphertext is the canonical, NOT in the managed list.
+        // (It's expected to be committed normally.)
+    }
+
+    /// `yui apply` bails when the on-disk plaintext sibling has
+    /// drifted from the canonical `.age`. Mirrors render-drift
+    /// semantics: the user must run `yui secret encrypt` to roll
+    /// the change back into ciphertext before re-running apply.
+    #[test]
+    fn apply_bails_on_secret_drift() {
+        let tmp = TempDir::new().unwrap();
+        let source = utf8(tmp.path().join("dotfiles"));
+        let target = utf8(tmp.path().join("target"));
+        std::fs::create_dir_all(source.join("home")).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+
+        let identity_path = utf8(tmp.path().join("age.txt"));
+        let (secret_key, public) = secret::generate_x25519_keypair();
+        std::fs::write(&identity_path, format!("{secret_key}\n")).unwrap();
+
+        let recipient = secret::parse_recipient(&public).unwrap();
+        let cipher = secret::encrypt(b"v1 content\n", &[recipient]).unwrap();
+        std::fs::write(source.join("home/secret.age"), &cipher).unwrap();
+        // Drifted sibling: plaintext exists but doesn't match the .age content.
+        std::fs::write(source.join("home/secret"), "edited locally\n").unwrap();
+
+        let cfg = format!(
+            r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+
+[secrets]
+identity = "{}"
+recipients = ["{}"]
+"#,
+            toml_path(&target),
+            toml_path(&identity_path),
+            public
+        );
+        std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+        let err = apply(Some(source.clone()), false).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("secret drift"),
+            "expected secret drift error, got: {err:#}"
+        );
+    }
+
+    /// Secrets feature is opt-in: an empty `[secrets] recipients`
+    /// list keeps `decrypt_all` a no-op so existing repos behave
+    /// exactly as before this PR.
+    #[test]
+    fn apply_without_recipients_skips_secret_walker() {
+        let tmp = TempDir::new().unwrap();
+        let (source, _target) = setup_minimal_dotfiles(&tmp);
+        // No `[secrets]` block at all.
+        std::fs::write(source.join("home/.bashrc"), "x").unwrap();
+        // A stray `.age` file with no recipients configured: walker
+        // shouldn't even open it (no identity loaded → no decrypt
+        // attempt → no error).
+        std::fs::write(source.join("home/some.junk.age"), b"not actually a cipher").unwrap();
+        apply(Some(source.clone()), false).unwrap();
     }
 
     /// v0.6+: parent `.yuilink` doesn't stop the walker. A parent

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,9 @@ pub struct Config {
 
     #[serde(default)]
     pub hook: Vec<HookConfig>,
+
+    #[serde(default)]
+    pub secrets: SecretsConfig,
 }
 
 /// One hook = one script invocation triggered around `yui apply`.
@@ -272,6 +275,49 @@ impl Default for BackupConfig {
 
 fn default_backup_dir() -> String {
     ".yui/backup".to_string()
+}
+
+/// `[secrets]` — wires the age encryption pipeline into apply.
+///
+/// `identity` is the path to your local age secret key file (NOT
+/// committed). `recipients` is the public-key list every new
+/// encryption is wrapped to — at minimum, the public key matching
+/// `identity`, and any additional machines / users that should
+/// also be able to decrypt. yui defaults the identity path to
+/// `~/.config/yui/age.txt` and treats an empty `recipients` list
+/// as "secrets feature off".
+#[derive(Debug, Clone, Deserialize)]
+pub struct SecretsConfig {
+    #[serde(default = "default_identity_path")]
+    pub identity: String,
+    #[serde(default)]
+    pub recipients: Vec<String>,
+}
+
+impl Default for SecretsConfig {
+    fn default() -> Self {
+        Self {
+            identity: default_identity_path(),
+            recipients: Vec::new(),
+        }
+    }
+}
+
+impl SecretsConfig {
+    /// `[secrets]` is "on" once the user has populated `recipients`
+    /// (which `yui secret init` does). Until then, the apply walker
+    /// won't even look for `*.age` files — keeps every existing
+    /// dotfiles repo behaving exactly the same as before this PR.
+    pub fn enabled(&self) -> bool {
+        !self.recipients.is_empty()
+    }
+}
+
+fn default_identity_path() -> String {
+    // Cross-platform `~/.config/yui/age.txt` — `paths::expand_tilde`
+    // turns `~` into `$HOME` / `$USERPROFILE` at use time so the
+    // string stays portable across machines.
+    "~/.config/yui/age.txt".to_string()
 }
 
 fn default_ts_format() -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod marker;
 pub mod mount;
 pub mod paths;
 pub mod render;
+pub mod secret;
 pub mod template;
 pub mod vars;
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -98,10 +98,17 @@ pub fn render_all(
         )?;
     }
 
-    if !dry_run && config.render.manage_gitignore {
-        update_gitignore(source, &collect_managed_paths(&report))?;
-    }
     Ok(report)
+}
+
+/// Every `*.tera` output path the report knows about — written /
+/// unchanged / diverged. The apply orchestrator unions this with
+/// the secret pipeline's plaintext outputs to drive a single
+/// `write_managed_section` call (rather than render writing one
+/// list of paths and secrets immediately overwriting it with a
+/// different one). PR #57 review.
+pub fn report_managed_paths(report: &RenderReport) -> Vec<Utf8PathBuf> {
+    collect_managed_paths(report)
 }
 
 /// Render a single template and return the body it would produce
@@ -580,7 +587,11 @@ mod tests {
         let r = root(&tmp);
         write(&r.join("home/foo.tera"), "body");
         write(&r.join("home/bar.tera"), "body2");
-        let _ = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        // PR #57: render_all no longer manages .gitignore as a
+        // side effect; callers (apply / cmd::render) drive the
+        // single deterministic write.
+        write_managed_section(&r, &report_managed_paths(&report)).unwrap();
         let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
         assert!(gi.contains(GITIGNORE_BEGIN));
         assert!(gi.contains(GITIGNORE_END));
@@ -598,7 +609,8 @@ mod tests {
         let r = root(&tmp);
         write(&r.join(".gitignore"), "node_modules/\ntarget/\n");
         write(&r.join("home/foo.tera"), "body");
-        let _ = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        write_managed_section(&r, &report_managed_paths(&report)).unwrap();
         let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
         assert!(gi.contains("node_modules/"));
         assert!(gi.contains("target/"));
@@ -615,7 +627,8 @@ mod tests {
             &format!("node_modules/\n\n{GITIGNORE_BEGIN}\nstale/path\n{GITIGNORE_END}\n\nfoo\n"),
         );
         write(&r.join("home/foo.tera"), "body");
-        let _ = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        let report = render_all(&r, &empty_config(), &yui_vars(&r), false).unwrap();
+        write_managed_section(&r, &report_managed_paths(&report)).unwrap();
         let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
         assert!(gi.contains("node_modules/"));
         assert!(gi.contains("home/foo"));

--- a/src/render.rs
+++ b/src/render.rs
@@ -303,6 +303,18 @@ fn collect_managed_paths(report: &RenderReport) -> Vec<Utf8PathBuf> {
     all
 }
 
+/// Write or replace yui's managed `.gitignore` section in the
+/// repo root, listing every absolute path the apply pipeline
+/// produced as a sibling-without-suffix (rendered `.tera` outputs
+/// AND decrypted `.age` outputs share this section). The block is
+/// delimited by `# >>> yui rendered (auto-managed) >>>` /
+/// `# <<< yui rendered (auto-managed) <<<` so successive runs
+/// idempotently rewrite it without disturbing user content above
+/// or below.
+pub fn write_managed_section(source: &Utf8Path, managed_abs_paths: &[Utf8PathBuf]) -> Result<()> {
+    update_gitignore(source, managed_abs_paths)
+}
+
 fn update_gitignore(source: &Utf8Path, rendered_abs_paths: &[Utf8PathBuf]) -> Result<()> {
     let gi_path = source.join(".gitignore");
     let existing = match std::fs::read_to_string(&gi_path) {

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,0 +1,355 @@
+//! age-based file encryption for the secrets pipeline.
+//!
+//! `*.age` files in source are decrypted to a sibling without the
+//! `.age` suffix on every `apply`, and the sibling lands in the
+//! managed `# >>> yui rendered <<<` section of `.gitignore` so the
+//! plaintext never gets committed. From the apply walker's
+//! perspective the sibling is just another regular file — link it
+//! to target like any other dotfile.
+//!
+//! ## Why a separate module from `render.rs`
+//!
+//! `*.tera` and `*.age` both produce a sibling-without-suffix and
+//! both wire that sibling through the `.gitignore` managed section,
+//! but they're different operations: rendering needs Tera contexts
+//! and yui-when headers; decryption needs an age identity file and
+//! recipient validation. Keeping `secret::*` self-contained also
+//! means the crypto stays out of `render.rs`, which a casual
+//! reader expects to be pure-text manipulation.
+//!
+//! ## v1 scope: X25519 only
+//!
+//! `[secrets] identity` is an X25519 secret (`AGE-SECRET-KEY-1…`)
+//! and `recipients = […]` are X25519 public keys (`age1…`).
+//! `yui secret init` produces both.
+//!
+//! Plugin-backed identities (YubiKey / FIDO2 passkey / Touch ID /
+//! TPM / 1Password) need age's `plugin` feature plus callback
+//! plumbing to drive the plugin binaries' interactive prompts —
+//! a worthwhile follow-up but real implementation work, kept out
+//! of v1 to ship the simple flow first.
+
+use std::io::{Read as _, Write as _};
+use std::str::FromStr as _;
+
+use age::secrecy::ExposeSecret as _;
+use camino::Utf8Path;
+
+use crate::{Error, Result};
+
+/// Load an age X25519 identity from `path`. The file is expected
+/// to be the output of `age-keygen` / `yui secret init`: lines
+/// beginning with `#` are comments, the first non-comment line is
+/// the `AGE-SECRET-KEY-1…` secret.
+pub fn load_identity(path: &Utf8Path) -> Result<age::x25519::Identity> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| Error::Other(anyhow::anyhow!("read identity {path}: {e}")))?;
+    let line = raw
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with('#'))
+        .ok_or_else(|| {
+            Error::Other(anyhow::anyhow!(
+                "identity file {path} contains no key (only comments / blank lines)"
+            ))
+        })?;
+
+    age::x25519::Identity::from_str(line).map_err(|e| {
+        Error::Other(anyhow::anyhow!(
+            "identity file {path} is not a valid age X25519 secret \
+             (expected `AGE-SECRET-KEY-1…`): {e}"
+        ))
+    })
+}
+
+/// Parse an X25519 recipient string (`age1…`).
+pub fn parse_recipient(s: &str) -> Result<age::x25519::Recipient> {
+    let trimmed = s.trim();
+    age::x25519::Recipient::from_str(trimmed).map_err(|e| {
+        Error::Other(anyhow::anyhow!(
+            "not a valid age X25519 recipient {trimmed:?}: {e}"
+        ))
+    })
+}
+
+/// Encrypt `plaintext` to one or more recipients. The output is
+/// the binary age format (the same bytes a `*.age` file holds on
+/// disk).
+pub fn encrypt(plaintext: &[u8], recipients: &[age::x25519::Recipient]) -> Result<Vec<u8>> {
+    if recipients.is_empty() {
+        return Err(Error::Other(anyhow::anyhow!(
+            "no recipients configured — add at least one to `[secrets] recipients` \
+             (or run `yui secret init` to generate a key)"
+        )));
+    }
+    let encryptor =
+        age::Encryptor::with_recipients(recipients.iter().map(|r| r as &dyn age::Recipient))
+            .map_err(|e| Error::Other(anyhow::anyhow!("age encryptor: {e}")))?;
+
+    let mut out = Vec::with_capacity(plaintext.len() + 256);
+    let mut writer = encryptor
+        .wrap_output(&mut out)
+        .map_err(|e| Error::Other(anyhow::anyhow!("age wrap_output: {e}")))?;
+    writer
+        .write_all(plaintext)
+        .map_err(|e| Error::Other(anyhow::anyhow!("age write: {e}")))?;
+    writer
+        .finish()
+        .map_err(|e| Error::Other(anyhow::anyhow!("age finish: {e}")))?;
+    Ok(out)
+}
+
+/// Decrypt `ciphertext` (the bytes of a `*.age` file) using the
+/// supplied identity. Returns the plaintext on success.
+pub fn decrypt(ciphertext: &[u8], identity: &age::x25519::Identity) -> Result<Vec<u8>> {
+    let decryptor = age::Decryptor::new(ciphertext)
+        .map_err(|e| Error::Other(anyhow::anyhow!("age decryptor: {e}")))?;
+    let mut reader = decryptor
+        .decrypt(std::iter::once(identity as &dyn age::Identity))
+        .map_err(|e| Error::Other(anyhow::anyhow!("age decrypt: {e}")))?;
+    let mut out = Vec::new();
+    reader
+        .read_to_end(&mut out)
+        .map_err(|e| Error::Other(anyhow::anyhow!("age read: {e}")))?;
+    Ok(out)
+}
+
+/// Generate a fresh X25519 keypair. Returns the serialised secret
+/// (write this to the identity file) and the corresponding public
+/// recipient string (add this to `[secrets] recipients`).
+pub fn generate_x25519_keypair() -> (String, String) {
+    let id = age::x25519::Identity::generate();
+    let secret = id.to_string().expose_secret().to_string();
+    let public = id.to_public().to_string();
+    (secret, public)
+}
+
+/// Strip the `.age` suffix from a path, if present. Returns `None`
+/// when the path doesn't end in `.age` (so callers can short-circuit
+/// non-secret files in a uniform walk).
+pub fn strip_age_suffix(path: &Utf8Path) -> Option<camino::Utf8PathBuf> {
+    let name = path.file_name()?;
+    let stem = name.strip_suffix(".age")?;
+    if stem.is_empty() {
+        return None; // a literal `.age` file with no stem isn't a secret backup
+    }
+    let parent = path.parent()?;
+    Some(parent.join(stem))
+}
+
+/// Walk every `*.age` under `source`, decrypt to a sibling without
+/// the suffix, and report the plaintext paths so the caller can
+/// add them to the managed `.gitignore` section. Mirrors the
+/// `render::render_all` shape: ignore-files honoured via
+/// `paths::source_walker`, `.yuiignore` filters apply, `.yui/`
+/// and `.git/` skipped.
+///
+/// Returns `Ok(SecretReport::default())` when `[secrets]` is off
+/// (no recipients configured). Otherwise loads the identity once
+/// and decrypts each `.age` file. `dry_run = true` skips the
+/// disk write but still confirms the file decrypts (so a missing
+/// identity / corrupted ciphertext surfaces as an error early).
+pub fn decrypt_all(
+    source: &Utf8Path,
+    config: &crate::config::Config,
+    dry_run: bool,
+) -> Result<SecretReport> {
+    let mut report = SecretReport::default();
+    if !config.secrets.enabled() {
+        return Ok(report);
+    }
+
+    let identity_path = crate::paths::expand_tilde(&config.secrets.identity);
+    let identity = load_identity(&identity_path)?;
+
+    let walker = crate::paths::source_walker(source).build();
+    for entry in walker {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            continue;
+        }
+        let std_path = entry.path();
+        let Some(name) = std_path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !name.ends_with(".age") || name == ".age" {
+            continue;
+        }
+        let cipher_path = match camino::Utf8PathBuf::from_path_buf(std_path.to_path_buf()) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let plaintext_path = match strip_age_suffix(&cipher_path) {
+            Some(p) => p,
+            None => continue,
+        };
+
+        let cipher_bytes = std::fs::read(&cipher_path)
+            .map_err(|e| Error::Other(anyhow::anyhow!("read {cipher_path}: {e}")))?;
+        let plain_bytes = decrypt(&cipher_bytes, &identity)?;
+
+        // Drift check against the on-disk plaintext sibling, mirroring
+        // the render-drift detection in `render::process_template`.
+        // If the user edited the plaintext directly (target-as-truth
+        // path), absorb already pulled the change into source; we
+        // surface it as `diverged` here so they know to re-encrypt
+        // (`yui secret encrypt <path>`) instead of silently
+        // overwriting their edit with the stale ciphertext content.
+        match std::fs::read(&plaintext_path) {
+            Ok(existing) if existing == plain_bytes => {
+                report.unchanged.push(plaintext_path);
+                continue;
+            }
+            Ok(_) => {
+                report.diverged.push(plaintext_path);
+                continue;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(Error::Other(anyhow::anyhow!("read {plaintext_path}: {e}")));
+            }
+        }
+
+        if !dry_run {
+            if let Some(parent) = plaintext_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&plaintext_path, &plain_bytes)?;
+        }
+        report.written.push(plaintext_path);
+    }
+    Ok(report)
+}
+
+/// Per-`apply` summary of what the secrets walker did. Mirrors
+/// `RenderReport`'s shape so the apply orchestrator can union
+/// managed-path lists across both pipelines.
+#[derive(Debug, Default)]
+pub struct SecretReport {
+    pub written: Vec<camino::Utf8PathBuf>,
+    pub unchanged: Vec<camino::Utf8PathBuf>,
+    /// Plaintext sibling diverged from current ciphertext. User
+    /// edited the plaintext target directly; they must
+    /// `yui secret encrypt <path>` to roll the change back into
+    /// the canonical `.age` before the next apply.
+    pub diverged: Vec<camino::Utf8PathBuf>,
+}
+
+impl SecretReport {
+    pub fn has_drift(&self) -> bool {
+        !self.diverged.is_empty()
+    }
+
+    /// Every plaintext sibling we know about — written, unchanged,
+    /// or diverged. The apply orchestrator unions this with the
+    /// render report's managed paths to build the `.gitignore`
+    /// managed section.
+    pub fn managed_paths(&self) -> impl Iterator<Item = &camino::Utf8PathBuf> {
+        self.written
+            .iter()
+            .chain(self.unchanged.iter())
+            .chain(self.diverged.iter())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+
+    #[test]
+    fn x25519_round_trip() {
+        let (secret, public) = generate_x25519_keypair();
+        let id = age::x25519::Identity::from_str(&secret).unwrap();
+        let recipient = parse_recipient(&public).unwrap();
+        let plaintext = b"hello secret world\n";
+        let cipher = encrypt(plaintext, &[recipient]).unwrap();
+        // Ciphertext should look like an age file.
+        assert!(cipher.starts_with(b"age-encryption.org/v1\n"));
+        let recovered = decrypt(&cipher, &id).unwrap();
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[test]
+    fn multi_recipient_decrypts_with_either_key() {
+        let (secret_a, public_a) = generate_x25519_keypair();
+        let (secret_b, public_b) = generate_x25519_keypair();
+        let id_a = age::x25519::Identity::from_str(&secret_a).unwrap();
+        let id_b = age::x25519::Identity::from_str(&secret_b).unwrap();
+        let recipients = vec![
+            parse_recipient(&public_a).unwrap(),
+            parse_recipient(&public_b).unwrap(),
+        ];
+        let plaintext = b"team secret";
+        let cipher = encrypt(plaintext, &recipients).unwrap();
+        // Either identity should decrypt — that's the whole point of
+        // multi-recipient encryption.
+        assert_eq!(decrypt(&cipher, &id_a).unwrap(), plaintext);
+        assert_eq!(decrypt(&cipher, &id_b).unwrap(), plaintext);
+    }
+
+    #[test]
+    fn load_identity_skips_comments_and_blanks() {
+        let tmp = TempDir::new().unwrap();
+        let path = Utf8PathBuf::from_path_buf(tmp.path().join("age.txt")).unwrap();
+        let (secret, _public) = generate_x25519_keypair();
+        let body = format!("# created: 2026-05-02\n# public key: ageXXX\n\n{secret}\n");
+        std::fs::write(&path, body).unwrap();
+        let id = load_identity(&path).unwrap();
+        // Round-trip through decrypt to confirm we got a usable
+        // identity back (not just any string-shaped placeholder).
+        let recipient = parse_recipient(&id.to_public().to_string()).unwrap();
+        let cipher = encrypt(b"x", &[recipient]).unwrap();
+        assert_eq!(decrypt(&cipher, &id).unwrap(), b"x");
+    }
+
+    #[test]
+    fn load_identity_errors_on_garbage() {
+        let tmp = TempDir::new().unwrap();
+        let path = Utf8PathBuf::from_path_buf(tmp.path().join("bad.txt")).unwrap();
+        std::fs::write(&path, "not a key at all\n").unwrap();
+        // `age::x25519::Identity` deliberately doesn't impl Debug
+        // (holds secret material), so `unwrap_err` won't compile —
+        // pattern match instead.
+        match load_identity(&path) {
+            Ok(_) => panic!("expected error on garbage identity file"),
+            Err(e) => assert!(format!("{e}").contains("not a valid age X25519 secret")),
+        }
+    }
+
+    #[test]
+    fn parse_recipient_rejects_garbage() {
+        let err = parse_recipient("ssh-rsa AAAA…").unwrap_err();
+        assert!(format!("{err}").contains("not a valid age X25519 recipient"));
+    }
+
+    #[test]
+    fn encrypt_with_no_recipients_errors() {
+        let err = encrypt(b"x", &[]).unwrap_err();
+        assert!(format!("{err}").contains("no recipients"));
+    }
+
+    #[test]
+    fn strip_age_suffix_basic() {
+        assert_eq!(
+            strip_age_suffix(Utf8PathBuf::from("home/.ssh/id_ed25519.age").as_path()),
+            Some(Utf8PathBuf::from("home/.ssh/id_ed25519"))
+        );
+        // Multiple dots: only the trailing `.age` is stripped.
+        assert_eq!(
+            strip_age_suffix(Utf8PathBuf::from("home/notes.tar.gz.age").as_path()),
+            Some(Utf8PathBuf::from("home/notes.tar.gz"))
+        );
+        // Not a secret.
+        assert_eq!(
+            strip_age_suffix(Utf8PathBuf::from("home/foo.txt").as_path()),
+            None
+        );
+        // A literal `.age` with no stem isn't a secret either.
+        assert_eq!(strip_age_suffix(Utf8PathBuf::from(".age").as_path()), None);
+    }
+}


### PR DESCRIPTION
Second half of the secret-management work — depends conceptually on but isn't blocked by #56 (mount-src absolute / Tera). Either lands first; merge ordering doesn't matter since the changes don't overlap.

## What

\`*.age\` ciphertext files in source are decrypted to a plaintext sibling (suffix dropped) on every \`yui apply\`, like \`*.tera\` rendering. The plaintext sibling lands in the same managed \`# >>> yui rendered <<<\` section of \`.gitignore\`; the apply walker links it to target like any other dotfile.

\`\`\`
home/.ssh/id_ed25519.age   <- committed ciphertext
     ↓ yui apply
home/.ssh/id_ed25519       <- decrypted sibling, gitignored
     ↓ link
~/.ssh/id_ed25519          <- target
\`\`\`

## Public surface

- **\`[secrets] identity\`** — path to your local age secret key file (default \`~/.config/yui/age.txt\`).
- **\`[secrets] recipients\`** — list of \`age1…\` public keys; feature is OFF when empty, so existing repos behave exactly as before this PR.
- **\`yui secret init [--comment TEXT]\`** — generate an X25519 keypair, write the secret with the same header format \`age-keygen\` produces, append the public key to \`config.local.toml\` \`[secrets].recipients\`. Idempotent.
- **\`yui secret encrypt <path> [--force] [--rm-plaintext]\`** — encrypt to all recipients. \`--rm-plaintext\` is gated on the plaintext living under \`\$DOTFILES\` so a typo can't erase files outside the repo.

## Drift detection

If the on-disk plaintext sibling diverges from the canonical \`.age\` (e.g. user edited the target which got auto-absorbed into the plaintext sibling), \`apply\` bails with a clear message. Fix: \`yui secret encrypt --force <path>\`. Mirrors the existing render-drift policy.

## Crypto + scope

**X25519 only in v1.** Plugin identities (YubiKey, FIDO2 / Pixel passkey, Touch ID, Windows Hello, TPM, 1Password) are real and useful but need callback plumbing for the plugin binaries' interactive prompts. Out of scope for this PR; the data model is plugin-ready so plugin support is additive.

## Test plan

- [x] 162 tests passing (8 secret module + 3 apply end-to-end + existing 151)
- [x] \`cargo make check\` (fmt + clippy \`-D warnings\` + locked check + tests)
- [x] Crypto round-trip with random keypair (single + multi recipient)
- [x] apply decrypt → sibling → link → target
- [x] apply bails on plaintext-vs-ciphertext drift
- [x] empty recipients list → secret walker is a no-op (existing repos unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added age-based encrypted secrets management with `yui secret init` to bootstrap and `yui secret encrypt` to secure files.
  * Secrets are automatically decrypted during `apply` with drift detection to ensure consistency.
  * Support for multi-machine recipient access.
  * Rendered plaintext secrets are automatically added to `.gitignore`.

* **Documentation**
  * Added comprehensive secrets documentation with setup and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->