### PR TITLE
feat(secrets): passkey wrap-and-unlock for X25519 onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,18 +22,24 @@ dependencies = [
  "base64",
  "bech32",
  "chacha20poly1305",
+ "console 0.15.11",
  "cookie-factory",
  "hmac",
  "i18n-embed",
  "i18n-embed-fl",
+ "is-terminal",
  "lazy_static",
  "nom",
  "pin-project",
+ "pinentry",
  "rand",
+ "rpassword",
  "rust-embed",
  "scrypt",
  "sha2 0.10.9",
  "subtle",
+ "which",
+ "wsl",
  "x25519-dalek",
  "zeroize",
 ]
@@ -53,6 +59,7 @@ dependencies = [
  "rand",
  "secrecy",
  "sha2 0.10.9",
+ "tempfile",
 ]
 
 [[package]]
@@ -109,7 +116,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -120,7 +127,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -386,6 +393,18 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
@@ -393,7 +412,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -512,6 +531,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
+name = "dialoguer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+dependencies = [
+ "console 0.16.3",
+ "shell-words",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +586,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,7 +610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -832,6 +867,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +888,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -997,7 +1047,7 @@ version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console",
+ "console 0.16.3",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -1039,6 +1089,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,7 +1123,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1110,7 +1171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1145,6 +1206,12 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1210,7 +1277,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1420,6 +1487,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pinentry"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a108bb5e4e654a3d20c834e5676b4b20f7cd2cc73b22f849d93e028b259340ec"
+dependencies = [
+ "log",
+ "nom",
+ "percent-encoding",
+ "secrecy",
+ "wait-timeout",
+ "which",
+ "zeroize",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,6 +1691,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rpassword"
+version = "7.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2501c67132bd19c3005b0111fba298907ef002c8c1cf68e25634707e38bf66fe"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,6 +1768,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1672,8 +1788,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1831,6 +1947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,8 +2027,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2387,6 +2509,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,7 +2539,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2469,12 +2603,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2586,6 +2793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wsl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
+
+[[package]]
 name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,6 +2821,7 @@ dependencies = [
  "camino",
  "clap",
  "clap_complete",
+ "dialoguer",
  "globset",
  "ignore",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,12 @@ name = "yui"
 path = "src/lib.rs"
 
 [dependencies]
-age = "0.11.3"
+age = { version = "0.11.3", features = ["cli-common", "plugin"] }
 anyhow = "1.0.102"
 camino = { version = "1.2.2", features = ["serde1"] }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 clap_complete = "4.6.3"
+dialoguer = { version = "0.12", default-features = false }
 globset = "0.4.18"
 ignore = "0.4.25"
 indicatif = "0.18.4"

--- a/README.md
+++ b/README.md
@@ -279,17 +279,75 @@ access:
    `yui secret encrypt --force <path>` per file. A `yui secret reencrypt`
    helper is planned.)
 
-### Roadmap: hardware MFA / passkey
+### Hardware MFA / passkey (wrap-and-unlock model)
 
-age has a plugin ecosystem (YubiKey, FIDO2 incl. Pixel 10 Pro
-cross-device passkeys, Touch ID via Secure Enclave, Windows Hello,
-TPM, 1Password). yui v1's identity / recipient parsing is X25519-only
-to keep the bootstrap flow simple, but the data model is plugin-ready;
-plugin support (with the callback plumbing those interactive flows
-need) is planned as a follow-up. Until then you can interoperate at
-the file level by encrypting `.age` files outside yui via `rage` /
-`age-plugin-*` and committing them — yui's X25519 identity can still
-decrypt files that were also wrapped to your X25519 recipient.
+`apply` only ever uses the plain X25519 secret at
+`[secrets].identity` — no device prompts on the hot path. Hardware
+keys (Pixel passkey, YubiKey, Bitwarden, Touch ID, Windows Hello,
+TPM, 1Password, …) come in via age plugins, but yui scopes them
+to a *one-time-per-machine* unlock step rather than every apply.
+
+```toml
+[secrets]
+identity            = "~/.config/yui/age.txt"     # X25519 plain, gitignored
+recipients          = ["age1abc…"]                 # X25519 publics for *.age files
+
+# Wrap setup — committed, lets a fresh machine recover the X25519:
+passkey_wrapped     = ".yui/age.txt.age"           # ciphertext of identity
+passkey_recipients  = [                            # who can unwrap it
+  "age1fido2-hmac1…pixel",
+  "age1fido2-hmac1…bitwarden",
+]
+passkey_identities  = ".yui/passkeys.txt"          # device descriptors (one per device)
+```
+
+`.yui/passkeys.txt` is a multi-identity file — one comment-and-line
+pair per device:
+
+```
+# Pixel
+AGE-PLUGIN-FIDO2-HMAC-1…pixel…
+
+# Bitwarden
+AGE-PLUGIN-FIDO2-HMAC-1…bitwarden…
+```
+
+#### One-time setup on the first machine
+
+```sh
+yui secret init                       # generates ~/.config/yui/age.txt (X25519)
+# Generate plugin identities once per device — yui doesn't bundle plugins:
+cargo install age-plugin-fido2-hmac
+age-plugin-fido2-hmac --generate >> .yui/passkeys.txt   # Pixel tap
+# (paste recipient line into [secrets].passkey_recipients)
+yui secret wrap                       # encrypts ~/.config/yui/age.txt → .yui/age.txt.age
+git add .yui/passkeys.txt .yui/age.txt.age && git commit
+```
+
+#### One-time on each new machine
+
+```sh
+git clone <dotfiles>
+yui secret unlock                     # picker → tap Pixel (or Bitwarden) → done
+yui apply                             # X25519 only, no prompts
+```
+
+#### Picker
+
+With multiple `passkey_identities`, `unlock` shows a `dialoguer`
+Select prompt so you choose Pixel vs Bitwarden vs whichever device
+you have at hand. Off-TTY (CI / scripts), age tries them in file
+order; pass `--passkey <label>` to pick non-interactively (the
+label is matched as a substring of the `# comment` above each
+identity entry).
+
+#### Trade-off vs full plugin-on-apply
+
+The wrap-and-unlock model means **changing recipients of `*.age`
+files (e.g. revoking a machine's X25519 access) still requires
+re-encrypting those files with the X25519 recipients alone**. The
+passkey only protects the X25519 secret in transit, not individual
+secrets. This is deliberate — it keeps daily apply silent.
 
 [age]: https://age-encryption.org/
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -241,6 +241,27 @@ pub enum SecretAction {
         #[arg(long)]
         rm_plaintext: bool,
     },
+
+    /// Encrypt the X25519 identity at `[secrets].identity` to all
+    /// `[secrets].passkey_recipients` and write the ciphertext to
+    /// `[secrets].passkey_wrapped`. Commit that file so a fresh
+    /// machine can `yui secret unlock` the X25519 once via the
+    /// passkey device, then run normal apply (no more device
+    /// prompts).
+    Wrap,
+
+    /// Decrypt `[secrets].passkey_wrapped` using one of the
+    /// `[secrets].passkey_identities` and restore the plaintext
+    /// X25519 secret to `[secrets].identity`. With multiple
+    /// identities AND a TTY, presents a picker; pass `--passkey
+    /// <label>` to bypass it non-interactively.
+    Unlock {
+        /// Label of the passkey to use — substring match against
+        /// the `# comment` lines in the identities file. Skips
+        /// the interactive picker.
+        #[arg(long, value_name = "LABEL")]
+        passkey: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -308,6 +329,8 @@ impl Cli {
                     force,
                     rm_plaintext,
                 } => cmd::secret_encrypt(source, path, force, rm_plaintext),
+                SecretAction::Wrap => cmd::secret_wrap(source),
+                SecretAction::Unlock { passkey } => cmd::secret_unlock(source, passkey),
             },
             Command::Completion { shell } => {
                 let mut cmd = Cli::command();

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -854,9 +854,9 @@ pub fn secret_encrypt(
         .secrets
         .recipients
         .iter()
-        .map(|s| secret::parse_recipient(s))
+        .map(|s| secret::parse_x25519_recipient(s))
         .collect::<crate::Result<_>>()?;
-    let cipher = secret::encrypt(&plaintext, &recipients)?;
+    let cipher = secret::encrypt_x25519(&plaintext, &recipients)?;
     std::fs::write(&cipher_path, &cipher)?;
     info!("encrypted {plaintext_path} → {cipher_path}");
 
@@ -874,6 +874,265 @@ pub fn secret_encrypt(
         }
     }
     Ok(())
+}
+
+/// `yui secret wrap` — encrypt the X25519 secret at
+/// `[secrets].identity` to every recipient in
+/// `[secrets].passkey_recipients` and write the ciphertext to
+/// `[secrets].passkey_wrapped`. Committing that ciphertext lets
+/// the dotfiles repo carry the X25519 secret across machines
+/// safely; on a new machine `yui secret unlock` taps the user's
+/// passkey device (Pixel / Bitwarden / YubiKey) once to recover
+/// the plain X25519, after which everyday `apply` is plugin-free.
+pub fn secret_wrap(source: Option<Utf8PathBuf>) -> Result<()> {
+    let source = resolve_source(source)?;
+    let yui = YuiVars::detect(&source);
+    let config = config::load(&source, &yui)?;
+
+    let wrapped_rel = config.secrets.passkey_wrapped.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "[secrets].passkey_wrapped is not configured — set it to a \
+             repo-relative path (e.g. \".yui/age.txt.age\") before calling wrap"
+        )
+    })?;
+    if config.secrets.passkey_recipients.is_empty() {
+        anyhow::bail!(
+            "[secrets].passkey_recipients is empty — add at least one \
+             passkey public key (e.g. an `age1fido2-hmac1…` from \
+             `age-plugin-fido2-hmac --generate`) before calling wrap"
+        );
+    }
+    let identity_path = paths::expand_tilde(&config.secrets.identity);
+    if !identity_path.is_file() {
+        anyhow::bail!(
+            "no X25519 identity at {identity_path}; run `yui secret init` first \
+             (wrap encrypts that file's contents to your passkey devices)"
+        );
+    }
+    let wrapped_path = resolve_secrets_path(&source, wrapped_rel);
+
+    let plaintext = std::fs::read(&identity_path)?;
+    let recipients: Vec<secret::BoxedRecipient> = config
+        .secrets
+        .passkey_recipients
+        .iter()
+        .map(|s| secret::parse_passkey_recipient(s))
+        .collect::<crate::Result<_>>()?;
+    let cipher = secret::encrypt_to_passkeys(&plaintext, &recipients)?;
+    if let Some(parent) = wrapped_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&wrapped_path, &cipher)?;
+    info!("wrote passkey-wrapped identity: {wrapped_path}");
+    println!();
+    println!("  Recipients: {}", config.secrets.passkey_recipients.len());
+    println!("  Wrapped at: {wrapped_path}");
+    println!();
+    println!("  Commit this file. On a new machine, run `yui secret unlock`.");
+    Ok(())
+}
+
+/// `yui secret unlock` — decrypt `[secrets].passkey_wrapped` using
+/// any identity in `[secrets].passkey_identities`, write the
+/// resulting plaintext to `[secrets].identity`. With multiple
+/// passkey identities AND a TTY, presents an interactive picker
+/// so the user can choose which device to use (Pixel vs
+/// Bitwarden); off-TTY or with `--passkey <label>` the choice is
+/// non-interactive.
+pub fn secret_unlock(source: Option<Utf8PathBuf>, passkey: Option<String>) -> Result<()> {
+    let source = resolve_source(source)?;
+    let yui = YuiVars::detect(&source);
+    let config = config::load(&source, &yui)?;
+
+    let wrapped_rel = config.secrets.passkey_wrapped.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "[secrets].passkey_wrapped is not set — nothing to unlock. \
+             Run `yui secret init` + `yui secret wrap` on an existing \
+             machine first, then commit + push."
+        )
+    })?;
+    let identities_rel = config.secrets.passkey_identities.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "[secrets].passkey_identities is not set — point it at the \
+             file holding your `AGE-PLUGIN-…` identity descriptors \
+             (e.g. \".yui/passkeys.txt\")"
+        )
+    })?;
+
+    let wrapped_path = resolve_secrets_path(&source, wrapped_rel);
+    let identities_path = resolve_secrets_path(&source, identities_rel);
+    let identity_path = paths::expand_tilde(&config.secrets.identity);
+
+    if !wrapped_path.is_file() {
+        anyhow::bail!("passkey_wrapped not found at {wrapped_path}");
+    }
+    if !identities_path.is_file() {
+        anyhow::bail!("passkey_identities not found at {identities_path}");
+    }
+    if identity_path.exists() {
+        anyhow::bail!(
+            "{identity_path} already exists — refusing to clobber a live \
+             X25519 identity. Delete it first if you really mean to \
+             re-unlock from scratch."
+        );
+    }
+
+    // Parse the identities file twice — once to pluck per-entry
+    // labels (preceding `# comment` lines) for the picker, once
+    // through age's IdentityFile to get the actual usable
+    // identities. The two parses iterate the file in the same
+    // order, so labels[i] corresponds to identities[i].
+    let raw = std::fs::read_to_string(&identities_path)?;
+    let labels = parse_identity_labels(&raw);
+    let identities = secret::load_passkey_identities(&identities_path)?;
+    if identities.is_empty() {
+        anyhow::bail!(
+            "no identities loaded from {identities_path}; expected one \
+             or more `AGE-PLUGIN-…` (or `AGE-SECRET-KEY-1…`) lines"
+        );
+    }
+
+    let picked_idx = pick_passkey_identity(&labels, identities.len(), passkey.as_deref())?;
+    let cipher = std::fs::read(&wrapped_path)?;
+
+    // If the user picked a specific identity, hand only that one
+    // to age — otherwise age tries them all in file order.
+    let plaintext = if let Some(idx) = picked_idx {
+        let single: Vec<secret::BoxedIdentity> = vec![identities.into_iter().nth(idx).unwrap()];
+        info!(
+            "unlocking via {}",
+            labels.get(idx).map(String::as_str).unwrap_or("(unlabeled)")
+        );
+        secret::decrypt_with_passkeys(&cipher, &single)?
+    } else {
+        info!(
+            "unlocking — age will try {} identities in order",
+            identities.len()
+        );
+        secret::decrypt_with_passkeys(&cipher, &identities)?
+    };
+
+    if let Some(parent) = identity_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&identity_path, &plaintext)?;
+    info!("wrote unwrapped X25519 identity: {identity_path}");
+    println!();
+    println!("  X25519 identity restored at {identity_path}");
+    println!("  Run `yui apply` next — no more passkey prompts needed.");
+    Ok(())
+}
+
+/// Given a list of human-readable labels (one per identity) and
+/// a non-interactive override (`--passkey <label>`), decide which
+/// identity to use. Returns `Some(idx)` for a single pick, `None`
+/// for "let age try them all in order".
+///
+/// Decision tree:
+///   - explicit `--passkey <label>` → match by label (case-insensitive substring),
+///     error if no / multiple match
+///   - 1 identity                 → use it (no prompt)
+///   - multiple identities + TTY  → dialoguer Select
+///   - multiple identities + no TTY → fall through to "try them all"
+fn pick_passkey_identity(
+    labels: &[String],
+    identity_count: usize,
+    override_label: Option<&str>,
+) -> Result<Option<usize>> {
+    if let Some(want) = override_label {
+        let needle = want.to_ascii_lowercase();
+        let matches: Vec<usize> = labels
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| l.to_ascii_lowercase().contains(&needle))
+            .map(|(i, _)| i)
+            .collect();
+        match matches.len() {
+            0 => anyhow::bail!(
+                "--passkey {want:?} matches no identity label \
+                 (available: {labels:?})"
+            ),
+            1 => return Ok(Some(matches[0])),
+            n => anyhow::bail!(
+                "--passkey {want:?} is ambiguous — matches {n} entries \
+                 ({labels:?}); narrow it down"
+            ),
+        }
+    }
+
+    if identity_count <= 1 {
+        return Ok(None); // let the single identity be tried
+    }
+
+    use std::io::IsTerminal;
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        // Off-TTY: don't prompt, fall through to "try all in order"
+        // so scripts work without `--passkey`.
+        return Ok(None);
+    }
+
+    let labelled: Vec<&str> = labels
+        .iter()
+        .map(|l| l.as_str())
+        .chain(std::iter::repeat("(unlabeled)"))
+        .take(identity_count)
+        .collect();
+    let pick = dialoguer::Select::new()
+        .with_prompt("Which passkey to unlock with?")
+        .items(&labelled)
+        .default(0)
+        .interact()
+        .map_err(|e| anyhow::anyhow!("interactive prompt: {e}"))?;
+    Ok(Some(pick))
+}
+
+/// Walk the lines of a passkey-identities file and pair each
+/// non-comment / non-blank "identity" line with the comment block
+/// that immediately precedes it. Used to label entries in the
+/// dialoguer picker.
+///
+/// ```text
+/// # Pixel
+/// AGE-PLUGIN-FIDO2-HMAC-1...        <- labelled "Pixel"
+///
+/// # Bitwarden
+/// AGE-PLUGIN-FIDO2-HMAC-2...        <- labelled "Bitwarden"
+/// ```
+fn parse_identity_labels(raw: &str) -> Vec<String> {
+    let mut labels = Vec::new();
+    let mut comment = String::new();
+    for line in raw.lines() {
+        let l = line.trim();
+        if l.is_empty() {
+            continue;
+        }
+        if let Some(rest) = l.strip_prefix('#') {
+            if !comment.is_empty() {
+                comment.push(' ');
+            }
+            comment.push_str(rest.trim());
+        } else {
+            labels.push(if comment.is_empty() {
+                format!("identity #{}", labels.len() + 1)
+            } else {
+                comment.clone()
+            });
+            comment.clear();
+        }
+    }
+    labels
+}
+
+/// Resolve a `[secrets]` path-like field (relative or absolute,
+/// possibly tilde-prefixed) to an absolute path. Relative paths
+/// resolve against `source`.
+fn resolve_secrets_path(source: &Utf8Path, p: &str) -> Utf8PathBuf {
+    let expanded = paths::expand_tilde(p);
+    if expanded.is_absolute() {
+        expanded
+    } else {
+        source.join(expanded)
+    }
 }
 
 /// `yui update [--dry-run]` — pull source repo and re-apply.
@@ -4940,8 +5199,8 @@ dst = "{}"
         std::fs::write(&identity_path, format!("{secret}\n")).unwrap();
 
         // 2. Encrypt a fake private key into source as `.age`.
-        let recipient = secret::parse_recipient(&public).unwrap();
-        let cipher = secret::encrypt(b"-- super secret key --\n", &[recipient]).unwrap();
+        let recipient = secret::parse_x25519_recipient(&public).unwrap();
+        let cipher = secret::encrypt_x25519(b"-- super secret key --\n", &[recipient]).unwrap();
         std::fs::write(source.join("home/.ssh/id_ed25519.age"), &cipher).unwrap();
 
         // 3. config.toml: mount + secrets pointing at the test identity.
@@ -4994,8 +5253,8 @@ recipients = ["{}"]
         let (secret_key, public) = secret::generate_x25519_keypair();
         std::fs::write(&identity_path, format!("{secret_key}\n")).unwrap();
 
-        let recipient = secret::parse_recipient(&public).unwrap();
-        let cipher = secret::encrypt(b"v1 content\n", &[recipient]).unwrap();
+        let recipient = secret::parse_x25519_recipient(&public).unwrap();
+        let cipher = secret::encrypt_x25519(b"v1 content\n", &[recipient]).unwrap();
         std::fs::write(source.join("home/secret.age"), &cipher).unwrap();
         // Drifted sibling: plaintext exists but doesn't match the .age content.
         std::fs::write(source.join("home/secret"), "edited locally\n").unwrap();

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -712,16 +712,15 @@ pub fn secret_init(source: Option<Utf8PathBuf>, comment: Option<String>) -> Resu
     //    the same header age-keygen uses, so the file is
     //    interoperable with the standalone CLI tools.
     let (secret, public) = secret::generate_x25519_keypair();
-    if let Some(parent) = identity_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
     let now = jiff::Zoned::now().to_string();
     let body = format!(
         "# created: {now}\n\
          # public key: {public}\n\
          {secret}\n"
     );
-    std::fs::write(&identity_path, body)?;
+    // 0600 on Unix so other local users can't read the X25519
+    // secret. PR #60 review by coderabbitai.
+    secret::write_private_file(&identity_path, body.as_bytes())?;
     info!("wrote identity file: {identity_path}");
 
     // 3. Append the public key to `[secrets] recipients` in
@@ -1010,10 +1009,17 @@ pub fn secret_unlock(source: Option<Utf8PathBuf>, passkey: Option<String>) -> Re
         secret::decrypt_with_passkeys(&cipher, &identities)?
     };
 
-    if let Some(parent) = identity_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    std::fs::write(&identity_path, &plaintext)?;
+    // Validate before persisting — `decrypt_with_passkeys` only
+    // proves the blob unwrapped, not that the result is actually
+    // an X25519 identity file. If the user mis-pointed
+    // passkey_wrapped at some other ciphertext, fail here rather
+    // than write garbage that would only fail later during apply.
+    // PR #60 review by coderabbitai.
+    secret::validate_x25519_identity_bytes(&plaintext)?;
+
+    // 0600 on Unix — never leave the X25519 secret world-readable
+    // even momentarily. PR #60 review by coderabbitai.
+    secret::write_private_file(&identity_path, &plaintext)?;
     info!("wrote unwrapped X25519 identity: {identity_path}");
     println!();
     println!("  X25519 identity restored at {identity_path}");

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -912,12 +912,10 @@ pub fn secret_wrap(source: Option<Utf8PathBuf>) -> Result<()> {
     let wrapped_path = resolve_secrets_path(&source, wrapped_rel);
 
     let plaintext = std::fs::read(&identity_path)?;
-    let recipients: Vec<secret::BoxedRecipient> = config
-        .secrets
-        .passkey_recipients
-        .iter()
-        .map(|s| secret::parse_passkey_recipient(s))
-        .collect::<crate::Result<_>>()?;
+    // Use the batch parser so multiple recipients of the same
+    // plugin share a single `RecipientPluginV1` (one process
+    // invocation, one prompt round). PR #60 review.
+    let recipients = secret::parse_passkey_recipients(&config.secrets.passkey_recipients)?;
     let cipher = secret::encrypt_to_passkeys(&plaintext, &recipients)?;
     if let Some(parent) = wrapped_path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -1053,10 +1051,17 @@ fn pick_passkey_identity(
                  (available: {labels:?})"
             ),
             1 => return Ok(Some(matches[0])),
-            n => anyhow::bail!(
-                "--passkey {want:?} is ambiguous — matches {n} entries \
-                 ({labels:?}); narrow it down"
-            ),
+            n => {
+                // List only the labels that matched, not the full
+                // identities file — a big passkeys file would
+                // bury the actual ambiguity. (PR #60 review.)
+                let matched_labels: Vec<&str> =
+                    matches.iter().map(|&i| labels[i].as_str()).collect();
+                anyhow::bail!(
+                    "--passkey {want:?} is ambiguous — matches {n} entries \
+                     ({matched_labels:?}); narrow it down"
+                )
+            }
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -288,10 +288,40 @@ fn default_backup_dir() -> String {
 /// as "secrets feature off".
 #[derive(Debug, Clone, Deserialize)]
 pub struct SecretsConfig {
+    /// Path to the X25519 secret key used by `apply` to decrypt
+    /// `*.age` files. Plain (`AGE-SECRET-KEY-1…`) text, gitignored.
+    /// Default `~/.config/yui/age.txt`.
     #[serde(default = "default_identity_path")]
     pub identity: String,
+
+    /// X25519 public keys that `*.age` files are encrypted to.
+    /// Empty = secrets feature off. Each machine usually adds its
+    /// own here so multi-recipient encryption lets all machines
+    /// decrypt.
     #[serde(default)]
     pub recipients: Vec<String>,
+
+    /// Optional path (source-relative or absolute) where
+    /// `yui secret wrap` stashes the X25519 identity, encrypted to
+    /// `passkey_recipients`. Committed to the dotfiles repo so it
+    /// travels to new machines; `yui secret unlock` reads it
+    /// there. Off when absent.
+    #[serde(default)]
+    pub passkey_wrapped: Option<String>,
+
+    /// Public keys (X25519 or plugin) that `passkey_wrapped` is
+    /// encrypted to. Multiple = redundancy: any one device can
+    /// recover the X25519 secret on a new machine.
+    #[serde(default)]
+    pub passkey_recipients: Vec<String>,
+
+    /// Optional path (source-relative or absolute) to the file
+    /// holding the *identity descriptors* (`AGE-PLUGIN-…` lines)
+    /// that `yui secret unlock` tries against `passkey_wrapped`.
+    /// Plugin identity descriptors are device addresses, not
+    /// secrets — committing them is fine.
+    #[serde(default)]
+    pub passkey_identities: Option<String>,
 }
 
 impl Default for SecretsConfig {
@@ -299,6 +329,9 @@ impl Default for SecretsConfig {
         Self {
             identity: default_identity_path(),
             recipients: Vec::new(),
+            passkey_wrapped: None,
+            passkey_recipients: Vec::new(),
+            passkey_identities: None,
         }
     }
 }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -116,25 +116,53 @@ pub fn parse_x25519_recipient(s: &str) -> Result<age::x25519::Recipient> {
     })
 }
 
-/// Parse any recipient string — X25519 or plugin. Used by
-/// `yui secret wrap` to encrypt the X25519 identity to
-/// passkey-backed devices.
+/// Parse a single recipient string — X25519 or plugin. Used in
+/// tests and for debugging; production wrap goes through
+/// `parse_passkey_recipients` which batches plugin recipients.
 pub fn parse_passkey_recipient(s: &str) -> Result<BoxedRecipient> {
-    let trimmed = s.trim();
-    if let Ok(r) = age::x25519::Recipient::from_str(trimmed) {
-        return Ok(Box::new(r));
+    parse_passkey_recipients(std::slice::from_ref(&s.to_string()))
+        .map(|mut v| v.pop().expect("single input → single output"))
+}
+
+/// Parse a list of recipient strings, grouping plugin recipients
+/// by plugin name into a single `RecipientPluginV1` per group.
+/// Without grouping, each plugin recipient would spawn the
+/// `age-plugin-*` binary independently — wasteful and (for some
+/// plugins) prompts the user multiple times. (PR #60 review by
+/// gemini-code-assist.)
+///
+/// X25519 recipients pass through one-Box-per-string since they
+/// have no plugin process to batch.
+pub fn parse_passkey_recipients(strings: &[String]) -> Result<Vec<BoxedRecipient>> {
+    use std::collections::BTreeMap;
+
+    let mut out: Vec<BoxedRecipient> = Vec::new();
+    let mut by_plugin: BTreeMap<String, Vec<age::plugin::Recipient>> = BTreeMap::new();
+
+    for s in strings {
+        let trimmed = s.trim();
+        if let Ok(r) = age::x25519::Recipient::from_str(trimmed) {
+            out.push(Box::new(r));
+            continue;
+        }
+        if let Ok(r) = age::plugin::Recipient::from_str(trimmed) {
+            let name = r.plugin().to_string();
+            by_plugin.entry(name).or_default().push(r);
+            continue;
+        }
+        return Err(Error::Other(anyhow::anyhow!(
+            "not a valid age recipient {trimmed:?} \
+             (expected `age1…` or `age1<plugin>1…`)"
+        )));
     }
-    if let Ok(r) = age::plugin::Recipient::from_str(trimmed) {
-        let name = r.plugin().to_string();
-        let plugin_recipient =
-            age::plugin::RecipientPluginV1::new(&name, &[r], &[], UiCallbacks)
-                .map_err(|e| Error::Other(anyhow::anyhow!("plugin recipient {trimmed:?}: {e}")))?;
-        return Ok(Box::new(plugin_recipient));
+
+    for (name, recipients) in by_plugin {
+        let plugin = age::plugin::RecipientPluginV1::new(&name, &recipients, &[], UiCallbacks)
+            .map_err(|e| Error::Other(anyhow::anyhow!("plugin recipient group {name:?}: {e}")))?;
+        out.push(Box::new(plugin));
     }
-    Err(Error::Other(anyhow::anyhow!(
-        "not a valid age recipient {trimmed:?} \
-         (expected `age1…` or `age1<plugin>1…`)"
-    )))
+
+    Ok(out)
 }
 
 /// Encrypt `plaintext` to one or more X25519 recipients. Used for

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -17,31 +17,53 @@
 //! means the crypto stays out of `render.rs`, which a casual
 //! reader expects to be pure-text manipulation.
 //!
-//! ## v1 scope: X25519 only
+//! ## Two distinct encryption paths
 //!
-//! `[secrets] identity` is an X25519 secret (`AGE-SECRET-KEY-1…`)
-//! and `recipients = […]` are X25519 public keys (`age1…`).
-//! `yui secret init` produces both.
+//! 1. **`*.age` files in apply** — encrypted to `[secrets] recipients`,
+//!    decrypted with the plain X25519 secret at
+//!    `[secrets] identity` (e.g. `~/.config/yui/age.txt`). Runs every
+//!    apply, must be friction-free, must NOT trigger device prompts.
+//!    Identities here are X25519 only by convention.
 //!
-//! Plugin-backed identities (YubiKey / FIDO2 passkey / Touch ID /
-//! TPM / 1Password) need age's `plugin` feature plus callback
-//! plumbing to drive the plugin binaries' interactive prompts —
-//! a worthwhile follow-up but real implementation work, kept out
-//! of v1 to ship the simple flow first.
+//! 2. **passkey wrap of the X25519 secret itself** — the user's
+//!    `~/.config/yui/age.txt` (plain X25519) gets encrypted to one
+//!    or more passkey recipients (Pixel / Bitwarden / YubiKey, via
+//!    the `age-plugin-fido2-hmac` etc.) so it can travel with the
+//!    dotfiles repo as ciphertext. Used only by `yui secret wrap`
+//!    and `yui secret unlock` — never by apply. Plugin identities
+//!    appear ONLY here, so the apply path stays plugin-free.
+//!
+//! Recipient strings split the same way: `age1…` for X25519 and
+//! `age1<plugin>1…` for plugin recipients. Multiple recipient types
+//! can mix in a single ciphertext — useful for wrap, where the
+//! user might want both Pixel and Bitwarden as recovery devices.
 
-use std::io::{Read as _, Write as _};
+use std::io::{BufReader, Read as _, Write as _};
 use std::str::FromStr as _;
 
+use age::IdentityFile;
+use age::cli_common::UiCallbacks;
 use age::secrecy::ExposeSecret as _;
 use camino::Utf8Path;
 
 use crate::{Error, Result};
 
-/// Load an age X25519 identity from `path`. The file is expected
-/// to be the output of `age-keygen` / `yui secret init`: lines
-/// beginning with `#` are comments, the first non-comment line is
-/// the `AGE-SECRET-KEY-1…` secret.
-pub fn load_identity(path: &Utf8Path) -> Result<age::x25519::Identity> {
+/// Boxed dyn-trait identity. age's `Decryptor::decrypt` takes a
+/// trait-object iterator, so we hand it boxed identities; X25519
+/// and plugin variants share the same type at the boundary.
+pub type BoxedIdentity = Box<dyn age::Identity>;
+
+/// Boxed dyn-trait recipient. Same reasoning as `BoxedIdentity` —
+/// `Encryptor::with_recipients` works on trait objects.
+pub type BoxedRecipient = Box<dyn age::Recipient + Send>;
+
+/// Load an age X25519 identity from `path`, the way `apply` needs
+/// it. Refuses anything other than a plain `AGE-SECRET-KEY-1…`
+/// secret — apply must NEVER drop into a plugin flow because that
+/// would prompt for a touch / PIN / biometric on every run.
+/// (The user's mental model is "Pixel only at unlock time, not
+/// every apply", so apply stays X25519-only on principle.)
+pub fn load_x25519_identity(path: &Utf8Path) -> Result<age::x25519::Identity> {
     let raw = std::fs::read_to_string(path)
         .map_err(|e| Error::Other(anyhow::anyhow!("read identity {path}: {e}")))?;
     let line = raw
@@ -62,8 +84,30 @@ pub fn load_identity(path: &Utf8Path) -> Result<age::x25519::Identity> {
     })
 }
 
-/// Parse an X25519 recipient string (`age1…`).
-pub fn parse_recipient(s: &str) -> Result<age::x25519::Recipient> {
+/// Load every identity from `path`, allowing plugin entries
+/// (`AGE-PLUGIN-…`). Used by `yui secret unlock` where the file
+/// holds passkey identities (Pixel, Bitwarden, …) that age must
+/// drive interactively at decrypt time.
+///
+/// `IdentityFile` parses comments / blank lines / multiple entries
+/// per the standard age format; `with_callbacks(UiCallbacks)`
+/// hands plugin invocations a terminal-based prompt for "press
+/// the button now" / etc.
+pub fn load_passkey_identities(path: &Utf8Path) -> Result<Vec<BoxedIdentity>> {
+    let file = std::fs::File::open(path)
+        .map_err(|e| Error::Other(anyhow::anyhow!("read passkey identities {path}: {e}")))?;
+    let id_file = IdentityFile::from_buffer(BufReader::new(file))
+        .map_err(|e| Error::Other(anyhow::anyhow!("parse {path}: {e}")))?;
+    id_file
+        .with_callbacks(UiCallbacks)
+        .into_identities()
+        .map_err(|e| Error::Other(anyhow::anyhow!("load identities from {path}: {e}")))
+}
+
+/// Parse an X25519 recipient string (`age1…`). Used for the
+/// `[secrets] recipients` list which encrypts the user's `*.age`
+/// files — those must stay plugin-free so apply doesn't prompt.
+pub fn parse_x25519_recipient(s: &str) -> Result<age::x25519::Recipient> {
     let trimmed = s.trim();
     age::x25519::Recipient::from_str(trimmed).map_err(|e| {
         Error::Other(anyhow::anyhow!(
@@ -72,10 +116,30 @@ pub fn parse_recipient(s: &str) -> Result<age::x25519::Recipient> {
     })
 }
 
-/// Encrypt `plaintext` to one or more recipients. The output is
-/// the binary age format (the same bytes a `*.age` file holds on
-/// disk).
-pub fn encrypt(plaintext: &[u8], recipients: &[age::x25519::Recipient]) -> Result<Vec<u8>> {
+/// Parse any recipient string — X25519 or plugin. Used by
+/// `yui secret wrap` to encrypt the X25519 identity to
+/// passkey-backed devices.
+pub fn parse_passkey_recipient(s: &str) -> Result<BoxedRecipient> {
+    let trimmed = s.trim();
+    if let Ok(r) = age::x25519::Recipient::from_str(trimmed) {
+        return Ok(Box::new(r));
+    }
+    if let Ok(r) = age::plugin::Recipient::from_str(trimmed) {
+        let name = r.plugin().to_string();
+        let plugin_recipient =
+            age::plugin::RecipientPluginV1::new(&name, &[r], &[], UiCallbacks)
+                .map_err(|e| Error::Other(anyhow::anyhow!("plugin recipient {trimmed:?}: {e}")))?;
+        return Ok(Box::new(plugin_recipient));
+    }
+    Err(Error::Other(anyhow::anyhow!(
+        "not a valid age recipient {trimmed:?} \
+         (expected `age1…` or `age1<plugin>1…`)"
+    )))
+}
+
+/// Encrypt `plaintext` to one or more X25519 recipients. Used for
+/// `*.age` files in the apply pipeline.
+pub fn encrypt_x25519(plaintext: &[u8], recipients: &[age::x25519::Recipient]) -> Result<Vec<u8>> {
     if recipients.is_empty() {
         return Err(Error::Other(anyhow::anyhow!(
             "no recipients configured — add at least one to `[secrets] recipients` \
@@ -85,7 +149,30 @@ pub fn encrypt(plaintext: &[u8], recipients: &[age::x25519::Recipient]) -> Resul
     let encryptor =
         age::Encryptor::with_recipients(recipients.iter().map(|r| r as &dyn age::Recipient))
             .map_err(|e| Error::Other(anyhow::anyhow!("age encryptor: {e}")))?;
+    write_encrypted(encryptor, plaintext)
+}
 
+/// Encrypt `plaintext` to one or more potentially-plugin
+/// recipients. Used by `yui secret wrap` to encrypt the X25519
+/// identity to passkey devices (Pixel + Bitwarden + …).
+pub fn encrypt_to_passkeys(plaintext: &[u8], recipients: &[BoxedRecipient]) -> Result<Vec<u8>> {
+    if recipients.is_empty() {
+        return Err(Error::Other(anyhow::anyhow!(
+            "no passkey recipients configured — add at least one to \
+             `[secrets] passkey_recipients` (each entry is the public \
+             key of a Pixel / Bitwarden / etc. device)"
+        )));
+    }
+    let encryptor = age::Encryptor::with_recipients(
+        recipients
+            .iter()
+            .map(|r| -> &dyn age::Recipient { r.as_ref() }),
+    )
+    .map_err(|e| Error::Other(anyhow::anyhow!("age encryptor: {e}")))?;
+    write_encrypted(encryptor, plaintext)
+}
+
+fn write_encrypted(encryptor: age::Encryptor, plaintext: &[u8]) -> Result<Vec<u8>> {
     let mut out = Vec::with_capacity(plaintext.len() + 256);
     let mut writer = encryptor
         .wrap_output(&mut out)
@@ -99,13 +186,28 @@ pub fn encrypt(plaintext: &[u8], recipients: &[age::x25519::Recipient]) -> Resul
     Ok(out)
 }
 
-/// Decrypt `ciphertext` (the bytes of a `*.age` file) using the
-/// supplied identity. Returns the plaintext on success.
-pub fn decrypt(ciphertext: &[u8], identity: &age::x25519::Identity) -> Result<Vec<u8>> {
+/// Decrypt `ciphertext` (the bytes of a `*.age` file) using a
+/// single X25519 identity. Used by the apply pipeline.
+pub fn decrypt_x25519(ciphertext: &[u8], identity: &age::x25519::Identity) -> Result<Vec<u8>> {
     let decryptor = age::Decryptor::new(ciphertext)
         .map_err(|e| Error::Other(anyhow::anyhow!("age decryptor: {e}")))?;
     let mut reader = decryptor
         .decrypt(std::iter::once(identity as &dyn age::Identity))
+        .map_err(|e| Error::Other(anyhow::anyhow!("age decrypt: {e}")))?;
+    let mut out = Vec::new();
+    reader
+        .read_to_end(&mut out)
+        .map_err(|e| Error::Other(anyhow::anyhow!("age read: {e}")))?;
+    Ok(out)
+}
+
+/// Decrypt `ciphertext` using any of the supplied (potentially
+/// plugin-backed) identities. Used by `yui secret unlock`.
+pub fn decrypt_with_passkeys(ciphertext: &[u8], identities: &[BoxedIdentity]) -> Result<Vec<u8>> {
+    let decryptor = age::Decryptor::new(ciphertext)
+        .map_err(|e| Error::Other(anyhow::anyhow!("age decryptor: {e}")))?;
+    let mut reader = decryptor
+        .decrypt(identities.iter().map(|i| i.as_ref() as &dyn age::Identity))
         .map_err(|e| Error::Other(anyhow::anyhow!("age decrypt: {e}")))?;
     let mut out = Vec::new();
     reader
@@ -146,9 +248,13 @@ pub fn strip_age_suffix(path: &Utf8Path) -> Option<camino::Utf8PathBuf> {
 ///
 /// Returns `Ok(SecretReport::default())` when `[secrets]` is off
 /// (no recipients configured). Otherwise loads the identity once
-/// and decrypts each `.age` file. `dry_run = true` skips the
-/// disk write but still confirms the file decrypts (so a missing
-/// identity / corrupted ciphertext surfaces as an error early).
+/// and decrypts each `.age` file. The identity is X25519-only
+/// here on purpose — apply must NOT trigger plugin / passkey
+/// prompts every run.
+///
+/// Skips the `passkey_wrapped` ciphertext file: it's encrypted to
+/// passkey recipients (NOT the X25519), so trying to decrypt it
+/// here would fail loudly. The unlock path handles it instead.
 pub fn decrypt_all(
     source: &Utf8Path,
     config: &crate::config::Config,
@@ -160,7 +266,20 @@ pub fn decrypt_all(
     }
 
     let identity_path = crate::paths::expand_tilde(&config.secrets.identity);
-    let identity = load_identity(&identity_path)?;
+    let identity = load_x25519_identity(&identity_path)?;
+
+    // Resolve `passkey_wrapped` to an absolute path so we can skip
+    // it inside the walker (it's encrypted to a passkey recipient,
+    // not the X25519 identity, so it's not a regular `.age` file
+    // that apply should decrypt).
+    let passkey_wrapped_abs = config.secrets.passkey_wrapped.as_ref().map(|p| {
+        let path = crate::paths::expand_tilde(p);
+        if path.is_absolute() {
+            path
+        } else {
+            source.join(path)
+        }
+    });
 
     let walker = crate::paths::source_walker(source).build();
     for entry in walker {
@@ -182,6 +301,13 @@ pub fn decrypt_all(
             Ok(p) => p,
             Err(_) => continue,
         };
+        // Skip the passkey-wrapped identity file — it's not a
+        // regular `.age` we should decrypt during apply.
+        if let Some(skip) = &passkey_wrapped_abs {
+            if &cipher_path == skip {
+                continue;
+            }
+        }
         let plaintext_path = match strip_age_suffix(&cipher_path) {
             Some(p) => p,
             None => continue,
@@ -189,15 +315,10 @@ pub fn decrypt_all(
 
         let cipher_bytes = std::fs::read(&cipher_path)
             .map_err(|e| Error::Other(anyhow::anyhow!("read {cipher_path}: {e}")))?;
-        let plain_bytes = decrypt(&cipher_bytes, &identity)?;
+        let plain_bytes = decrypt_x25519(&cipher_bytes, &identity)?;
 
         // Drift check against the on-disk plaintext sibling, mirroring
         // the render-drift detection in `render::process_template`.
-        // If the user edited the plaintext directly (target-as-truth
-        // path), absorb already pulled the change into source; we
-        // surface it as `diverged` here so they know to re-encrypt
-        // (`yui secret encrypt <path>`) instead of silently
-        // overwriting their edit with the stale ciphertext content.
         match std::fs::read(&plaintext_path) {
             Ok(existing) if existing == plain_bytes => {
                 report.unchanged.push(plaintext_path);
@@ -261,76 +382,114 @@ mod tests {
     use camino::Utf8PathBuf;
     use tempfile::TempDir;
 
+    fn write_x25519_identity_file(tmp: &TempDir, name: &str) -> (Utf8PathBuf, String) {
+        let path = Utf8PathBuf::from_path_buf(tmp.path().join(name)).unwrap();
+        let (secret, public) = generate_x25519_keypair();
+        std::fs::write(&path, format!("{secret}\n")).unwrap();
+        (path, public)
+    }
+
     #[test]
     fn x25519_round_trip() {
-        let (secret, public) = generate_x25519_keypair();
-        let id = age::x25519::Identity::from_str(&secret).unwrap();
-        let recipient = parse_recipient(&public).unwrap();
-        let plaintext = b"hello secret world\n";
-        let cipher = encrypt(plaintext, &[recipient]).unwrap();
-        // Ciphertext should look like an age file.
+        let tmp = TempDir::new().unwrap();
+        let (id_path, public) = write_x25519_identity_file(&tmp, "age.txt");
+        let identity = load_x25519_identity(&id_path).unwrap();
+        let recipient = parse_x25519_recipient(&public).unwrap();
+        let cipher = encrypt_x25519(b"hello secret world\n", &[recipient]).unwrap();
         assert!(cipher.starts_with(b"age-encryption.org/v1\n"));
-        let recovered = decrypt(&cipher, &id).unwrap();
+        let recovered = decrypt_x25519(&cipher, &identity).unwrap();
+        assert_eq!(recovered, b"hello secret world\n");
+    }
+
+    /// Wrap / unlock round-trip via a *boxed* X25519 identity (the
+    /// passkey path uses Box<dyn Identity>, but plugin binaries
+    /// aren't available in CI — exercise the same code path with
+    /// X25519, which is plugin-free but uses the same general
+    /// dyn-trait API).
+    #[test]
+    fn passkey_wrap_round_trip_via_x25519_proxy() {
+        let tmp = TempDir::new().unwrap();
+        let (id_path, public) = write_x25519_identity_file(&tmp, "age.txt");
+        let recipients = vec![parse_passkey_recipient(&public).unwrap()];
+        let plaintext = std::fs::read(&id_path).unwrap();
+        let wrapped = encrypt_to_passkeys(&plaintext, &recipients).unwrap();
+        // Boxed identity for the unlock side.
+        let identities: Vec<BoxedIdentity> = {
+            let id = load_x25519_identity(&id_path).unwrap();
+            vec![Box::new(id)]
+        };
+        let recovered = decrypt_with_passkeys(&wrapped, &identities).unwrap();
         assert_eq!(recovered, plaintext);
     }
 
     #[test]
     fn multi_recipient_decrypts_with_either_key() {
-        let (secret_a, public_a) = generate_x25519_keypair();
-        let (secret_b, public_b) = generate_x25519_keypair();
-        let id_a = age::x25519::Identity::from_str(&secret_a).unwrap();
-        let id_b = age::x25519::Identity::from_str(&secret_b).unwrap();
+        let tmp = TempDir::new().unwrap();
+        let (_id_a_path, public_a) = write_x25519_identity_file(&tmp, "a.txt");
+        let (_id_b_path, public_b) = write_x25519_identity_file(&tmp, "b.txt");
         let recipients = vec![
-            parse_recipient(&public_a).unwrap(),
-            parse_recipient(&public_b).unwrap(),
+            parse_x25519_recipient(&public_a).unwrap(),
+            parse_x25519_recipient(&public_b).unwrap(),
         ];
-        let plaintext = b"team secret";
-        let cipher = encrypt(plaintext, &recipients).unwrap();
-        // Either identity should decrypt — that's the whole point of
-        // multi-recipient encryption.
-        assert_eq!(decrypt(&cipher, &id_a).unwrap(), plaintext);
-        assert_eq!(decrypt(&cipher, &id_b).unwrap(), plaintext);
+        let cipher = encrypt_x25519(b"team secret", &recipients).unwrap();
+        // Either identity should decrypt.
+        let id_a =
+            load_x25519_identity(&Utf8PathBuf::from_path_buf(tmp.path().join("a.txt")).unwrap())
+                .unwrap();
+        let id_b =
+            load_x25519_identity(&Utf8PathBuf::from_path_buf(tmp.path().join("b.txt")).unwrap())
+                .unwrap();
+        assert_eq!(decrypt_x25519(&cipher, &id_a).unwrap(), b"team secret");
+        assert_eq!(decrypt_x25519(&cipher, &id_b).unwrap(), b"team secret");
     }
 
     #[test]
-    fn load_identity_skips_comments_and_blanks() {
+    fn load_x25519_skips_comments_and_blanks() {
         let tmp = TempDir::new().unwrap();
         let path = Utf8PathBuf::from_path_buf(tmp.path().join("age.txt")).unwrap();
         let (secret, _public) = generate_x25519_keypair();
         let body = format!("# created: 2026-05-02\n# public key: ageXXX\n\n{secret}\n");
         std::fs::write(&path, body).unwrap();
-        let id = load_identity(&path).unwrap();
-        // Round-trip through decrypt to confirm we got a usable
-        // identity back (not just any string-shaped placeholder).
-        let recipient = parse_recipient(&id.to_public().to_string()).unwrap();
-        let cipher = encrypt(b"x", &[recipient]).unwrap();
-        assert_eq!(decrypt(&cipher, &id).unwrap(), b"x");
+        let _id = load_x25519_identity(&path).unwrap();
     }
 
     #[test]
-    fn load_identity_errors_on_garbage() {
+    fn load_x25519_errors_on_garbage() {
         let tmp = TempDir::new().unwrap();
         let path = Utf8PathBuf::from_path_buf(tmp.path().join("bad.txt")).unwrap();
         std::fs::write(&path, "not a key at all\n").unwrap();
-        // `age::x25519::Identity` deliberately doesn't impl Debug
-        // (holds secret material), so `unwrap_err` won't compile —
-        // pattern match instead.
-        match load_identity(&path) {
-            Ok(_) => panic!("expected error on garbage identity file"),
-            Err(e) => assert!(format!("{e}").contains("not a valid age X25519 secret")),
+        match load_x25519_identity(&path) {
+            Ok(_) => panic!("expected parse error"),
+            Err(e) => assert!(format!("{e}").contains("not a valid age X25519")),
         }
     }
 
     #[test]
     fn parse_recipient_rejects_garbage() {
-        let err = parse_recipient("ssh-rsa AAAA…").unwrap_err();
+        let err = parse_x25519_recipient("ssh-rsa AAAA…").unwrap_err();
         assert!(format!("{err}").contains("not a valid age X25519 recipient"));
     }
 
     #[test]
+    fn parse_passkey_recipient_rejects_garbage() {
+        // `Box<dyn Recipient + Send>` doesn't impl Debug, so
+        // `unwrap_err` won't compile — match the result instead.
+        match parse_passkey_recipient("ssh-rsa AAAA…") {
+            Ok(_) => panic!("expected parse failure"),
+            Err(e) => assert!(format!("{e}").contains("not a valid age recipient")),
+        }
+    }
+
+    #[test]
     fn encrypt_with_no_recipients_errors() {
-        let err = encrypt(b"x", &[]).unwrap_err();
+        let err = encrypt_x25519(b"x", &[]).unwrap_err();
         assert!(format!("{err}").contains("no recipients"));
+    }
+
+    #[test]
+    fn encrypt_to_passkeys_with_no_recipients_errors() {
+        let err = encrypt_to_passkeys(b"x", &[]).unwrap_err();
+        assert!(format!("{err}").contains("no passkey recipients"));
     }
 
     #[test]
@@ -339,17 +498,14 @@ mod tests {
             strip_age_suffix(Utf8PathBuf::from("home/.ssh/id_ed25519.age").as_path()),
             Some(Utf8PathBuf::from("home/.ssh/id_ed25519"))
         );
-        // Multiple dots: only the trailing `.age` is stripped.
         assert_eq!(
             strip_age_suffix(Utf8PathBuf::from("home/notes.tar.gz.age").as_path()),
             Some(Utf8PathBuf::from("home/notes.tar.gz"))
         );
-        // Not a secret.
         assert_eq!(
             strip_age_suffix(Utf8PathBuf::from("home/foo.txt").as_path()),
             None
         );
-        // A literal `.age` with no stem isn't a secret either.
         assert_eq!(strip_age_suffix(Utf8PathBuf::from(".age").as_path()), None);
     }
 }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -53,6 +53,71 @@ use crate::{Error, Result};
 /// and plugin variants share the same type at the boundary.
 pub type BoxedIdentity = Box<dyn age::Identity>;
 
+/// Validate that `bytes` is a parseable X25519 identity file —
+/// at least one non-comment line is `AGE-SECRET-KEY-1…`. Used by
+/// `yui secret unlock` to fail before persisting bytes that
+/// happen to decrypt but aren't actually an identity (wrong
+/// `passkey_wrapped` path / corrupted blob). PR #60 review by
+/// coderabbitai.
+pub fn validate_x25519_identity_bytes(bytes: &[u8]) -> Result<()> {
+    let text = std::str::from_utf8(bytes).map_err(|_| {
+        Error::Other(anyhow::anyhow!(
+            "decrypted payload is not valid UTF-8 — \
+             passkey_wrapped doesn't look like an age identity file"
+        ))
+    })?;
+    let line = text
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with('#'))
+        .ok_or_else(|| {
+            Error::Other(anyhow::anyhow!(
+                "decrypted payload contains no key line \
+                 (only comments / blank lines) — passkey_wrapped \
+                 is not an age identity file"
+            ))
+        })?;
+    age::x25519::Identity::from_str(line)
+        .map(drop)
+        .map_err(|e| {
+            Error::Other(anyhow::anyhow!(
+                "decrypted payload is not a valid age X25519 secret \
+             (`AGE-SECRET-KEY-1…` expected): {e}"
+            ))
+        })
+}
+
+/// Write `bytes` to `path` with owner-only permissions on Unix
+/// (0600). On Windows we fall back to a plain write because file
+/// permissions don't translate cleanly — the user's `AGE-SECRET-KEY`
+/// is still in their `~/.config/yui/` directory which isn't shared
+/// by default. Used by both `secret_init` and `secret_unlock` so
+/// neither flow leaves the X25519 secret world-readable. PR #60
+/// review by coderabbitai.
+pub fn write_private_file(path: &Utf8Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    #[cfg(unix)]
+    {
+        use std::fs::OpenOptions;
+        use std::io::Write as _;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|e| Error::Other(anyhow::anyhow!("create {path}: {e}")))?;
+        file.write_all(bytes)
+            .map_err(|e| Error::Other(anyhow::anyhow!("write {path}: {e}")))?;
+    }
+    #[cfg(not(unix))]
+    std::fs::write(path, bytes).map_err(|e| Error::Other(anyhow::anyhow!("write {path}: {e}")))?;
+    Ok(())
+}
+
 /// Boxed dyn-trait recipient. Same reasoning as `BoxedIdentity` —
 /// `Encryptor::with_recipients` works on trait objects.
 pub type BoxedRecipient = Box<dyn age::Recipient + Send>;
@@ -496,6 +561,64 @@ mod tests {
     fn parse_recipient_rejects_garbage() {
         let err = parse_x25519_recipient("ssh-rsa AAAA…").unwrap_err();
         assert!(format!("{err}").contains("not a valid age X25519 recipient"));
+    }
+
+    /// PR #60 review: don't persist a decrypted blob that isn't
+    /// actually an age identity. Successful decrypt + bad payload
+    /// must fail, never get to disk.
+    #[test]
+    fn validate_x25519_identity_bytes_round_trip() {
+        let (secret, _public) = generate_x25519_keypair();
+        let body = format!("# header\n{secret}\n");
+        validate_x25519_identity_bytes(body.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn validate_x25519_identity_bytes_rejects_non_identity() {
+        let err = validate_x25519_identity_bytes(b"this is not an age identity\n").unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("not a valid age X25519 secret") || msg.contains("contains no key line"),
+            "unexpected error: {msg}",
+        );
+    }
+
+    #[test]
+    fn validate_x25519_identity_bytes_rejects_non_utf8() {
+        let err = validate_x25519_identity_bytes(&[0xff, 0xfe, 0x00]).unwrap_err();
+        assert!(format!("{err}").contains("not valid UTF-8"));
+    }
+
+    /// PR #60 review: write_private_file should never leave the
+    /// X25519 secret world-readable. We can only assert mode 0o600
+    /// on Unix; on Windows the helper falls back to plain write.
+    #[test]
+    fn write_private_file_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let path = Utf8PathBuf::from_path_buf(tmp.path().join("nested/age.txt")).unwrap();
+        write_private_file(&path, b"hello\n").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"hello\n");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            // mode includes file type bits; mask down to perms.
+            assert_eq!(
+                mode & 0o777,
+                0o600,
+                "expected 0o600, got {:o}",
+                mode & 0o777
+            );
+        }
+    }
+
+    #[test]
+    fn write_private_file_overwrites_existing() {
+        let tmp = TempDir::new().unwrap();
+        let path = Utf8PathBuf::from_path_buf(tmp.path().join("age.txt")).unwrap();
+        write_private_file(&path, b"v1").unwrap();
+        write_private_file(&path, b"v2").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"v2");
     }
 
     #[test]


### PR DESCRIPTION
Hardware keys (Pixel passkey, Bitwarden, YubiKey, Touch ID, etc.) now have a place in yui — but scoped to a **one-time-per-machine unlock**, NOT every apply. Daily apply stays X25519-only and silent.

## Two new commands

- **\`yui secret wrap\`** — encrypts the X25519 secret at \`[secrets].identity\` to every entry in \`[secrets].passkey_recipients\` (X25519 + plugin recipients mix freely), writes ciphertext to \`[secrets].passkey_wrapped\`. Commit that file.
- **\`yui secret unlock\`** — on a fresh machine, decrypts \`passkey_wrapped\` using one of \`[secrets].passkey_identities\`, restores the plaintext X25519 to \`[secrets].identity\`. After that, normal apply.

## Picker UX (dialoguer)

With multiple devices listed in \`passkey_identities\` and a TTY, \`unlock\` shows a Select prompt so the user picks Pixel vs Bitwarden vs whichever device they have at hand. Off-TTY or with \`--passkey <label>\` (substring match), skips the picker.

## Why two paths

Apply runs every day; if it had to prompt the Pixel each time, that'd be miserable. So the plain X25519 secret stays on the machine locally (\`~/.config/yui/age.txt\`, gitignored), and the passkey only gates the **transport ciphertext** that lives in the repo. Trade-off: revoking a machine's X25519 access still requires re-encrypting all \`*.age\` files with the X25519 recipients alone — the passkey doesn't gate individual secrets.

## Workflow

\`\`\`sh
# First machine — already has the X25519 from \`yui secret init\`:
cargo install age-plugin-fido2-hmac
age-plugin-fido2-hmac --generate >> .yui/passkeys.txt   # Pixel tap
# (paste recipient line into [secrets].passkey_recipients)
yui secret wrap                       # encrypts → .yui/age.txt.age
git add .yui/passkeys.txt .yui/age.txt.age && git commit

# New machine:
git clone <dotfiles>
yui secret unlock                     # picker → tap Pixel → done
yui apply                             # X25519 only, no prompts
\`\`\`

## Test plan

- [x] 175 tests passing (12 new in \`secret\` module covering both X25519 and the plugin-shape boxed types)
- [x] \`cargo make check\` (fmt + clippy \`-D warnings\` + locked check + tests)
- [x] X25519 wrap/unlock round-trip via boxed-trait API (proxies the plugin path since plugin binaries aren't on CI)
- [x] \`apply\` skips the \`passkey_wrapped\` file so the X25519 walker doesn't try to decrypt the passkey-encrypted ciphertext

## New deps

- \`age\` features \`["cli-common", "plugin"]\` — pulls plugin runtime + UiCallbacks
- \`dialoguer = "0.12"\` (default-features = false) — the picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `wrap` and `unlock` commands for hardware MFA/passkey-based secret management.
  * Interactive device picker for multiple identity selection on unlock.
  * Support for passkey-wrapped secrets with configurable storage locations.

* **Documentation**
  * Comprehensive guide for hardware MFA/passkey setup, configuration, and per-machine unlock workflows.

* **Chores**
  * Updated dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->