### PR TITLE
feat(secrets): vault-backed transport (Bitwarden / 1Password), drop age-passkey path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,21 +19,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a07d86e4272c093c88caf7864a2d09af52a5159180848ca4832a3cdbd7d014d5"
 dependencies = [
  "age-core",
- "base64",
+ "base64 0.21.7",
  "bech32",
  "chacha20poly1305",
+ "console 0.15.11",
  "cookie-factory",
  "hmac",
  "i18n-embed",
  "i18n-embed-fl",
+ "is-terminal",
  "lazy_static",
  "nom",
  "pin-project",
+ "pinentry",
  "rand",
+ "rpassword",
  "rust-embed",
  "scrypt",
  "sha2 0.10.9",
  "subtle",
+ "which",
+ "wsl",
  "x25519-dalek",
  "zeroize",
 ]
@@ -44,7 +50,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "chacha20poly1305",
  "cookie-factory",
  "hkdf",
@@ -53,6 +59,7 @@ dependencies = [
  "rand",
  "secrecy",
  "sha2 0.10.9",
+ "tempfile",
 ]
 
 [[package]]
@@ -109,7 +116,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -120,7 +127,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -179,6 +186,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "basic-toml"
@@ -386,6 +399,18 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
@@ -393,7 +418,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -557,6 +582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,7 +606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -832,6 +863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +884,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -997,7 +1043,7 @@ version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console",
+ "console 0.16.3",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -1039,6 +1085,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,7 +1119,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1110,7 +1167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1145,6 +1202,12 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1210,7 +1273,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1420,6 +1483,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pinentry"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a108bb5e4e654a3d20c834e5676b4b20f7cd2cc73b22f849d93e028b259340ec"
+dependencies = [
+ "log",
+ "nom",
+ "percent-encoding",
+ "secrecy",
+ "wait-timeout",
+ "which",
+ "zeroize",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,6 +1687,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rpassword"
+version = "7.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2501c67132bd19c3005b0111fba298907ef002c8c1cf68e25634707e38bf66fe"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,6 +1764,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1672,8 +1784,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1905,8 +2017,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2387,6 +2499,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,7 +2529,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2469,12 +2593,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2586,6 +2783,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wsl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
+
+[[package]]
 name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2605,6 +2808,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_fs",
+ "base64 0.22.1",
  "camino",
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,9 @@ name = "yui"
 path = "src/lib.rs"
 
 [dependencies]
-age = "0.11.3"
+age = { version = "0.11.3", features = ["cli-common", "plugin"] }
 anyhow = "1.0.102"
+base64 = "0.22"
 camino = { version = "1.2.2", features = ["serde1"] }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 clap_complete = "4.6.3"

--- a/README.md
+++ b/README.md
@@ -279,17 +279,61 @@ access:
    `yui secret encrypt --force <path>` per file. A `yui secret reencrypt`
    helper is planned.)
 
-### Roadmap: hardware MFA / passkey
+### Carrying the X25519 across machines (vault model)
 
-age has a plugin ecosystem (YubiKey, FIDO2 incl. Pixel 10 Pro
-cross-device passkeys, Touch ID via Secure Enclave, Windows Hello,
-TPM, 1Password). yui v1's identity / recipient parsing is X25519-only
-to keep the bootstrap flow simple, but the data model is plugin-ready;
-plugin support (with the callback plumbing those interactive flows
-need) is planned as a follow-up. Until then you can interoperate at
-the file level by encrypting `.age` files outside yui via `rage` /
-`age-plugin-*` and committing them — yui's X25519 identity can still
-decrypt files that were also wrapped to your X25519 recipient.
+`apply` only ever uses the plain X25519 secret at
+`[secrets].identity` — no device prompts on the hot path. To
+ferry that secret to a new machine, yui wraps a vault provider
+of your choice (**Bitwarden** or **1Password**) so the same
+auth you already use for that vault — master password, biometric,
+passkey unlock in the web vault, SSO — gates the unlock here.
+
+```toml
+[secrets]
+identity   = "~/.config/yui/age.txt"   # X25519 plain, gitignored
+recipients = ["age1abc…"]              # X25519 publics for *.age files
+
+[secrets.vault]
+provider = "bitwarden"                 # or "1password"
+item     = "yui-x25519-identity"       # vault item name
+```
+
+#### Setup (once on the first machine)
+
+```sh
+yui secret init                # generates ~/.config/yui/age.txt
+yui secret store               # pushes the file into the vault Secure Note
+```
+
+#### On each new machine
+
+```sh
+git clone <dotfiles>
+# 1. Authenticate the vault CLI ONCE on this machine:
+bw login && bw unlock          # Bitwarden — or `op signin` for 1Password
+# 2. Pull the X25519 from the vault:
+yui secret unlock              # writes ~/.config/yui/age.txt
+yui apply                      # done
+```
+
+The vault CLI itself is the auth boundary — yui shells out to
+`bw` / `op` and inherits whatever factor that CLI accepts.
+Bitwarden's web vault supports passkey unlock; once you've used
+your Pixel passkey to log into the BW web vault and the CLI
+session is alive, `yui secret unlock` will quietly fetch the
+X25519 with no further prompts.
+
+#### Plugin recipients (advanced, unsupported)
+
+`[secrets].recipients` accepts plugin-flavoured public keys
+(`age1yubikey1…`, `age1fido2-hmac1…`, …) alongside the X25519
+ones. yui doesn't ship first-class commands for plugin
+identities — `apply` decrypts only with the X25519 in
+`[secrets].identity` — but encrypting `*.age` files to
+plugin-backed *recipients* works as long as the matching
+`age-plugin-*` binary is on `$PATH`, so a YubiKey holder can
+decrypt the same file via `age` directly without yui in the
+loop. No support promises, but the path is open.
 
 [age]: https://age-encryption.org/
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -241,6 +241,25 @@ pub enum SecretAction {
         #[arg(long)]
         rm_plaintext: bool,
     },
+
+    /// Push the X25519 secret at `[secrets].identity` into the
+    /// configured `[secrets.vault]` (Bitwarden or 1Password).
+    /// Run this once on a machine that has the X25519; then on
+    /// a new machine `yui secret unlock` recovers it through the
+    /// vault provider's own auth (master password, biometric,
+    /// passkey, SSO — whatever the vault itself accepts).
+    Store {
+        /// Overwrite the existing vault item without prompting.
+        #[arg(long)]
+        force: bool,
+    },
+
+    /// Fetch the X25519 secret from the configured `[secrets.vault]`
+    /// and write it to `[secrets].identity`. The vault CLI (`bw`
+    /// or `op`) handles its own auth, so any factor that CLI
+    /// supports (passkey unlock in the BW web vault, Touch ID via
+    /// 1Password, …) gates this command.
+    Unlock,
 }
 
 #[derive(Subcommand, Debug)]
@@ -308,6 +327,8 @@ impl Cli {
                     force,
                     rm_plaintext,
                 } => cmd::secret_encrypt(source, path, force, rm_plaintext),
+                SecretAction::Store { force } => cmd::secret_store(source, force),
+                SecretAction::Unlock => cmd::secret_unlock(source),
             },
             Command::Completion { shell } => {
                 let mut cmd = Cli::command();

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -19,6 +19,7 @@ use crate::render::{self, RenderReport};
 use crate::secret;
 use crate::template;
 use crate::vars::YuiVars;
+use crate::vault;
 use crate::{absorb, backup, paths};
 
 // NOTE: `owo_colors::OwoColorize` is intentionally NOT imported at module
@@ -712,16 +713,15 @@ pub fn secret_init(source: Option<Utf8PathBuf>, comment: Option<String>) -> Resu
     //    the same header age-keygen uses, so the file is
     //    interoperable with the standalone CLI tools.
     let (secret, public) = secret::generate_x25519_keypair();
-    if let Some(parent) = identity_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
     let now = jiff::Zoned::now().to_string();
     let body = format!(
         "# created: {now}\n\
          # public key: {public}\n\
          {secret}\n"
     );
-    std::fs::write(&identity_path, body)?;
+    // 0600 on Unix so other local users can't read the X25519
+    // secret. PR #60 review by coderabbitai.
+    secret::write_private_file(&identity_path, body.as_bytes())?;
     info!("wrote identity file: {identity_path}");
 
     // 3. Append the public key to `[secrets] recipients` in
@@ -850,13 +850,15 @@ pub fn secret_encrypt(
     }
 
     let plaintext = std::fs::read(&plaintext_path)?;
-    let recipients: Vec<age::x25519::Recipient> = config
-        .secrets
-        .recipients
-        .iter()
-        .map(|s| secret::parse_recipient(s))
-        .collect::<crate::Result<_>>()?;
-    let cipher = secret::encrypt(&plaintext, &recipients)?;
+    // Use the general parser so `[secrets].recipients` can hold
+    // plugin entries (`age1yubikey1…` / `age1fido2-hmac1…` etc.)
+    // alongside the X25519 ones. yui doesn't drive plugin flows
+    // first-class, but a hand-written plugin recipient still gets
+    // a stanza in the ciphertext — useful if a user wants their
+    // YubiKey to decrypt the same `*.age` outside yui via the
+    // standalone `age` CLI.
+    let recipients = secret::parse_passkey_recipients(&config.secrets.recipients)?;
+    let cipher = secret::encrypt_to_passkeys(&plaintext, &recipients)?;
     std::fs::write(&cipher_path, &cipher)?;
     info!("encrypted {plaintext_path} → {cipher_path}");
 
@@ -873,6 +875,105 @@ pub fn secret_encrypt(
             );
         }
     }
+    Ok(())
+}
+
+/// `yui secret store [--force]` — push the X25519 identity at
+/// `[secrets].identity` into the configured `[secrets.vault]`.
+/// Run on a machine that already has the identity; the new
+/// machine then recovers it via `yui secret unlock`.
+///
+/// yui doesn't drive the vault's auth flow itself — it shells
+/// out to `bw` / `op`. Whatever those CLIs are configured to
+/// accept (master password, biometric, passkey unlock in the
+/// web vault, SSO) gates the operation.
+pub fn secret_store(source: Option<Utf8PathBuf>, force: bool) -> Result<()> {
+    let source = resolve_source(source)?;
+    let yui = YuiVars::detect(&source);
+    let config = config::load(&source, &yui)?;
+
+    let vault_cfg = config.secrets.vault.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "[secrets.vault] is not configured — set provider \
+             (\"bitwarden\" or \"1password\") and item before \
+             calling store"
+        )
+    })?;
+
+    let identity_path = paths::expand_tilde(&config.secrets.identity);
+    if !identity_path.is_file() {
+        anyhow::bail!(
+            "no X25519 identity at {identity_path}; run `yui secret init` first \
+             (store needs that file's content to push to the vault)"
+        );
+    }
+    let plaintext = std::fs::read(&identity_path)?;
+
+    let vault = vault::driver(vault_cfg);
+    info!(
+        "pushing X25519 identity to {} item {:?}",
+        vault.provider_name(),
+        vault_cfg.item
+    );
+    vault.store(&vault_cfg.item, &plaintext, force)?;
+
+    println!();
+    println!(
+        "  X25519 identity pushed to {} item {:?}",
+        vault.provider_name(),
+        vault_cfg.item
+    );
+    println!("  On a new machine, run `yui secret unlock`.");
+    Ok(())
+}
+
+/// `yui secret unlock` — fetch the X25519 identity from the
+/// configured `[secrets.vault]` and write it to
+/// `[secrets].identity`. The vault provider's CLI (`bw` / `op`)
+/// handles auth — yui inherits whatever factor that CLI is
+/// configured to require.
+pub fn secret_unlock(source: Option<Utf8PathBuf>) -> Result<()> {
+    let source = resolve_source(source)?;
+    let yui = YuiVars::detect(&source);
+    let config = config::load(&source, &yui)?;
+
+    let vault_cfg = config.secrets.vault.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "[secrets.vault] is not configured — nothing to unlock. \
+             Run `yui secret init` + `yui secret store` on an existing \
+             machine first, then commit + push the config."
+        )
+    })?;
+    let identity_path = paths::expand_tilde(&config.secrets.identity);
+    if identity_path.exists() {
+        anyhow::bail!(
+            "{identity_path} already exists — refusing to clobber a live \
+             X25519 identity. Delete it first if you really mean to \
+             re-unlock from scratch."
+        );
+    }
+
+    let vault = vault::driver(vault_cfg);
+    info!(
+        "fetching X25519 identity from {} item {:?}",
+        vault.provider_name(),
+        vault_cfg.item
+    );
+    let plaintext = vault.fetch(&vault_cfg.item)?;
+
+    // Validate before persisting — the vault could legitimately
+    // hold any blob, so the fetched bytes might not actually be
+    // an age identity (typo'd item name, wrong field). Bail
+    // before touching `[secrets].identity` so a future apply
+    // doesn't fail with a confusing "not a valid age key" error.
+    secret::validate_x25519_identity_bytes(&plaintext)?;
+
+    // 0600 on Unix — never leave the X25519 secret world-readable.
+    secret::write_private_file(&identity_path, &plaintext)?;
+    info!("wrote X25519 identity: {identity_path}");
+    println!();
+    println!("  X25519 identity restored at {identity_path}");
+    println!("  Run `yui apply` next.");
     Ok(())
 }
 
@@ -4940,8 +5041,8 @@ dst = "{}"
         std::fs::write(&identity_path, format!("{secret}\n")).unwrap();
 
         // 2. Encrypt a fake private key into source as `.age`.
-        let recipient = secret::parse_recipient(&public).unwrap();
-        let cipher = secret::encrypt(b"-- super secret key --\n", &[recipient]).unwrap();
+        let recipient = secret::parse_x25519_recipient(&public).unwrap();
+        let cipher = secret::encrypt_x25519(b"-- super secret key --\n", &[recipient]).unwrap();
         std::fs::write(source.join("home/.ssh/id_ed25519.age"), &cipher).unwrap();
 
         // 3. config.toml: mount + secrets pointing at the test identity.
@@ -4994,8 +5095,8 @@ recipients = ["{}"]
         let (secret_key, public) = secret::generate_x25519_keypair();
         std::fs::write(&identity_path, format!("{secret_key}\n")).unwrap();
 
-        let recipient = secret::parse_recipient(&public).unwrap();
-        let cipher = secret::encrypt(b"v1 content\n", &[recipient]).unwrap();
+        let recipient = secret::parse_x25519_recipient(&public).unwrap();
+        let cipher = secret::encrypt_x25519(b"v1 content\n", &[recipient]).unwrap();
         std::fs::write(source.join("home/secret.age"), &cipher).unwrap();
         // Drifted sibling: plaintext exists but doesn't match the .age content.
         std::fs::write(source.join("home/secret"), "edited locally\n").unwrap();

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -908,6 +908,11 @@ pub fn secret_store(source: Option<Utf8PathBuf>, force: bool) -> Result<()> {
         );
     }
     let plaintext = std::fs::read(&identity_path)?;
+    // Refuse to upload bytes that aren't actually an age identity
+    // — a mistyped `[secrets].identity` path or a corrupted file
+    // would otherwise stash garbage that `yui secret unlock`
+    // would only fail to use later. (PR #61 review by coderabbitai.)
+    secret::validate_x25519_identity_bytes(&plaintext)?;
 
     let vault = vault::driver(vault_cfg);
     // Verify the provider CLI is installed and authenticated

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -910,6 +910,11 @@ pub fn secret_store(source: Option<Utf8PathBuf>, force: bool) -> Result<()> {
     let plaintext = std::fs::read(&identity_path)?;
 
     let vault = vault::driver(vault_cfg);
+    // Verify the provider CLI is installed and authenticated
+    // BEFORE reading the identity into memory + pushing — gives
+    // the user an actionable hint instead of the raw `bw` /
+    // `op` error from the upcoming write.
+    vault.precheck()?;
     info!(
         "pushing X25519 identity to {} item {:?}",
         vault.provider_name(),
@@ -954,6 +959,7 @@ pub fn secret_unlock(source: Option<Utf8PathBuf>) -> Result<()> {
     }
 
     let vault = vault::driver(vault_cfg);
+    vault.precheck()?;
     info!(
         "fetching X25519 identity from {} item {:?}",
         vault.provider_name(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -288,10 +288,34 @@ fn default_backup_dir() -> String {
 /// as "secrets feature off".
 #[derive(Debug, Clone, Deserialize)]
 pub struct SecretsConfig {
+    /// Path to the X25519 secret key used by `apply` to decrypt
+    /// `*.age` files. Plain (`AGE-SECRET-KEY-1…`) text, gitignored.
+    /// Default `~/.config/yui/age.txt`.
     #[serde(default = "default_identity_path")]
     pub identity: String,
+
+    /// Public keys that `*.age` files are encrypted to. X25519
+    /// (`age1…`) is the everyday case and is what `yui secret init`
+    /// adds. Plugin recipients (`age1<plugin>1…`) are also accepted
+    /// — yui doesn't ship first-class commands for them, but if you
+    /// hand-write a YubiKey / FIDO2 / TPM / Secure Enclave / 1P
+    /// recipient here it'll be honored, and the matching
+    /// `age-plugin-*` binary on `$PATH` lets `age` itself decrypt
+    /// those stanzas. (yui's apply uses the X25519 in `identity`
+    /// only, so plugin recipients add a *parallel* decrypt path
+    /// without slowing apply down.)
+    ///
+    /// Empty = secrets feature off.
     #[serde(default)]
     pub recipients: Vec<String>,
+
+    /// Vault provider config — when set, `yui secret store` /
+    /// `yui secret unlock` use it to ferry the X25519 identity
+    /// across machines via Bitwarden / 1Password instead of
+    /// asking the user to copy `~/.config/yui/age.txt` by hand.
+    /// Off when absent.
+    #[serde(default)]
+    pub vault: Option<VaultConfig>,
 }
 
 impl Default for SecretsConfig {
@@ -299,8 +323,37 @@ impl Default for SecretsConfig {
         Self {
             identity: default_identity_path(),
             recipients: Vec::new(),
+            vault: None,
         }
     }
+}
+
+/// `[secrets.vault]` — points yui at a vault item that holds the
+/// X25519 identity. yui doesn't authenticate against the vault
+/// itself; it shells out to the provider's official CLI (`bw` or
+/// `op`), which already knows how to drive its own auth flow
+/// (master password, biometric, passkey-via-web-vault, SSO).
+///
+/// Storage convention: the X25519 secret file's full content
+/// (header comments + the `AGE-SECRET-KEY-1…` line) goes in the
+/// item's notes field. Picking notes (rather than the password
+/// field) keeps the multi-line content intact and doesn't pollute
+/// the vault's password autofill UI.
+#[derive(Debug, Clone, Deserialize)]
+pub struct VaultConfig {
+    /// `"bitwarden"` or `"1password"`.
+    pub provider: VaultProvider,
+    /// Item name / id inside the vault. yui passes this verbatim
+    /// to `bw get item <item>` / `op item get <item>`.
+    pub item: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum VaultProvider {
+    Bitwarden,
+    #[serde(alias = "1password")]
+    OnePassword,
 }
 
 impl SecretsConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod render;
 pub mod secret;
 pub mod template;
 pub mod vars;
+pub mod vault;
 
 pub use error::{Error, Result};
 

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -17,31 +17,118 @@
 //! means the crypto stays out of `render.rs`, which a casual
 //! reader expects to be pure-text manipulation.
 //!
-//! ## v1 scope: X25519 only
+//! ## Two distinct encryption paths
 //!
-//! `[secrets] identity` is an X25519 secret (`AGE-SECRET-KEY-1…`)
-//! and `recipients = […]` are X25519 public keys (`age1…`).
-//! `yui secret init` produces both.
+//! 1. **`*.age` files in apply** — encrypted to `[secrets] recipients`,
+//!    decrypted with the plain X25519 secret at
+//!    `[secrets] identity` (e.g. `~/.config/yui/age.txt`). Runs every
+//!    apply, must be friction-free, must NOT trigger device prompts.
+//!    Identities here are X25519 only by convention.
 //!
-//! Plugin-backed identities (YubiKey / FIDO2 passkey / Touch ID /
-//! TPM / 1Password) need age's `plugin` feature plus callback
-//! plumbing to drive the plugin binaries' interactive prompts —
-//! a worthwhile follow-up but real implementation work, kept out
-//! of v1 to ship the simple flow first.
+//! 2. **passkey wrap of the X25519 secret itself** — the user's
+//!    `~/.config/yui/age.txt` (plain X25519) gets encrypted to one
+//!    or more passkey recipients (Pixel / Bitwarden / YubiKey, via
+//!    the `age-plugin-fido2-hmac` etc.) so it can travel with the
+//!    dotfiles repo as ciphertext. Used only by `yui secret wrap`
+//!    and `yui secret unlock` — never by apply. Plugin identities
+//!    appear ONLY here, so the apply path stays plugin-free.
+//!
+//! Recipient strings split the same way: `age1…` for X25519 and
+//! `age1<plugin>1…` for plugin recipients. Multiple recipient types
+//! can mix in a single ciphertext — useful for wrap, where the
+//! user might want both Pixel and Bitwarden as recovery devices.
 
-use std::io::{Read as _, Write as _};
+use std::io::{BufReader, Read as _, Write as _};
 use std::str::FromStr as _;
 
+use age::IdentityFile;
+use age::cli_common::UiCallbacks;
 use age::secrecy::ExposeSecret as _;
 use camino::Utf8Path;
 
 use crate::{Error, Result};
 
-/// Load an age X25519 identity from `path`. The file is expected
-/// to be the output of `age-keygen` / `yui secret init`: lines
-/// beginning with `#` are comments, the first non-comment line is
-/// the `AGE-SECRET-KEY-1…` secret.
-pub fn load_identity(path: &Utf8Path) -> Result<age::x25519::Identity> {
+/// Boxed dyn-trait identity. age's `Decryptor::decrypt` takes a
+/// trait-object iterator, so we hand it boxed identities; X25519
+/// and plugin variants share the same type at the boundary.
+pub type BoxedIdentity = Box<dyn age::Identity>;
+
+/// Validate that `bytes` is a parseable X25519 identity file —
+/// at least one non-comment line is `AGE-SECRET-KEY-1…`. Used by
+/// `yui secret unlock` to fail before persisting bytes that
+/// happen to decrypt but aren't actually an identity (wrong
+/// `passkey_wrapped` path / corrupted blob). PR #60 review by
+/// coderabbitai.
+pub fn validate_x25519_identity_bytes(bytes: &[u8]) -> Result<()> {
+    let text = std::str::from_utf8(bytes).map_err(|_| {
+        Error::Other(anyhow::anyhow!(
+            "decrypted payload is not valid UTF-8 — \
+             passkey_wrapped doesn't look like an age identity file"
+        ))
+    })?;
+    let line = text
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with('#'))
+        .ok_or_else(|| {
+            Error::Other(anyhow::anyhow!(
+                "decrypted payload contains no key line \
+                 (only comments / blank lines) — passkey_wrapped \
+                 is not an age identity file"
+            ))
+        })?;
+    age::x25519::Identity::from_str(line)
+        .map(drop)
+        .map_err(|e| {
+            Error::Other(anyhow::anyhow!(
+                "decrypted payload is not a valid age X25519 secret \
+             (`AGE-SECRET-KEY-1…` expected): {e}"
+            ))
+        })
+}
+
+/// Write `bytes` to `path` with owner-only permissions on Unix
+/// (0600). On Windows we fall back to a plain write because file
+/// permissions don't translate cleanly — the user's `AGE-SECRET-KEY`
+/// is still in their `~/.config/yui/` directory which isn't shared
+/// by default. Used by both `secret_init` and `secret_unlock` so
+/// neither flow leaves the X25519 secret world-readable. PR #60
+/// review by coderabbitai.
+pub fn write_private_file(path: &Utf8Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    #[cfg(unix)]
+    {
+        use std::fs::OpenOptions;
+        use std::io::Write as _;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|e| Error::Other(anyhow::anyhow!("create {path}: {e}")))?;
+        file.write_all(bytes)
+            .map_err(|e| Error::Other(anyhow::anyhow!("write {path}: {e}")))?;
+    }
+    #[cfg(not(unix))]
+    std::fs::write(path, bytes).map_err(|e| Error::Other(anyhow::anyhow!("write {path}: {e}")))?;
+    Ok(())
+}
+
+/// Boxed dyn-trait recipient. Same reasoning as `BoxedIdentity` —
+/// `Encryptor::with_recipients` works on trait objects.
+pub type BoxedRecipient = Box<dyn age::Recipient + Send>;
+
+/// Load an age X25519 identity from `path`, the way `apply` needs
+/// it. Refuses anything other than a plain `AGE-SECRET-KEY-1…`
+/// secret — apply must NEVER drop into a plugin flow because that
+/// would prompt for a touch / PIN / biometric on every run.
+/// (The user's mental model is "Pixel only at unlock time, not
+/// every apply", so apply stays X25519-only on principle.)
+pub fn load_x25519_identity(path: &Utf8Path) -> Result<age::x25519::Identity> {
     let raw = std::fs::read_to_string(path)
         .map_err(|e| Error::Other(anyhow::anyhow!("read identity {path}: {e}")))?;
     let line = raw
@@ -62,8 +149,30 @@ pub fn load_identity(path: &Utf8Path) -> Result<age::x25519::Identity> {
     })
 }
 
-/// Parse an X25519 recipient string (`age1…`).
-pub fn parse_recipient(s: &str) -> Result<age::x25519::Recipient> {
+/// Load every identity from `path`, allowing plugin entries
+/// (`AGE-PLUGIN-…`). Used by `yui secret unlock` where the file
+/// holds passkey identities (Pixel, Bitwarden, …) that age must
+/// drive interactively at decrypt time.
+///
+/// `IdentityFile` parses comments / blank lines / multiple entries
+/// per the standard age format; `with_callbacks(UiCallbacks)`
+/// hands plugin invocations a terminal-based prompt for "press
+/// the button now" / etc.
+pub fn load_passkey_identities(path: &Utf8Path) -> Result<Vec<BoxedIdentity>> {
+    let file = std::fs::File::open(path)
+        .map_err(|e| Error::Other(anyhow::anyhow!("read passkey identities {path}: {e}")))?;
+    let id_file = IdentityFile::from_buffer(BufReader::new(file))
+        .map_err(|e| Error::Other(anyhow::anyhow!("parse {path}: {e}")))?;
+    id_file
+        .with_callbacks(UiCallbacks)
+        .into_identities()
+        .map_err(|e| Error::Other(anyhow::anyhow!("load identities from {path}: {e}")))
+}
+
+/// Parse an X25519 recipient string (`age1…`). Used for the
+/// `[secrets] recipients` list which encrypts the user's `*.age`
+/// files — those must stay plugin-free so apply doesn't prompt.
+pub fn parse_x25519_recipient(s: &str) -> Result<age::x25519::Recipient> {
     let trimmed = s.trim();
     age::x25519::Recipient::from_str(trimmed).map_err(|e| {
         Error::Other(anyhow::anyhow!(
@@ -72,10 +181,58 @@ pub fn parse_recipient(s: &str) -> Result<age::x25519::Recipient> {
     })
 }
 
-/// Encrypt `plaintext` to one or more recipients. The output is
-/// the binary age format (the same bytes a `*.age` file holds on
-/// disk).
-pub fn encrypt(plaintext: &[u8], recipients: &[age::x25519::Recipient]) -> Result<Vec<u8>> {
+/// Parse a single recipient string — X25519 or plugin. Used in
+/// tests and for debugging; production wrap goes through
+/// `parse_passkey_recipients` which batches plugin recipients.
+pub fn parse_passkey_recipient(s: &str) -> Result<BoxedRecipient> {
+    parse_passkey_recipients(std::slice::from_ref(&s.to_string()))
+        .map(|mut v| v.pop().expect("single input → single output"))
+}
+
+/// Parse a list of recipient strings, grouping plugin recipients
+/// by plugin name into a single `RecipientPluginV1` per group.
+/// Without grouping, each plugin recipient would spawn the
+/// `age-plugin-*` binary independently — wasteful and (for some
+/// plugins) prompts the user multiple times. (PR #60 review by
+/// gemini-code-assist.)
+///
+/// X25519 recipients pass through one-Box-per-string since they
+/// have no plugin process to batch.
+pub fn parse_passkey_recipients(strings: &[String]) -> Result<Vec<BoxedRecipient>> {
+    use std::collections::BTreeMap;
+
+    let mut out: Vec<BoxedRecipient> = Vec::new();
+    let mut by_plugin: BTreeMap<String, Vec<age::plugin::Recipient>> = BTreeMap::new();
+
+    for s in strings {
+        let trimmed = s.trim();
+        if let Ok(r) = age::x25519::Recipient::from_str(trimmed) {
+            out.push(Box::new(r));
+            continue;
+        }
+        if let Ok(r) = age::plugin::Recipient::from_str(trimmed) {
+            let name = r.plugin().to_string();
+            by_plugin.entry(name).or_default().push(r);
+            continue;
+        }
+        return Err(Error::Other(anyhow::anyhow!(
+            "not a valid age recipient {trimmed:?} \
+             (expected `age1…` or `age1<plugin>1…`)"
+        )));
+    }
+
+    for (name, recipients) in by_plugin {
+        let plugin = age::plugin::RecipientPluginV1::new(&name, &recipients, &[], UiCallbacks)
+            .map_err(|e| Error::Other(anyhow::anyhow!("plugin recipient group {name:?}: {e}")))?;
+        out.push(Box::new(plugin));
+    }
+
+    Ok(out)
+}
+
+/// Encrypt `plaintext` to one or more X25519 recipients. Used for
+/// `*.age` files in the apply pipeline.
+pub fn encrypt_x25519(plaintext: &[u8], recipients: &[age::x25519::Recipient]) -> Result<Vec<u8>> {
     if recipients.is_empty() {
         return Err(Error::Other(anyhow::anyhow!(
             "no recipients configured — add at least one to `[secrets] recipients` \
@@ -85,7 +242,30 @@ pub fn encrypt(plaintext: &[u8], recipients: &[age::x25519::Recipient]) -> Resul
     let encryptor =
         age::Encryptor::with_recipients(recipients.iter().map(|r| r as &dyn age::Recipient))
             .map_err(|e| Error::Other(anyhow::anyhow!("age encryptor: {e}")))?;
+    write_encrypted(encryptor, plaintext)
+}
 
+/// Encrypt `plaintext` to one or more potentially-plugin
+/// recipients. Used by `yui secret wrap` to encrypt the X25519
+/// identity to passkey devices (Pixel + Bitwarden + …).
+pub fn encrypt_to_passkeys(plaintext: &[u8], recipients: &[BoxedRecipient]) -> Result<Vec<u8>> {
+    if recipients.is_empty() {
+        return Err(Error::Other(anyhow::anyhow!(
+            "no passkey recipients configured — add at least one to \
+             `[secrets] passkey_recipients` (each entry is the public \
+             key of a Pixel / Bitwarden / etc. device)"
+        )));
+    }
+    let encryptor = age::Encryptor::with_recipients(
+        recipients
+            .iter()
+            .map(|r| -> &dyn age::Recipient { r.as_ref() }),
+    )
+    .map_err(|e| Error::Other(anyhow::anyhow!("age encryptor: {e}")))?;
+    write_encrypted(encryptor, plaintext)
+}
+
+fn write_encrypted(encryptor: age::Encryptor, plaintext: &[u8]) -> Result<Vec<u8>> {
     let mut out = Vec::with_capacity(plaintext.len() + 256);
     let mut writer = encryptor
         .wrap_output(&mut out)
@@ -99,13 +279,28 @@ pub fn encrypt(plaintext: &[u8], recipients: &[age::x25519::Recipient]) -> Resul
     Ok(out)
 }
 
-/// Decrypt `ciphertext` (the bytes of a `*.age` file) using the
-/// supplied identity. Returns the plaintext on success.
-pub fn decrypt(ciphertext: &[u8], identity: &age::x25519::Identity) -> Result<Vec<u8>> {
+/// Decrypt `ciphertext` (the bytes of a `*.age` file) using a
+/// single X25519 identity. Used by the apply pipeline.
+pub fn decrypt_x25519(ciphertext: &[u8], identity: &age::x25519::Identity) -> Result<Vec<u8>> {
     let decryptor = age::Decryptor::new(ciphertext)
         .map_err(|e| Error::Other(anyhow::anyhow!("age decryptor: {e}")))?;
     let mut reader = decryptor
         .decrypt(std::iter::once(identity as &dyn age::Identity))
+        .map_err(|e| Error::Other(anyhow::anyhow!("age decrypt: {e}")))?;
+    let mut out = Vec::new();
+    reader
+        .read_to_end(&mut out)
+        .map_err(|e| Error::Other(anyhow::anyhow!("age read: {e}")))?;
+    Ok(out)
+}
+
+/// Decrypt `ciphertext` using any of the supplied (potentially
+/// plugin-backed) identities. Used by `yui secret unlock`.
+pub fn decrypt_with_passkeys(ciphertext: &[u8], identities: &[BoxedIdentity]) -> Result<Vec<u8>> {
+    let decryptor = age::Decryptor::new(ciphertext)
+        .map_err(|e| Error::Other(anyhow::anyhow!("age decryptor: {e}")))?;
+    let mut reader = decryptor
+        .decrypt(identities.iter().map(|i| i.as_ref() as &dyn age::Identity))
         .map_err(|e| Error::Other(anyhow::anyhow!("age decrypt: {e}")))?;
     let mut out = Vec::new();
     reader
@@ -146,9 +341,13 @@ pub fn strip_age_suffix(path: &Utf8Path) -> Option<camino::Utf8PathBuf> {
 ///
 /// Returns `Ok(SecretReport::default())` when `[secrets]` is off
 /// (no recipients configured). Otherwise loads the identity once
-/// and decrypts each `.age` file. `dry_run = true` skips the
-/// disk write but still confirms the file decrypts (so a missing
-/// identity / corrupted ciphertext surfaces as an error early).
+/// and decrypts each `.age` file. The identity is X25519-only
+/// here on purpose — apply must NOT trigger plugin / passkey
+/// prompts every run.
+///
+/// Skips the `passkey_wrapped` ciphertext file: it's encrypted to
+/// passkey recipients (NOT the X25519), so trying to decrypt it
+/// here would fail loudly. The unlock path handles it instead.
 pub fn decrypt_all(
     source: &Utf8Path,
     config: &crate::config::Config,
@@ -160,7 +359,7 @@ pub fn decrypt_all(
     }
 
     let identity_path = crate::paths::expand_tilde(&config.secrets.identity);
-    let identity = load_identity(&identity_path)?;
+    let identity = load_x25519_identity(&identity_path)?;
 
     let walker = crate::paths::source_walker(source).build();
     for entry in walker {
@@ -189,15 +388,10 @@ pub fn decrypt_all(
 
         let cipher_bytes = std::fs::read(&cipher_path)
             .map_err(|e| Error::Other(anyhow::anyhow!("read {cipher_path}: {e}")))?;
-        let plain_bytes = decrypt(&cipher_bytes, &identity)?;
+        let plain_bytes = decrypt_x25519(&cipher_bytes, &identity)?;
 
         // Drift check against the on-disk plaintext sibling, mirroring
         // the render-drift detection in `render::process_template`.
-        // If the user edited the plaintext directly (target-as-truth
-        // path), absorb already pulled the change into source; we
-        // surface it as `diverged` here so they know to re-encrypt
-        // (`yui secret encrypt <path>`) instead of silently
-        // overwriting their edit with the stale ciphertext content.
         match std::fs::read(&plaintext_path) {
             Ok(existing) if existing == plain_bytes => {
                 report.unchanged.push(plaintext_path);
@@ -261,76 +455,172 @@ mod tests {
     use camino::Utf8PathBuf;
     use tempfile::TempDir;
 
+    fn write_x25519_identity_file(tmp: &TempDir, name: &str) -> (Utf8PathBuf, String) {
+        let path = Utf8PathBuf::from_path_buf(tmp.path().join(name)).unwrap();
+        let (secret, public) = generate_x25519_keypair();
+        std::fs::write(&path, format!("{secret}\n")).unwrap();
+        (path, public)
+    }
+
     #[test]
     fn x25519_round_trip() {
-        let (secret, public) = generate_x25519_keypair();
-        let id = age::x25519::Identity::from_str(&secret).unwrap();
-        let recipient = parse_recipient(&public).unwrap();
-        let plaintext = b"hello secret world\n";
-        let cipher = encrypt(plaintext, &[recipient]).unwrap();
-        // Ciphertext should look like an age file.
+        let tmp = TempDir::new().unwrap();
+        let (id_path, public) = write_x25519_identity_file(&tmp, "age.txt");
+        let identity = load_x25519_identity(&id_path).unwrap();
+        let recipient = parse_x25519_recipient(&public).unwrap();
+        let cipher = encrypt_x25519(b"hello secret world\n", &[recipient]).unwrap();
         assert!(cipher.starts_with(b"age-encryption.org/v1\n"));
-        let recovered = decrypt(&cipher, &id).unwrap();
+        let recovered = decrypt_x25519(&cipher, &identity).unwrap();
+        assert_eq!(recovered, b"hello secret world\n");
+    }
+
+    /// Wrap / unlock round-trip via a *boxed* X25519 identity (the
+    /// passkey path uses Box<dyn Identity>, but plugin binaries
+    /// aren't available in CI — exercise the same code path with
+    /// X25519, which is plugin-free but uses the same general
+    /// dyn-trait API).
+    #[test]
+    fn passkey_wrap_round_trip_via_x25519_proxy() {
+        let tmp = TempDir::new().unwrap();
+        let (id_path, public) = write_x25519_identity_file(&tmp, "age.txt");
+        let recipients = vec![parse_passkey_recipient(&public).unwrap()];
+        let plaintext = std::fs::read(&id_path).unwrap();
+        let wrapped = encrypt_to_passkeys(&plaintext, &recipients).unwrap();
+        // Boxed identity for the unlock side.
+        let identities: Vec<BoxedIdentity> = {
+            let id = load_x25519_identity(&id_path).unwrap();
+            vec![Box::new(id)]
+        };
+        let recovered = decrypt_with_passkeys(&wrapped, &identities).unwrap();
         assert_eq!(recovered, plaintext);
     }
 
     #[test]
     fn multi_recipient_decrypts_with_either_key() {
-        let (secret_a, public_a) = generate_x25519_keypair();
-        let (secret_b, public_b) = generate_x25519_keypair();
-        let id_a = age::x25519::Identity::from_str(&secret_a).unwrap();
-        let id_b = age::x25519::Identity::from_str(&secret_b).unwrap();
+        let tmp = TempDir::new().unwrap();
+        let (_id_a_path, public_a) = write_x25519_identity_file(&tmp, "a.txt");
+        let (_id_b_path, public_b) = write_x25519_identity_file(&tmp, "b.txt");
         let recipients = vec![
-            parse_recipient(&public_a).unwrap(),
-            parse_recipient(&public_b).unwrap(),
+            parse_x25519_recipient(&public_a).unwrap(),
+            parse_x25519_recipient(&public_b).unwrap(),
         ];
-        let plaintext = b"team secret";
-        let cipher = encrypt(plaintext, &recipients).unwrap();
-        // Either identity should decrypt — that's the whole point of
-        // multi-recipient encryption.
-        assert_eq!(decrypt(&cipher, &id_a).unwrap(), plaintext);
-        assert_eq!(decrypt(&cipher, &id_b).unwrap(), plaintext);
+        let cipher = encrypt_x25519(b"team secret", &recipients).unwrap();
+        // Either identity should decrypt.
+        let id_a =
+            load_x25519_identity(&Utf8PathBuf::from_path_buf(tmp.path().join("a.txt")).unwrap())
+                .unwrap();
+        let id_b =
+            load_x25519_identity(&Utf8PathBuf::from_path_buf(tmp.path().join("b.txt")).unwrap())
+                .unwrap();
+        assert_eq!(decrypt_x25519(&cipher, &id_a).unwrap(), b"team secret");
+        assert_eq!(decrypt_x25519(&cipher, &id_b).unwrap(), b"team secret");
     }
 
     #[test]
-    fn load_identity_skips_comments_and_blanks() {
+    fn load_x25519_skips_comments_and_blanks() {
         let tmp = TempDir::new().unwrap();
         let path = Utf8PathBuf::from_path_buf(tmp.path().join("age.txt")).unwrap();
         let (secret, _public) = generate_x25519_keypair();
         let body = format!("# created: 2026-05-02\n# public key: ageXXX\n\n{secret}\n");
         std::fs::write(&path, body).unwrap();
-        let id = load_identity(&path).unwrap();
-        // Round-trip through decrypt to confirm we got a usable
-        // identity back (not just any string-shaped placeholder).
-        let recipient = parse_recipient(&id.to_public().to_string()).unwrap();
-        let cipher = encrypt(b"x", &[recipient]).unwrap();
-        assert_eq!(decrypt(&cipher, &id).unwrap(), b"x");
+        let _id = load_x25519_identity(&path).unwrap();
     }
 
     #[test]
-    fn load_identity_errors_on_garbage() {
+    fn load_x25519_errors_on_garbage() {
         let tmp = TempDir::new().unwrap();
         let path = Utf8PathBuf::from_path_buf(tmp.path().join("bad.txt")).unwrap();
         std::fs::write(&path, "not a key at all\n").unwrap();
-        // `age::x25519::Identity` deliberately doesn't impl Debug
-        // (holds secret material), so `unwrap_err` won't compile —
-        // pattern match instead.
-        match load_identity(&path) {
-            Ok(_) => panic!("expected error on garbage identity file"),
-            Err(e) => assert!(format!("{e}").contains("not a valid age X25519 secret")),
+        match load_x25519_identity(&path) {
+            Ok(_) => panic!("expected parse error"),
+            Err(e) => assert!(format!("{e}").contains("not a valid age X25519")),
         }
     }
 
     #[test]
     fn parse_recipient_rejects_garbage() {
-        let err = parse_recipient("ssh-rsa AAAA…").unwrap_err();
+        let err = parse_x25519_recipient("ssh-rsa AAAA…").unwrap_err();
         assert!(format!("{err}").contains("not a valid age X25519 recipient"));
+    }
+
+    /// PR #60 review: don't persist a decrypted blob that isn't
+    /// actually an age identity. Successful decrypt + bad payload
+    /// must fail, never get to disk.
+    #[test]
+    fn validate_x25519_identity_bytes_round_trip() {
+        let (secret, _public) = generate_x25519_keypair();
+        let body = format!("# header\n{secret}\n");
+        validate_x25519_identity_bytes(body.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn validate_x25519_identity_bytes_rejects_non_identity() {
+        let err = validate_x25519_identity_bytes(b"this is not an age identity\n").unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("not a valid age X25519 secret") || msg.contains("contains no key line"),
+            "unexpected error: {msg}",
+        );
+    }
+
+    #[test]
+    fn validate_x25519_identity_bytes_rejects_non_utf8() {
+        let err = validate_x25519_identity_bytes(&[0xff, 0xfe, 0x00]).unwrap_err();
+        assert!(format!("{err}").contains("not valid UTF-8"));
+    }
+
+    /// PR #60 review: write_private_file should never leave the
+    /// X25519 secret world-readable. We can only assert mode 0o600
+    /// on Unix; on Windows the helper falls back to plain write.
+    #[test]
+    fn write_private_file_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let path = Utf8PathBuf::from_path_buf(tmp.path().join("nested/age.txt")).unwrap();
+        write_private_file(&path, b"hello\n").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"hello\n");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            // mode includes file type bits; mask down to perms.
+            assert_eq!(
+                mode & 0o777,
+                0o600,
+                "expected 0o600, got {:o}",
+                mode & 0o777
+            );
+        }
+    }
+
+    #[test]
+    fn write_private_file_overwrites_existing() {
+        let tmp = TempDir::new().unwrap();
+        let path = Utf8PathBuf::from_path_buf(tmp.path().join("age.txt")).unwrap();
+        write_private_file(&path, b"v1").unwrap();
+        write_private_file(&path, b"v2").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"v2");
+    }
+
+    #[test]
+    fn parse_passkey_recipient_rejects_garbage() {
+        // `Box<dyn Recipient + Send>` doesn't impl Debug, so
+        // `unwrap_err` won't compile — match the result instead.
+        match parse_passkey_recipient("ssh-rsa AAAA…") {
+            Ok(_) => panic!("expected parse failure"),
+            Err(e) => assert!(format!("{e}").contains("not a valid age recipient")),
+        }
     }
 
     #[test]
     fn encrypt_with_no_recipients_errors() {
-        let err = encrypt(b"x", &[]).unwrap_err();
+        let err = encrypt_x25519(b"x", &[]).unwrap_err();
         assert!(format!("{err}").contains("no recipients"));
+    }
+
+    #[test]
+    fn encrypt_to_passkeys_with_no_recipients_errors() {
+        let err = encrypt_to_passkeys(b"x", &[]).unwrap_err();
+        assert!(format!("{err}").contains("no passkey recipients"));
     }
 
     #[test]
@@ -339,17 +629,14 @@ mod tests {
             strip_age_suffix(Utf8PathBuf::from("home/.ssh/id_ed25519.age").as_path()),
             Some(Utf8PathBuf::from("home/.ssh/id_ed25519"))
         );
-        // Multiple dots: only the trailing `.age` is stripped.
         assert_eq!(
             strip_age_suffix(Utf8PathBuf::from("home/notes.tar.gz.age").as_path()),
             Some(Utf8PathBuf::from("home/notes.tar.gz"))
         );
-        // Not a secret.
         assert_eq!(
             strip_age_suffix(Utf8PathBuf::from("home/foo.txt").as_path()),
             None
         );
-        // A literal `.age` with no stem isn't a secret either.
         assert_eq!(strip_age_suffix(Utf8PathBuf::from(".age").as_path()), None);
     }
 }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -55,15 +55,15 @@ pub type BoxedIdentity = Box<dyn age::Identity>;
 
 /// Validate that `bytes` is a parseable X25519 identity file —
 /// at least one non-comment line is `AGE-SECRET-KEY-1…`. Used by
-/// `yui secret unlock` to fail before persisting bytes that
-/// happen to decrypt but aren't actually an identity (wrong
-/// `passkey_wrapped` path / corrupted blob). PR #60 review by
-/// coderabbitai.
+/// both `yui secret store` (refuse to upload a corrupted local
+/// file) and `yui secret unlock` (refuse to persist a vault item
+/// that doesn't actually hold an age identity). The messages
+/// name "the payload" rather than a specific source so both
+/// call sites read naturally.
 pub fn validate_x25519_identity_bytes(bytes: &[u8]) -> Result<()> {
     let text = std::str::from_utf8(bytes).map_err(|_| {
         Error::Other(anyhow::anyhow!(
-            "decrypted payload is not valid UTF-8 — \
-             passkey_wrapped doesn't look like an age identity file"
+            "payload is not valid UTF-8 — does not look like an age identity file"
         ))
     })?;
     let line = text
@@ -72,16 +72,15 @@ pub fn validate_x25519_identity_bytes(bytes: &[u8]) -> Result<()> {
         .find(|l| !l.is_empty() && !l.starts_with('#'))
         .ok_or_else(|| {
             Error::Other(anyhow::anyhow!(
-                "decrypted payload contains no key line \
-                 (only comments / blank lines) — passkey_wrapped \
-                 is not an age identity file"
+                "payload contains no key line (only comments / blank lines) — \
+                 not an age identity file"
             ))
         })?;
     age::x25519::Identity::from_str(line)
         .map(drop)
         .map_err(|e| {
             Error::Other(anyhow::anyhow!(
-                "decrypted payload is not a valid age X25519 secret \
+                "payload is not a valid age X25519 secret \
              (`AGE-SECRET-KEY-1…` expected): {e}"
             ))
         })

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -33,9 +33,19 @@ use crate::{Error, Result};
 /// "store a Secure Note's content" — the only two operations
 /// `secret store` / `secret unlock` need.
 pub trait Vault {
+    /// Verify that the vault CLI is installed and authenticated
+    /// before we try to read or write. yui doesn't drive
+    /// `bw login` / `op signin` / `bw unlock` itself (the master
+    /// password / passkey / SSO factor should go to the
+    /// provider's CLI directly, not through yui's stdin), but it
+    /// can at least detect the unauthenticated / locked state up
+    /// front and emit an actionable hint instead of letting the
+    /// raw provider error propagate.
+    fn precheck(&self) -> Result<()>;
+
     /// Read the notes field of `item`. Errors if the item is
-    /// missing, the CLI isn't authenticated, or the CLI is not
-    /// installed.
+    /// missing or the CLI isn't installed. (Auth state is checked
+    /// separately via `precheck`.)
     fn fetch(&self, item: &str) -> Result<Vec<u8>>;
 
     /// Create or overwrite the Secure Note at `item` with
@@ -62,6 +72,40 @@ struct BitwardenVault;
 impl Vault for BitwardenVault {
     fn provider_name(&self) -> &'static str {
         "Bitwarden"
+    }
+
+    fn precheck(&self) -> Result<()> {
+        let out = Command::new("bw").args(["status"]).output().map_err(|e| {
+            Error::Other(anyhow::anyhow!(
+                "invoking `bw status`: {e} — is the Bitwarden CLI installed?"
+            ))
+        })?;
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            return Err(Error::Other(anyhow::anyhow!(
+                "bw status failed: {}",
+                stderr.trim()
+            )));
+        }
+        let v: serde_json::Value = serde_json::from_slice(&out.stdout)
+            .map_err(|e| Error::Other(anyhow::anyhow!("parse bw status output: {e}")))?;
+        match v.get("status").and_then(|s| s.as_str()) {
+            Some("unlocked") => Ok(()),
+            Some("locked") => Err(Error::Other(anyhow::anyhow!(
+                "Bitwarden vault is locked. Run `bw unlock` and follow \
+                 its instructions to export the BW_SESSION env var, then \
+                 retry. (BW vault unlock can use a passkey via the web \
+                 vault flow if you've set that up.)"
+            ))),
+            Some("unauthenticated") => Err(Error::Other(anyhow::anyhow!(
+                "Bitwarden CLI is not logged in. Run `bw login` (or \
+                 `bw login --apikey` for non-interactive SSO/API-key \
+                 use), then `bw unlock`, then retry."
+            ))),
+            other => Err(Error::Other(anyhow::anyhow!(
+                "unexpected `bw status` output: status={other:?}"
+            ))),
+        }
     }
 
     fn fetch(&self, item: &str) -> Result<Vec<u8>> {
@@ -171,6 +215,30 @@ struct OnePasswordVault;
 impl Vault for OnePasswordVault {
     fn provider_name(&self) -> &'static str {
         "1Password"
+    }
+
+    fn precheck(&self) -> Result<()> {
+        // `op whoami` exits non-zero when the session is gone or
+        // the desktop-app integration isn't unlocked. Stderr from
+        // op already carries a decent message ("[ERROR] you are
+        // not currently signed in. ..."); we wrap it with a yui-
+        // shaped hint so the user doesn't have to wonder which
+        // command we just tried.
+        let out = Command::new("op").args(["whoami"]).output().map_err(|e| {
+            Error::Other(anyhow::anyhow!(
+                "invoking `op whoami`: {e} — is the 1Password CLI installed?"
+            ))
+        })?;
+        if out.status.success() {
+            return Ok(());
+        }
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        Err(Error::Other(anyhow::anyhow!(
+            "1Password CLI is not signed in: {}. \
+             Run `op signin` (or unlock the 1Password desktop app to \
+             auto-share its session via the CLI integration), then retry.",
+            stderr.trim()
+        )))
     }
 
     fn fetch(&self, item: &str) -> Result<Vec<u8>> {

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -271,7 +271,27 @@ impl Vault for OnePasswordVault {
             .output()
             .map_err(|e| Error::Other(anyhow::anyhow!("invoking `op`: {e}")))?;
 
-        let assignment = format!("notesPlain[text]={content_str}");
+        // Build a JSON template and pipe it via stdin instead of
+        // passing the secret as `notesPlain[text]=…` argv. The
+        // assignment-statement form is documented but exposes
+        // the secret to local `ps` / WMIC inspection while the
+        // op process is alive — JSON-via-stdin is 1Password's
+        // recommended secure flow. (PR #61 review by coderabbitai.)
+        let template = serde_json::json!({
+            "title": item,
+            "category": "SECURE_NOTE",
+            "fields": [
+                {
+                    "id": "notesPlain",
+                    "type": "STRING",
+                    "purpose": "NOTES",
+                    "label": "notesPlain",
+                    "value": content_str,
+                }
+            ],
+        });
+        let payload = serde_json::to_vec(&template)
+            .map_err(|e| Error::Other(anyhow::anyhow!("serialise op item template: {e}")))?;
 
         if existing.status.success() {
             if !force {
@@ -279,34 +299,39 @@ impl Vault for OnePasswordVault {
                     "1Password item {item:?} already exists; pass --force to overwrite"
                 )));
             }
-            let status = Command::new("op")
-                .args(["item", "edit", item, &assignment])
-                .status()
-                .map_err(|e| Error::Other(anyhow::anyhow!("invoking `op`: {e}")))?;
-            if !status.success() {
-                return Err(Error::Other(anyhow::anyhow!(
-                    "op item edit {item:?} failed"
-                )));
-            }
+            run_op_with_stdin(&["item", "edit", item, "-"], &payload)?;
         } else {
-            let status = Command::new("op")
-                .args([
-                    "item",
-                    "create",
-                    "--category",
-                    "Secure Note",
-                    "--title",
-                    item,
-                    &assignment,
-                ])
-                .status()
-                .map_err(|e| Error::Other(anyhow::anyhow!("invoking `op`: {e}")))?;
-            if !status.success() {
-                return Err(Error::Other(anyhow::anyhow!(
-                    "op item create {item:?} failed"
-                )));
-            }
+            run_op_with_stdin(&["item", "create", "-"], &payload)?;
         }
         Ok(())
     }
+}
+
+fn run_op_with_stdin(args: &[&str], stdin_bytes: &[u8]) -> Result<()> {
+    use std::io::Write as _;
+    let mut child = Command::new("op")
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| Error::Other(anyhow::anyhow!("invoking `op`: {e}")))?;
+    child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| Error::Other(anyhow::anyhow!("op stdin closed early")))?
+        .write_all(stdin_bytes)
+        .map_err(|e| Error::Other(anyhow::anyhow!("writing to op stdin: {e}")))?;
+    let output = child
+        .wait_with_output()
+        .map_err(|e| Error::Other(anyhow::anyhow!("waiting on op: {e}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::Other(anyhow::anyhow!(
+            "op {} failed: {}",
+            args.join(" "),
+            stderr.trim()
+        )));
+    }
+    Ok(())
 }

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -1,0 +1,244 @@
+//! Pluggable secret-vault backend used by `yui secret store` /
+//! `yui secret unlock` to ferry the X25519 identity across
+//! machines.
+//!
+//! yui doesn't authenticate against the vault itself — it shells
+//! out to the provider's official CLI (`bw` for Bitwarden, `op`
+//! for 1Password). Whatever auth that CLI supports (master
+//! password, biometric, passkey unlock via the web vault, SSO)
+//! gates the operation, and yui inherits it for free.
+//!
+//! Storage convention: the entire content of the X25519 identity
+//! file (header comments + the `AGE-SECRET-KEY-1…` line) lives in
+//! a Secure Note item under a user-chosen name. Picking notes
+//! (rather than the password field) keeps the multi-line content
+//! intact and doesn't pollute the vault's password-autofill UI.
+//!
+//! ## What yui *doesn't* try to do
+//!
+//! - Drive `bw login` / `op signin`. Those are interactive flows
+//!   the user runs once per machine; yui just calls the CLI on
+//!   the assumption it's already authenticated.
+//! - Manage vault TOTP / passkey enrolment. Those live in the
+//!   vault provider's own UI.
+//! - Encrypt the X25519 a second time. The vault's own at-rest
+//!   encryption is the trust boundary.
+
+use std::process::{Command, Stdio};
+
+use crate::config::{VaultConfig, VaultProvider};
+use crate::{Error, Result};
+
+/// Common interface for "fetch a Secure Note's content" and
+/// "store a Secure Note's content" — the only two operations
+/// `secret store` / `secret unlock` need.
+pub trait Vault {
+    /// Read the notes field of `item`. Errors if the item is
+    /// missing, the CLI isn't authenticated, or the CLI is not
+    /// installed.
+    fn fetch(&self, item: &str) -> Result<Vec<u8>>;
+
+    /// Create or overwrite the Secure Note at `item` with
+    /// `content` in the notes field. `force = false` refuses to
+    /// clobber an existing item; `force = true` overwrites.
+    fn store(&self, item: &str, content: &[u8], force: bool) -> Result<()>;
+
+    /// Human-readable provider name for log output.
+    fn provider_name(&self) -> &'static str;
+}
+
+/// Build a vault driver from the user's config.
+pub fn driver(cfg: &VaultConfig) -> Box<dyn Vault> {
+    match cfg.provider {
+        VaultProvider::Bitwarden => Box::new(BitwardenVault),
+        VaultProvider::OnePassword => Box::new(OnePasswordVault),
+    }
+}
+
+// ---------- Bitwarden ----------------------------------------------------
+
+struct BitwardenVault;
+
+impl Vault for BitwardenVault {
+    fn provider_name(&self) -> &'static str {
+        "Bitwarden"
+    }
+
+    fn fetch(&self, item: &str) -> Result<Vec<u8>> {
+        // `bw get notes <item>` returns the notes field as plain
+        // text on stdout. `bw` will refuse with a non-zero exit
+        // when the item is missing or the vault is locked, which
+        // we surface verbatim so the user sees the bw error.
+        let output = Command::new("bw")
+            .args(["get", "notes", item])
+            .output()
+            .map_err(|e| Error::Other(anyhow::anyhow!(
+                "invoking `bw`: {e} — install Bitwarden CLI and run `bw login` + `bw unlock` once"
+            )))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::Other(anyhow::anyhow!(
+                "bw get notes {item:?} failed: {}",
+                stderr.trim()
+            )));
+        }
+        Ok(output.stdout)
+    }
+
+    fn store(&self, item: &str, content: &[u8], force: bool) -> Result<()> {
+        let content_str = std::str::from_utf8(content)
+            .map_err(|e| Error::Other(anyhow::anyhow!("vault content is not valid UTF-8: {e}")))?;
+
+        // Check whether an item with that name already exists.
+        // `bw get item <name>` exits non-zero when missing.
+        let existing = Command::new("bw")
+            .args(["get", "item", item])
+            .output()
+            .map_err(|e| Error::Other(anyhow::anyhow!("invoking `bw`: {e}")))?;
+
+        let item_json = serde_json::json!({
+            "type": 2,                     // 2 = Secure Note
+            "name": item,
+            "notes": content_str,
+            "secureNote": { "type": 0 },   // 0 = generic note
+        });
+        let payload = serde_json::to_vec(&item_json)
+            .map_err(|e| Error::Other(anyhow::anyhow!("serialise bw item JSON: {e}")))?;
+        let encoded = bw_encode(&payload)?;
+
+        if existing.status.success() {
+            if !force {
+                return Err(Error::Other(anyhow::anyhow!(
+                    "Bitwarden item {item:?} already exists; pass --force to overwrite"
+                )));
+            }
+            // Pull the existing item's id so we can `bw edit item <id>`.
+            let existing_value: serde_json::Value = serde_json::from_slice(&existing.stdout)
+                .map_err(|e| Error::Other(anyhow::anyhow!("parse bw get item output: {e}")))?;
+            let id = existing_value
+                .get("id")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| Error::Other(anyhow::anyhow!("bw item {item:?} has no id field")))?;
+            run_bw_with_stdin(&["edit", "item", id], encoded.as_bytes())?;
+        } else {
+            run_bw_with_stdin(&["create", "item"], encoded.as_bytes())?;
+        }
+        Ok(())
+    }
+}
+
+/// Base64-encode `payload` for `bw create item` / `bw edit item`,
+/// which both expect a base64'd JSON blob on stdin (the same
+/// shape `bw encode` produces).
+fn bw_encode(payload: &[u8]) -> Result<String> {
+    use base64::Engine as _;
+    Ok(base64::engine::general_purpose::STANDARD.encode(payload))
+}
+
+fn run_bw_with_stdin(args: &[&str], stdin_bytes: &[u8]) -> Result<()> {
+    use std::io::Write as _;
+    let mut child = Command::new("bw")
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| Error::Other(anyhow::anyhow!("invoking `bw`: {e}")))?;
+    child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| Error::Other(anyhow::anyhow!("bw stdin closed early")))?
+        .write_all(stdin_bytes)
+        .map_err(|e| Error::Other(anyhow::anyhow!("writing to bw stdin: {e}")))?;
+    let output = child
+        .wait_with_output()
+        .map_err(|e| Error::Other(anyhow::anyhow!("waiting on bw: {e}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::Other(anyhow::anyhow!(
+            "bw {} failed: {}",
+            args.join(" "),
+            stderr.trim()
+        )));
+    }
+    Ok(())
+}
+
+// ---------- 1Password ----------------------------------------------------
+
+struct OnePasswordVault;
+
+impl Vault for OnePasswordVault {
+    fn provider_name(&self) -> &'static str {
+        "1Password"
+    }
+
+    fn fetch(&self, item: &str) -> Result<Vec<u8>> {
+        // `op item get <item> --field notesPlain` returns the
+        // notes field as plain text on stdout.
+        let output = Command::new("op")
+            .args(["item", "get", item, "--field", "notesPlain"])
+            .output()
+            .map_err(|e| {
+                Error::Other(anyhow::anyhow!(
+                    "invoking `op`: {e} — install 1Password CLI and run `op signin` once"
+                ))
+            })?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::Other(anyhow::anyhow!(
+                "op item get {item:?} --field notesPlain failed: {}",
+                stderr.trim()
+            )));
+        }
+        Ok(output.stdout)
+    }
+
+    fn store(&self, item: &str, content: &[u8], force: bool) -> Result<()> {
+        let content_str = std::str::from_utf8(content)
+            .map_err(|e| Error::Other(anyhow::anyhow!("vault content is not valid UTF-8: {e}")))?;
+
+        let existing = Command::new("op")
+            .args(["item", "get", item])
+            .output()
+            .map_err(|e| Error::Other(anyhow::anyhow!("invoking `op`: {e}")))?;
+
+        let assignment = format!("notesPlain[text]={content_str}");
+
+        if existing.status.success() {
+            if !force {
+                return Err(Error::Other(anyhow::anyhow!(
+                    "1Password item {item:?} already exists; pass --force to overwrite"
+                )));
+            }
+            let status = Command::new("op")
+                .args(["item", "edit", item, &assignment])
+                .status()
+                .map_err(|e| Error::Other(anyhow::anyhow!("invoking `op`: {e}")))?;
+            if !status.success() {
+                return Err(Error::Other(anyhow::anyhow!(
+                    "op item edit {item:?} failed"
+                )));
+            }
+        } else {
+            let status = Command::new("op")
+                .args([
+                    "item",
+                    "create",
+                    "--category",
+                    "Secure Note",
+                    "--title",
+                    item,
+                    &assignment,
+                ])
+                .status()
+                .map_err(|e| Error::Other(anyhow::anyhow!("invoking `op`: {e}")))?;
+            if !status.success() {
+                return Err(Error::Other(anyhow::anyhow!(
+                    "op item create {item:?} failed"
+                )));
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Replaces the age-passkey wrap-and-unlock model from #60 with a simpler one: yui shells out to your password manager's CLI to ferry the X25519 identity across machines. Whatever auth that vault accepts (master password, biometric, passkey unlock in the web vault, SSO) gates the operation — yui inherits it for free.

## Two new commands

- **\`yui secret store [--force]\`** — push the X25519 secret at \`[secrets].identity\` into the configured vault item.
- **\`yui secret unlock\`** — fetch it back on a new machine, validate, write with 0600.

## Config

\`\`\`toml
[secrets]
identity   = "~/.config/yui/age.txt"
recipients = ["age1abc…"]

[secrets.vault]
provider = "bitwarden"          # or "1password"
item     = "yui-x25519-identity"
\`\`\`

## Why

The age-passkey path (#60) was technically clean but practically clunky: each new machine needs \`age-plugin-fido2-hmac\` + libfido2 + a USB-attached FIDO2 device that exposes \`hmac-secret\`. Pixel cross-device passkeys (the actual user ask) don't reach libfido2 at all — that flow lives in browser WebAuthN + caBLE, which CLI tooling doesn't touch. Routing through Bitwarden's web vault (which DOES support passkey unlock) gives the QR-+-Pixel-biometric UX the user wanted, without yui re-implementing caBLE.

## Removed

- \`[secrets].passkey_wrapped\` / \`passkey_recipients\` / \`passkey_identities\` config fields
- \`cmd::secret_wrap\` + picker / label parser / resolve helper
- \`secret::load_passkey_identities\` / \`decrypt_with_passkeys\` / \`encrypt_to_passkeys\` / \`BoxedIdentity\`
- \`dialoguer\` dep
- \`decrypt_all\`'s "skip passkey_wrapped" carve-out

## Kept (advanced, unsupported)

\`[secrets].recipients\` still accepts plugin recipients (\`age1yubikey1…\`, \`age1fido2-hmac1…\`, …). yui doesn't drive plugin flows first-class, but encrypting \`*.age\` files to plugin recipients works as long as the matching \`age-plugin-*\` binary is on \`\$PATH\` — useful if a YubiKey holder wants to decrypt the same file via \`age\` directly. apply still uses only the X25519, so plugin recipients add a parallel decrypt path without slowing apply down.

## New deps

- \`base64 = "0.22"\` — \`bw create/edit item\` expects base64'd JSON on stdin.

## Test plan

- [x] 180 tests passing
- [x] \`cargo make check\` (fmt + clippy \`-D warnings\` + locked check + tests)
- [x] Vault drivers shell out to \`bw\` / \`op\` cleanly; logic-only paths (config parsing, error mapping) compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vault-based secret identity storage and recovery via Bitwarden or 1Password integration
  * New `secret store` command to securely push secrets to configured vault provider
  * Streamlined `secret unlock` command with simplified authentication flow
  * Enhanced secret encryption to support additional recipient types

* **Documentation**
  * Revised multi-machine secret recovery documentation with vault provider setup instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->