### PR TITLE
fix(vault): hardcode the vault item name (drop the config knob)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,8 +295,12 @@ recipients = ["age1abc…"]              # X25519 publics for *.age files
 
 [secrets.vault]
 provider = "bitwarden"                 # or "1password"
-item     = "yui-x25519-identity"       # vault item name
 ```
+
+The vault item is stored under the fixed name
+`yui-x25519-identity` — yui doesn't expose a per-repo override
+yet (no one's hit the multi-yui-tree-on-one-vault collision in
+practice, so it's stayed hardcoded).
 
 #### Setup (once on the first machine)
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ provider = "bitwarden"                 # or "1password"
 The vault item is stored under the fixed name
 `yui-x25519-identity` — yui doesn't expose a per-repo override
 yet (no one's hit the multi-yui-tree-on-one-vault collision in
-practice, so it's stayed hardcoded).
+practice, so it's hardcoded).
 
 #### Setup (once on the first machine)
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -941,15 +941,15 @@ pub fn secret_store(source: Option<Utf8PathBuf>, force: bool) -> Result<()> {
     info!(
         "pushing X25519 identity to {} item {:?}",
         vault.provider_name(),
-        vault_cfg.item
+        config::VAULT_ITEM_NAME
     );
-    vault.store(&vault_cfg.item, &plaintext, force)?;
+    vault.store(config::VAULT_ITEM_NAME, &plaintext, force)?;
 
     println!();
     println!(
         "  X25519 identity pushed to {} item {:?}",
         vault.provider_name(),
-        vault_cfg.item
+        config::VAULT_ITEM_NAME
     );
     println!("  On a new machine, run `yui secret unlock`.");
     Ok(())
@@ -986,9 +986,9 @@ pub fn secret_unlock(source: Option<Utf8PathBuf>) -> Result<()> {
     info!(
         "fetching X25519 identity from {} item {:?}",
         vault.provider_name(),
-        vault_cfg.item
+        config::VAULT_ITEM_NAME
     );
-    let plaintext = vault.fetch(&vault_cfg.item)?;
+    let plaintext = vault.fetch(config::VAULT_ITEM_NAME)?;
 
     // Validate before persisting — the vault could legitimately
     // hold any blob, so the fetched bytes might not actually be

--- a/src/config.rs
+++ b/src/config.rs
@@ -343,10 +343,14 @@ impl Default for SecretsConfig {
 pub struct VaultConfig {
     /// `"bitwarden"` or `"1password"`.
     pub provider: VaultProvider,
-    /// Item name / id inside the vault. yui passes this verbatim
-    /// to `bw get item <item>` / `op item get <item>`.
-    pub item: String,
 }
+
+/// Vault item name yui stores the X25519 identity under. Hardcoded
+/// rather than configurable — the realistic "I have multiple yui
+/// dotfiles trees sharing one vault account" case is rare enough
+/// that the simplification of one-less config knob wins. Add a
+/// configurable knob back if a user actually hits the collision.
+pub const VAULT_ITEM_NAME: &str = "yui-x25519-identity";
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
\`[secrets.vault].item\` was a config field with no realistic per-user reason to vary. The only case where it would differ is "I run multiple yui dotfiles trees against one vault account", which nobody's hit yet. Drop the knob, hardcode the name as the constant \`config::VAULT_ITEM_NAME = "yui-x25519-identity"\`. (Add the knob back when someone hits the collision — YAGNI.)

## After

\`\`\`toml
[secrets.vault]
provider = "bitwarden"   # or "1password"
\`\`\`

Two-line block, no item field to remember.

## Migration

\`item = "..."\` in existing configs will fail to deserialize — yui's Config doesn't tolerate unknown fields. The user is the only one who's run \`yui secret store\` so far (private trial of v0.7.13 / 14), so the sharp edge is acceptable; documented in the commit message.

## Test plan

- [x] 180 tests passing
- [x] \`cargo make check\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)