### PR TITLE
feat(absorb): multi-choice anomaly prompt (overwrite / quit / sticky-all) (v0.7.16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.7.15"
+version = "0.7.16"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.svg" />
-    <img src="assets/logo.svg" width="560" alt="yui — target-as-truth dotfiles manager" />
-  </picture>
+  <img src="assets/logo.svg" width="560" alt="yui — target-as-truth dotfiles manager" />
 </p>
 
 <p align="center">

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -2,6 +2,7 @@
 //!
 //! Each `Command` variant in `cli.rs` calls one of these.
 
+use std::cell::Cell;
 use std::fmt::Write as _;
 
 use anyhow::{Context as _, Result};
@@ -272,6 +273,8 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
         dir_mode: resolve_dir_mode(config.link.dir_mode),
         backup_root: &backup_root,
         dry_run,
+        sticky_anomaly: Cell::new(None),
+        quit_requested: Cell::new(false),
     };
 
     info!("source: {source}");
@@ -344,6 +347,23 @@ fn log_secret_report(r: &secret::SecretReport) {
 /// (push on dir entry, pop on dir exit) which doesn't compose with
 /// `ApplyCtx` being shared by `&`. The stack is plumbed through
 /// `walk_and_link` as its own parameter instead.
+/// User-chosen direction for an `[absorb] on_anomaly = "ask"` prompt.
+///
+/// "Absorb" matches yui's default flow (target wins, content lands in
+/// source). "Overwrite" is the inverse for cases where the user just
+/// edited source intentionally and wants target updated to match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AnomalyChoice {
+    /// target → source (yui's default, "target is truth").
+    Absorb,
+    /// source → target (user-edited source wins, target updated).
+    Overwrite,
+    /// Leave both as-is for now.
+    Skip,
+    /// Skip this entry and stop walking remaining entries.
+    Quit,
+}
+
 struct ApplyCtx<'a> {
     config: &'a Config,
     /// Source repo root — needed for git-clean checks during absorb.
@@ -352,6 +372,13 @@ struct ApplyCtx<'a> {
     dir_mode: EffectiveDirMode,
     backup_root: &'a Utf8Path,
     dry_run: bool,
+    /// Sticky decision from a previous "all" prompt. When set, every
+    /// subsequent anomaly applies this choice without prompting.
+    sticky_anomaly: Cell<Option<AnomalyChoice>>,
+    /// Set by the `[q]uit` choice. The walker checks this at the top
+    /// of every link op and short-circuits to a no-op so apply exits
+    /// cleanly without further prompts.
+    quit_requested: Cell<bool>,
 }
 
 /// Show the resolved src→dst mappings for the current source repo.
@@ -1943,6 +1970,8 @@ pub fn absorb(
         dir_mode: resolve_dir_mode(config.link.dir_mode),
         backup_root: &backup_root,
         dry_run: false,
+        sticky_anomaly: Cell::new(None),
+        quit_requested: Cell::new(false),
     };
 
     // Manual absorb is an explicit user request — bypass `auto`,
@@ -1955,11 +1984,28 @@ pub fn absorb(
 /// side is a directory or content isn't valid UTF-8 — we'd rather
 /// say "binary file differs" than spew bytes through `similar`.
 fn print_absorb_diff(src: &Utf8Path, dst: &Utf8Path) {
+    use owo_colors::OwoColorize as _;
+    use std::io::IsTerminal;
+
+    let color = std::io::stderr().is_terminal();
+
     eprintln!();
-    eprintln!("--- diff (- source, + target) ---");
-    eprintln!("  src: {src}");
-    eprintln!("  dst: {dst}");
+    if color {
+        eprintln!(
+            "{}  {}  {}",
+            "── unified diff ──".bold(),
+            "[-] src".red().bold(),
+            "[+] dst".green().bold()
+        );
+        eprintln!("  {} {}", "[-] src:".red(), src);
+        eprintln!("  {} {}", "[+] dst:".green(), dst);
+    } else {
+        eprintln!("── unified diff ──  [-] src   [+] dst");
+        eprintln!("  [-] src: {src}");
+        eprintln!("  [+] dst: {dst}");
+    }
     eprintln!();
+
     if src.is_dir() || dst.is_dir() {
         eprintln!("(directory absorb — content listing skipped)");
         eprintln!();
@@ -1981,12 +2027,46 @@ fn print_absorb_diff(src: &Utf8Path, dst: &Utf8Path) {
             return;
         }
     };
+
     let diff = similar::TextDiff::from_lines(&src_content, &dst_content);
-    let formatted = diff
-        .unified_diff()
-        .header(src.as_str(), dst.as_str())
-        .to_string();
-    eprint!("{formatted}");
+    // Walk hunks ourselves so we can colorize each line by tag — the
+    // built-in `unified_diff().to_string()` returns one flat string
+    // with no ANSI escapes.
+    for hunk in diff.unified_diff().context_radius(3).iter_hunks() {
+        let header = hunk.header().to_string();
+        if color {
+            eprintln!("{}", header.cyan());
+        } else {
+            eprintln!("{header}");
+        }
+        for change in hunk.iter_changes() {
+            let line = change.value();
+            let line = line.strip_suffix('\n').unwrap_or(line);
+            match change.tag() {
+                similar::ChangeTag::Delete => {
+                    if color {
+                        eprintln!("{} {}", "-".red().bold(), line.red());
+                    } else {
+                        eprintln!("- {line}");
+                    }
+                }
+                similar::ChangeTag::Insert => {
+                    if color {
+                        eprintln!("{} {}", "+".green().bold(), line.green());
+                    } else {
+                        eprintln!("+ {line}");
+                    }
+                }
+                similar::ChangeTag::Equal => {
+                    if color {
+                        eprintln!("  {}", line.dimmed());
+                    } else {
+                        eprintln!("  {line}");
+                    }
+                }
+            }
+        }
+    }
     eprintln!();
 }
 
@@ -3240,6 +3320,10 @@ fn walk_and_link_body(
 fn link_file_with_backup(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>) -> Result<()> {
     use absorb::AbsorbDecision::*;
 
+    if ctx.quit_requested.get() {
+        return Ok(());
+    }
+
     let decision = absorb::classify(src, dst)?;
 
     if ctx.dry_run {
@@ -3307,6 +3391,19 @@ fn absorb_target_into_source(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>)
     Ok(())
 }
 
+/// Inverse of `absorb_target_into_source`: keep source's content,
+/// throw away target's diverged content (after backing it up), and
+/// re-link target so it once again reflects source. Used when the
+/// user picks `[o]verwrite` at the anomaly prompt — i.e. they edited
+/// source intentionally and want the target updated to match.
+fn overwrite_source_into_target(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>) -> Result<()> {
+    info!("overwrite: {src} → {dst}");
+    backup_existing(dst, ctx.backup_root, /* is_dir */ false)?;
+    link::unlink(dst)?;
+    link::link_file(src, dst, ctx.file_mode)?;
+    Ok(())
+}
+
 /// Decide what to do for an anomaly (NeedsConfirm or AutoAbsorb that was
 /// escalated by `auto = false` / dirty git). Per `[absorb] on_anomaly`:
 ///   - `skip`  → log warning, leave target alone
@@ -3323,28 +3420,99 @@ fn handle_anomaly(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>, reason: &s
             warn!("anomaly force: {dst} ({reason}) — absorbing target into source");
             absorb_target_into_source(src, dst, ctx)
         }
-        Ask => {
-            use std::io::IsTerminal;
-            if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
-                if prompt_absorb_with_diff(src, dst, reason)? {
-                    absorb_target_into_source(src, dst, ctx)
-                } else {
-                    warn!("anomaly skipped by user: {dst}");
-                    Ok(())
-                }
-            } else {
-                warn!("anomaly skip (non-TTY ask mode): {dst} ({reason})");
+        Ask => match prompt_anomaly(ctx, src, dst, reason)? {
+            AnomalyChoice::Absorb => absorb_target_into_source(src, dst, ctx),
+            AnomalyChoice::Overwrite => overwrite_source_into_target(src, dst, ctx),
+            AnomalyChoice::Skip => {
+                warn!("anomaly skipped by user: {dst}");
                 Ok(())
             }
-        }
+            AnomalyChoice::Quit => {
+                warn!("anomaly: user requested quit; stopping apply at {dst}");
+                ctx.quit_requested.set(true);
+                Ok(())
+            }
+        },
     }
 }
 
-fn prompt_absorb_with_diff(src: &Utf8Path, dst: &Utf8Path, reason: &str) -> Result<bool> {
+/// Multi-choice TTY prompt for an anomaly.
+///
+/// Replaces the old binary y/N "absorb?" prompt with chezmoi-style
+/// per-direction options plus uppercase "all-remaining" variants. The
+/// caller is responsible for performing the chosen action; this
+/// function only resolves the user's intent.
+///
+/// Sticky behaviour: if a prior prompt selected an `[A]/[O]/[S]` "all"
+/// option, that choice short-circuits subsequent prompts via
+/// `ctx.sticky_anomaly`. `[q]uit` flips `ctx.quit_requested` so the
+/// walker stops calling per-entry link ops.
+///
+/// Off-TTY: returns `Skip` immediately (caller logs the downgrade) —
+/// matches the previous "non-TTY ask = skip" behaviour. Quit is not
+/// possible without a TTY because there is nothing to interact with.
+fn prompt_anomaly(
+    ctx: &ApplyCtx<'_>,
+    src: &Utf8Path,
+    dst: &Utf8Path,
+    reason: &str,
+) -> Result<AnomalyChoice> {
+    if let Some(c) = ctx.sticky_anomaly.get() {
+        return Ok(c);
+    }
+
+    use std::io::IsTerminal;
+    use std::io::Write as _;
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        return Ok(AnomalyChoice::Skip);
+    }
+
     eprintln!();
     eprintln!("anomaly: {reason}");
+    eprintln!("  src: {src}");
+    eprintln!("  dst: {dst}");
     print_absorb_diff(src, dst);
-    prompt_yes_no("absorb target into source?")
+
+    loop {
+        eprintln!("  [a/A] absorb     target → source   (this / all remaining)");
+        eprintln!("  [o/O] overwrite  source → target   (this / all remaining)");
+        eprintln!("  [s/S] skip       leave as-is       (this / all remaining)");
+        eprintln!("  [d]   diff       re-show the diff");
+        eprintln!("  [q]   quit       skip this and stop apply");
+        eprint!("choice [s]: ");
+        std::io::stderr().flush().ok();
+
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        let trimmed = input.trim();
+        let choice = match trimmed {
+            "" | "s" => AnomalyChoice::Skip,
+            "a" => AnomalyChoice::Absorb,
+            "o" => AnomalyChoice::Overwrite,
+            "q" => AnomalyChoice::Quit,
+            "A" => {
+                ctx.sticky_anomaly.set(Some(AnomalyChoice::Absorb));
+                AnomalyChoice::Absorb
+            }
+            "O" => {
+                ctx.sticky_anomaly.set(Some(AnomalyChoice::Overwrite));
+                AnomalyChoice::Overwrite
+            }
+            "S" => {
+                ctx.sticky_anomaly.set(Some(AnomalyChoice::Skip));
+                AnomalyChoice::Skip
+            }
+            "d" => {
+                print_absorb_diff(src, dst);
+                continue;
+            }
+            other => {
+                eprintln!("unknown choice: {other:?}");
+                continue;
+            }
+        };
+        return Ok(choice);
+    }
 }
 
 /// Resilient git-clean check: if `git` isn't available or `source` isn't
@@ -3363,6 +3531,11 @@ fn source_repo_is_clean(source: &Utf8Path) -> bool {
 
 fn link_dir_with_backup(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>) -> Result<()> {
     use absorb::AbsorbDecision::*;
+
+    if ctx.quit_requested.get() {
+        return Ok(());
+    }
+
     let decision = absorb::classify(src, dst)?;
 
     if ctx.dry_run {
@@ -3612,24 +3785,30 @@ fn merge_resolve_file_conflict(
                     Ok(())
                 }
                 Ask => {
-                    use std::io::IsTerminal;
-                    if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
-                        if prompt_absorb_with_diff(
-                            source_path,
-                            target_path,
-                            "merge: file content differs and source is newer",
-                        )? {
+                    let choice = prompt_anomaly(
+                        ctx,
+                        source_path,
+                        target_path,
+                        "merge: file content differs and source is newer",
+                    )?;
+                    match choice {
+                        AnomalyChoice::Absorb => {
                             std::fs::copy(target_path, source_path)?;
-                        } else {
-                            warn!("merge: kept source version by user choice: {source_path}");
+                            Ok(())
                         }
-                        Ok(())
-                    } else {
-                        warn!(
-                            "merge anomaly skip (non-TTY ask mode): {target_path} \
-                             — keeping source version"
-                        );
-                        Ok(())
+                        AnomalyChoice::Overwrite => {
+                            std::fs::copy(source_path, target_path)?;
+                            Ok(())
+                        }
+                        AnomalyChoice::Skip => {
+                            warn!("merge: kept source version by user choice: {source_path}");
+                            Ok(())
+                        }
+                        AnomalyChoice::Quit => {
+                            warn!("merge: user requested quit; stopping at {target_path}");
+                            ctx.quit_requested.set(true);
+                            Ok(())
+                        }
                     }
                 }
             }
@@ -3649,6 +3828,22 @@ fn absorb_target_dir_into_source(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<
     merge_dir_target_into_source(dst, src, ctx)?;
     // Source now carries every regular file from target. Tear down the
     // original target dir and re-expose source via a junction.
+    remove_dir_link_or_real(dst)?;
+    link::link_dir(src, dst, ctx.dir_mode)?;
+    Ok(())
+}
+
+/// Inverse of `absorb_target_dir_into_source`: keep source's dir
+/// content as-is, back up target's diverged content, then re-expose
+/// source via a junction at the target path. Used when the user
+/// picks `[o]verwrite` for a dir-level anomaly.
+fn overwrite_source_dir_into_target(
+    src: &Utf8Path,
+    dst: &Utf8Path,
+    ctx: &ApplyCtx<'_>,
+) -> Result<()> {
+    info!("overwrite dir: {src} → {dst}");
+    backup_existing(dst, ctx.backup_root, /* is_dir */ true)?;
     remove_dir_link_or_real(dst)?;
     link::link_dir(src, dst, ctx.dir_mode)?;
     Ok(())
@@ -3676,30 +3871,19 @@ fn handle_anomaly_dir(
             );
             absorb_target_dir_into_source(src, dst, ctx)
         }
-        Ask => {
-            use std::io::IsTerminal;
-            if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
-                eprintln!();
-                eprintln!("anomaly: {dst}");
-                eprintln!("  {reason}");
-                eprintln!("  source: {src}");
-                eprint!("  absorb target dir into source? (y/N) ");
-                use std::io::{BufRead as _, Write as _};
-                std::io::stderr().flush().ok();
-                let mut buf = String::new();
-                std::io::stdin().lock().read_line(&mut buf)?;
-                let answer = buf.trim();
-                if answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes") {
-                    absorb_target_dir_into_source(src, dst, ctx)
-                } else {
-                    warn!("anomaly skipped by user: {dst}");
-                    Ok(())
-                }
-            } else {
-                warn!("anomaly skip (non-TTY ask mode): {dst} ({reason})");
+        Ask => match prompt_anomaly(ctx, src, dst, reason)? {
+            AnomalyChoice::Absorb => absorb_target_dir_into_source(src, dst, ctx),
+            AnomalyChoice::Overwrite => overwrite_source_dir_into_target(src, dst, ctx),
+            AnomalyChoice::Skip => {
+                warn!("anomaly skipped by user: {dst}");
                 Ok(())
             }
-        }
+            AnomalyChoice::Quit => {
+                warn!("anomaly dir: user requested quit; stopping apply at {dst}");
+                ctx.quit_requested.set(true);
+                Ok(())
+            }
+        },
     }
 }
 
@@ -5962,5 +6146,132 @@ when = "yui.os == 'definitely_not_a_real_os'"
         assert!(!snap.exists(), "dir snapshot removed wholesale");
         assert!(!backup.join("mirror").exists(), "empty mirror chain pruned");
         assert!(backup.exists(), "backup root preserved");
+    }
+
+    /// Build a no-op `ApplyCtx` over a `TempDir`. The returned tuple
+    /// owns the `Config` + paths so the borrow in `ApplyCtx` is valid
+    /// for the test scope. Callers can mutate the `Cell` fields in
+    /// place.
+    fn ctx_for_test(tmp: &TempDir) -> (Config, Utf8PathBuf, Utf8PathBuf) {
+        let source = utf8(tmp.path().join("src"));
+        let backup_root = source.join(".yui/backup");
+        std::fs::create_dir_all(&source).unwrap();
+        let cfg = Config::default();
+        (cfg, source, backup_root)
+    }
+
+    #[test]
+    fn prompt_anomaly_short_circuits_on_sticky_choice() {
+        // The whole point of sticky: once the user picks an `[A]`/`[O]`/`[S]`
+        // "all" option, every following anomaly applies that choice without
+        // re-prompting. We verify by pre-setting the cell and calling the
+        // prompt with stdin/stderr that would otherwise prompt.
+        let tmp = TempDir::new().unwrap();
+        let (cfg, source, backup_root) = ctx_for_test(&tmp);
+        let src_file = source.join("a");
+        let dst_file = utf8(tmp.path().join("dst"));
+        std::fs::write(&src_file, "X").unwrap();
+        std::fs::write(&dst_file, "Y").unwrap();
+
+        let ctx = ApplyCtx {
+            config: &cfg,
+            source: &source,
+            file_mode: resolve_file_mode(cfg.link.file_mode),
+            dir_mode: resolve_dir_mode(cfg.link.dir_mode),
+            backup_root: &backup_root,
+            dry_run: false,
+            sticky_anomaly: Cell::new(Some(AnomalyChoice::Overwrite)),
+            quit_requested: Cell::new(false),
+        };
+
+        let got = prompt_anomaly(&ctx, &src_file, &dst_file, "test").unwrap();
+        assert_eq!(got, AnomalyChoice::Overwrite);
+    }
+
+    #[test]
+    fn overwrite_source_into_target_replaces_target_and_backs_up() {
+        // `[o]verwrite`'s contract: the user keeps source's content and
+        // discards target's. After the call target reflects source, and
+        // target's old content is preserved under backup so it is
+        // recoverable.
+        let tmp = TempDir::new().unwrap();
+        let (cfg, source, backup_root) = ctx_for_test(&tmp);
+        let src_file = source.join("a");
+        let dst_file = utf8(tmp.path().join("dst"));
+        std::fs::write(&src_file, "from source").unwrap();
+        std::fs::write(&dst_file, "diverged target content").unwrap();
+
+        let ctx = ApplyCtx {
+            config: &cfg,
+            source: &source,
+            file_mode: resolve_file_mode(cfg.link.file_mode),
+            dir_mode: resolve_dir_mode(cfg.link.dir_mode),
+            backup_root: &backup_root,
+            dry_run: false,
+            sticky_anomaly: Cell::new(None),
+            quit_requested: Cell::new(false),
+        };
+
+        overwrite_source_into_target(&src_file, &dst_file, &ctx).unwrap();
+
+        // Target now matches source.
+        assert_eq!(std::fs::read_to_string(&dst_file).unwrap(), "from source");
+        // Source untouched.
+        assert_eq!(std::fs::read_to_string(&src_file).unwrap(), "from source");
+        // The diverged target content survives in backup.
+        let mut found_old = false;
+        for entry in walkdir(&backup_root) {
+            if let Ok(s) = std::fs::read_to_string(&entry) {
+                if s == "diverged target content" {
+                    found_old = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            found_old,
+            "expected backup containing target's diverged content"
+        );
+    }
+
+    #[test]
+    fn link_file_with_backup_short_circuits_when_quit_requested() {
+        // After `[q]uit` the walker keeps iterating but `quit_requested`
+        // makes every link op return Ok(()) without touching disk. We
+        // set up a clear anomaly (target older + content differs +
+        // on_anomaly=force, which would otherwise absorb) and verify
+        // nothing changed.
+        let tmp = TempDir::new().unwrap();
+        let (mut cfg, source, backup_root) = ctx_for_test(&tmp);
+        cfg.absorb.on_anomaly = crate::config::AnomalyAction::Force;
+
+        let src_file = source.join("a");
+        let dst_file = utf8(tmp.path().join("dst"));
+        let now = std::time::SystemTime::now();
+        let past = now - std::time::Duration::from_secs(120);
+        write_with_mtime(&dst_file, "target old", past);
+        write_with_mtime(&src_file, "source new", now);
+        let dst_before = std::fs::read_to_string(&dst_file).unwrap();
+        let src_before = std::fs::read_to_string(&src_file).unwrap();
+
+        let ctx = ApplyCtx {
+            config: &cfg,
+            source: &source,
+            file_mode: resolve_file_mode(cfg.link.file_mode),
+            dir_mode: resolve_dir_mode(cfg.link.dir_mode),
+            backup_root: &backup_root,
+            dry_run: false,
+            sticky_anomaly: Cell::new(None),
+            quit_requested: Cell::new(true),
+        };
+
+        link_file_with_backup(&src_file, &dst_file, &ctx).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&dst_file).unwrap(), dst_before);
+        assert_eq!(std::fs::read_to_string(&src_file).unwrap(), src_before);
+        assert!(
+            !backup_root.exists() || walkdir(&backup_root).is_empty(),
+            "no backup should be produced when quit is requested"
+        );
     }
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1987,7 +1987,9 @@ fn print_absorb_diff(src: &Utf8Path, dst: &Utf8Path) {
     use owo_colors::OwoColorize as _;
     use std::io::IsTerminal;
 
-    let color = std::io::stderr().is_terminal();
+    // Honor the de-facto NO_COLOR convention (https://no-color.org/) —
+    // any non-empty value disables colorisation, even on a TTY.
+    let color = std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none();
 
     eprintln!();
     if color {
@@ -3457,6 +3459,13 @@ fn prompt_anomaly(
     dst: &Utf8Path,
     reason: &str,
 ) -> Result<AnomalyChoice> {
+    // If a previous prompt selected `[q]uit`, every nested call (e.g.
+    // remaining file conflicts inside an in-flight dir merge) returns
+    // `Quit` immediately so we don't ask again, log redundant warnings,
+    // or block on stdin during teardown.
+    if ctx.quit_requested.get() {
+        return Ok(AnomalyChoice::Quit);
+    }
     if let Some(c) = ctx.sticky_anomaly.get() {
         return Ok(c);
     }
@@ -3485,9 +3494,12 @@ fn prompt_anomaly(
         let mut input = String::new();
         std::io::stdin().read_line(&mut input)?;
         let trimmed = input.trim();
+        // `y` / `n` are kept as aliases for the previous y/N prompt so
+        // muscle memory keeps working: `y` = "yes, absorb" (target →
+        // source), `n` = "no, leave it" (skip).
         let choice = match trimmed {
-            "" | "s" => AnomalyChoice::Skip,
-            "a" => AnomalyChoice::Absorb,
+            "" | "s" | "n" => AnomalyChoice::Skip,
+            "a" | "y" => AnomalyChoice::Absorb,
             "o" => AnomalyChoice::Overwrite,
             "q" => AnomalyChoice::Quit,
             "A" => {
@@ -3645,6 +3657,15 @@ fn merge_dir_target_into_source(
     ctx: &ApplyCtx<'_>,
 ) -> Result<()> {
     for entry in std::fs::read_dir(target)? {
+        // If the user picked `[q]uit` at a previous file-conflict
+        // prompt, every remaining entry in this dir merge becomes a
+        // no-op. The enclosing `absorb_target_dir_into_source` checks
+        // the same flag *after* the merge returns and skips the
+        // teardown/relink that would otherwise complete the absorb
+        // the user just asked us to abandon.
+        if ctx.quit_requested.get() {
+            return Ok(());
+        }
         let entry = entry?;
         let name_os = entry.file_name();
         let Some(name) = name_os.to_str() else {
@@ -3797,6 +3818,13 @@ fn merge_resolve_file_conflict(
                             Ok(())
                         }
                         AnomalyChoice::Overwrite => {
+                            // Preserve target's diverged content before
+                            // we clobber it with source's. The enclosing
+                            // dir absorb later removes target's tree
+                            // wholesale, so without this backup the
+                            // pre-overwrite state is unrecoverable.
+                            // Mirrors the file-level overwrite path.
+                            backup_existing(target_path, ctx.backup_root, /* is_dir */ false)?;
                             std::fs::copy(source_path, target_path)?;
                             Ok(())
                         }
@@ -3826,6 +3854,20 @@ fn absorb_target_dir_into_source(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<
     info!("absorb dir: {dst} → {src}");
     backup_existing(src, ctx.backup_root, /* is_dir */ true)?;
     merge_dir_target_into_source(dst, src, ctx)?;
+    // If the user picked `[q]uit` at a prompt during the merge, do not
+    // proceed with the teardown/relink that would finish the absorb
+    // the user just asked us to abandon. `dst` keeps its (partially
+    // populated) tree intact, source has whatever content was already
+    // merged before the quit, and the source-side backup taken at the
+    // top of this function is the recovery anchor.
+    if ctx.quit_requested.get() {
+        warn!(
+            "absorb dir interrupted by user quit: {dst} \
+             — leaving target tree intact; source backup at {}",
+            ctx.backup_root
+        );
+        return Ok(());
+    }
     // Source now carries every regular file from target. Tear down the
     // original target dir and re-expose source via a junction.
     remove_dir_link_or_real(dst)?;
@@ -6158,6 +6200,34 @@ when = "yui.os == 'definitely_not_a_real_os'"
         std::fs::create_dir_all(&source).unwrap();
         let cfg = Config::default();
         (cfg, source, backup_root)
+    }
+
+    #[test]
+    fn prompt_anomaly_short_circuits_on_quit_requested() {
+        // Once `[q]uit` flips the cell, every subsequent prompt
+        // (including the cascade of per-file prompts inside an
+        // in-flight dir merge) returns `Quit` immediately so we don't
+        // re-prompt or block on stdin during teardown.
+        let tmp = TempDir::new().unwrap();
+        let (cfg, source, backup_root) = ctx_for_test(&tmp);
+        let src_file = source.join("a");
+        let dst_file = utf8(tmp.path().join("dst"));
+        std::fs::write(&src_file, "X").unwrap();
+        std::fs::write(&dst_file, "Y").unwrap();
+
+        let ctx = ApplyCtx {
+            config: &cfg,
+            source: &source,
+            file_mode: resolve_file_mode(cfg.link.file_mode),
+            dir_mode: resolve_dir_mode(cfg.link.dir_mode),
+            backup_root: &backup_root,
+            dry_run: false,
+            sticky_anomaly: Cell::new(None),
+            quit_requested: Cell::new(true),
+        };
+
+        let got = prompt_anomaly(&ctx, &src_file, &dst_file, "test").unwrap();
+        assert_eq!(got, AnomalyChoice::Quit);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace the `[absorb] on_anomaly = "ask"` y/N prompt with a chezmoi-style multi-choice menu that also lets the user push **source → target** (`[o]verwrite`), bail out (`[q]uit`), or apply the same answer to every remaining anomaly (`[A]`/`[O]`/`[S]` uppercase variants).
- Colorise the diff with `owo-colors` (already a dependency) and label hunks `[-] src` / `[+] dst` so the +/- ↔ src/dst mapping is unambiguous regardless of which direction the user picks. ANSI escapes are gated on `stderr().is_terminal()`.
- New unit tests cover the sticky short-circuit, the source → target writer, and the quit-flag walker guard. `v0.7.16`.

## Why

The previous y/N prompt offered only "absorb (target → source)" or "skip". When the user has just edited the source side intentionally and wants the target updated to match, the only escape was to abort `apply` and copy the file by hand — which exactly matched a real workflow that surfaced this gap (encrypting a config file via `yui secret encrypt`, profile path edited in source, target stale).

## What changed

`src/cmd.rs`:
- `AnomalyChoice` enum (`Absorb` / `Overwrite` / `Skip` / `Quit`) — captures the user's intent independently from the action.
- `ApplyCtx` gains `sticky_anomaly: Cell<Option<AnomalyChoice>>` and `quit_requested: Cell<bool>` so the prompt can persist state across iterations without threading a return value back through every call site.
- New `prompt_anomaly` short-circuits on sticky, returns `Skip` off-TTY (preserving the prior "non-TTY ask = skip" downgrade), prints a colorised diff, and accepts the menu above. `[d]` re-shows the diff without leaving the loop.
- New `overwrite_source_into_target` / `overwrite_source_dir_into_target` — back up target's diverged content, then re-link from source so target reflects source again.
- All three anomaly call sites (`handle_anomaly`, `handle_anomaly_dir`, `merge_resolve_file_conflict`) now do a 4-way dispatch on the prompt's return; quit flips the cell.
- `link_file_with_backup` and `link_dir_with_backup` short-circuit at the top when `quit_requested` is set, so apply finishes the walk silently after `[q]`.
- `print_absorb_diff` walks hunks itself rather than delegating to `unified_diff().to_string()`, so each tag (`Insert` / `Delete` / `Equal`) gets its own ANSI styling.

`README.md`: drop the `<picture>` dark-mode logo swap (rendered inconsistently across GitHub themes).

## Test plan

- [x] `cargo test` (180 prior + 3 new = 183 pass)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] Local `yui apply` against an actual anomaly: prompt renders with colored diff, `o` overwrites target as expected, `A` sticks for subsequent files, `q` exits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive multi-choice prompts for handling anomalies during apply, including an “apply to all” choice.
  * Colorized unified diffs for clearer review.
  * Safer overwrite flow that creates backups when replacing divergent targets.

* **Bug Fixes**
  * Quit during prompts now halts remaining operations and avoids finalizing interrupted work.

* **Documentation**
  * Updated logo display in README.

* **Chores**
  * Version bumped to 0.7.16.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->