### PR TITLE
docs(claude) + feat: agent workflow policy + post_create on-add hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,86 @@ manage worktrees / jj workspaces while developing yui. Lockfile is
 `apm.lock.yaml`. Pinned to `#main`, so `apm install --update`
 always pulls the latest renri skill content.
 
+## Working in this repo with AI agents
+
+- **Read-only inspection** (browsing files, answering questions,
+  running read-only commands): no worktree needed; work in the
+  existing checkout.
+- **Any commit-bound change** — new feature, bug fix, refactor,
+  reviewer-feedback fix on an open PR: if you are on the **main
+  checkout**, start with `renri add <branch-name>` and move into
+  the worktree before committing (`cd "$(renri cd <branch-name>)"`,
+  or use the shell wrapper from `renri shell-init` so plain
+  `renri cd <name>` cds for you). If you are **already in a
+  worktree** (e.g. iterating on an existing PR), keep working
+  there. Do **not** edit on the main checkout for non-trivial
+  changes.
+- **Trivial wording / typo fixes** are the only soft exception, and
+  even then `renri add` is cheap enough that defaulting to it is
+  fine.
+
+### Backend choice — jj-first
+
+This repo is colocated git+jj. `renri add` defaults to **jj**
+(creates a non-colocated jj workspace where `jj` commands work and
+`git` does not — see [jj-vcs/jj#8052](https://github.com/jj-vcs/jj/issues/8052)
+for why secondary colocation isn't possible yet). Stick to the
+default unless there is a specific reason to use git tooling.
+
+```sh
+# In a freshly created worktree (default jj backend):
+jj st                                               # status
+jj describe -m "feat: ..."                          # set @-commit description
+jj git push --bookmark <branch-name> --allow-new    # first push of a new branch
+jj git push --bookmark <branch-name>                # subsequent pushes
+```
+
+`renri --vcs git add <branch-name>` is the override and exists for
+genuine git-CLI-only needs (git submodule, native git2 tooling,
+git-only hooks). Do **not** reach for it out of git-CLI familiarity
+— prefer learning the equivalent jj commands.
+
+### Cleanup after merge
+
+After the PR merges and you've pulled the change into main:
+
+- `renri remove <branch>` — removes a single worktree. Calls
+  `git worktree remove` or `jj workspace forget` as appropriate,
+  then deletes the directory. Refuses to remove the main worktree.
+- `renri prune` — best-effort GC across the repo. Git: removes
+  worktree metadata for already-deleted directories. jj: forgets
+  workspaces whose root path is gone (the missing
+  `jj workspace prune` analog).
+
+Run `renri prune` periodically — especially after manually
+`rm -rf`-ing worktree dirs without going through `renri remove`.
+
+### Hooks in worktrees
+
+The pre-push hook installed by `cargo make hook-install` lives in
+the **main repo's** `.git/hooks/pre-push`.
+
+- **git worktrees** share that hook directory, so plain `git push`
+  from a worktree triggers `cargo make check` automatically.
+- **jj workspaces** route their pushes through `jj git push`, which
+  uses libgit2 directly and **does not fire git hooks**. From a jj
+  workspace, run `cargo make check` manually before
+  `jj git push --bookmark <branch-name>` — there is no automatic gate.
+
+### Post-create automation (`cargo make on-add`)
+
+`renri.toml` declares a `[[hooks.post_create]]` that runs
+`cargo make on-add` immediately after `renri add` finishes. The
+default chain is:
+
+- `apm install --update` — refresh the renri skill so AI agents in
+  the new worktree see the latest guidance.
+- `vcs-fetch` — `jj git fetch` in a jj workspace, `git fetch`
+  otherwise; cleans up subsequent rebase / merge.
+
+Add per-repo extras (e.g. `cargo fetch`) by extending
+`[tasks.on-add]`'s dependency list in `Makefile.toml`.
+
 ## Resilience principle
 
 Borrowed from rvpm: a single failure should not stop the whole tool.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -57,6 +57,34 @@ description = "Install agent skills declared in apm.yml — pinned to copilot, c
 command = "apm"
 args = ["install", "-t", "copilot,claude,gemini"]
 
+[tasks.apm-install-update]
+description = "Refresh APM dependencies to upstream latest (used by on-add hook)"
+command = "apm"
+args = ["install", "--update", "-t", "copilot,claude,gemini"]
+
+[tasks.vcs-fetch]
+description = "Fetch latest origin refs (jj when in a jj workspace, otherwise git)"
+script_runner = "@duckscript"
+script = '''
+# A non-colocated jj workspace has `.jj/` but no `.git/`, and `git fetch`
+# fails there with "not a git repository". Prefer `jj git fetch`, which
+# works in pure-jj and colocated repos. Fall back to `git fetch` for
+# pure-git (no `.jj/`) worktrees.
+#
+# Best-effort: don't `--fail-on-error` because a transient network
+# failure during `renri add` shouldn't break the worktree; the user
+# can always `cargo make vcs-fetch` later.
+if is_path_exists .jj
+    exec jj git fetch
+else
+    exec git fetch
+end
+'''
+
+[tasks.on-add]
+description = "Wired to renri's [[hooks.post_create]] — runs in a freshly created worktree"
+dependencies = ["apm-install-update", "vcs-fetch"]
+
 [tasks.setup]
 description = "One-time setup for new contributors: pre-push hook + APM install (requires `apm` CLI on PATH — see https://github.com/microsoft/apm)"
 dependencies = ["hook-install", "apm-install"]

--- a/renri.toml
+++ b/renri.toml
@@ -1,0 +1,7 @@
+# renri.toml
+# Schema and examples: https://github.com/yukimemi/renri
+
+[[hooks.post_create]]
+type = "command"
+run = "cargo make on-add"
+shell = "auto"


### PR DESCRIPTION
## Summary

Mirrors the renri policy + on-add hook landed upstream (renri PRs #2 and #4). Brings yui in line with the cross-repo convention now that #67 has merged.

- **"Working in this repo with AI agents"** CLAUDE.md section: when to use renri, jj-first backend choice with cheatsheet, cleanup commands, hooks-in-worktrees gotchas, post-create automation.
- **\`renri.toml\`** with \`[[hooks.post_create]]\` calling \`cargo make on-add\`.
- Three new **Makefile.toml** tasks:
  - \`apm-install-update\` — \`apm install --update -t copilot,claude,gemini\`
  - \`vcs-fetch\` — \`jj git fetch\` when in a jj workspace, \`git fetch origin\` otherwise (auto-dispatch via duckscript)
  - \`on-add\` — depends on the two above, called from the \`renri.toml\` hook

Pure tooling / docs; no Rust API change.

## Dogfood

Authored from \`renri add chore/agent-workflow-on-add\` (jj workspace at \`~/wt/yukimemi/yui/chore-agent-workflow-on-add\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)