### PR TITLE
fix(secret): close .gitignore window after `secret encrypt` (#71)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,6 +231,12 @@ pub enum SecretAction {
     /// `[secrets] recipients`, and write the ciphertext as
     /// `<path>.age` next to it. Refuses to clobber an existing
     /// `.age` without `--force`.
+    ///
+    /// The plaintext sibling is added to the managed `.gitignore`
+    /// section immediately so it can't be staged accidentally
+    /// before the next `apply`. Pass `--rm-plaintext` to also
+    /// delete the plaintext after a successful encryption (works
+    /// only when it lives under `$DOTFILES`).
     Encrypt {
         path: Utf8PathBuf,
         /// Replace an existing `<path>.age`.

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -907,6 +907,19 @@ pub fn secret_encrypt(
     std::fs::write(&cipher_path, &cipher)?;
     info!("encrypted {plaintext_path} → {cipher_path}");
 
+    // Issue #71: close the .gitignore window. `apply` rewrites the
+    // managed section from a full render+decrypt walk, but until
+    // that runs the freshly created plaintext sibling is visible to
+    // `git add` / `git commit -a`. Merge this one entry now so the
+    // plaintext can't be staged accidentally between encrypt and the
+    // next apply. Only meaningful when the plaintext actually lives
+    // under `$DOTFILES` (matches the `rm_plaintext` safety check
+    // below) and when gitignore management is enabled.
+    if config.render.manage_gitignore && plaintext_path.starts_with(&source) {
+        render::add_to_managed_section(&source, &plaintext_path)?;
+    }
+    info!("run `yui apply` to refresh links and the rest of the managed section");
+
     if rm_plaintext {
         // Only remove plaintext when it lives under `$DOTFILES` —
         // erasing files outside the repo on a typo would be cruel.

--- a/src/render.rs
+++ b/src/render.rs
@@ -322,6 +322,64 @@ pub fn write_managed_section(source: &Utf8Path, managed_abs_paths: &[Utf8PathBuf
     update_gitignore(source, managed_abs_paths)
 }
 
+/// Additively merge `plaintext_abs_path` into yui's managed
+/// `.gitignore` section, preserving every other entry already
+/// there. Used by `yui secret encrypt` to close the window where a
+/// freshly written plaintext sibling would be visible to `git add`
+/// until the next `apply` rewrites the full managed block (issue
+/// #71).
+///
+/// Unlike [`write_managed_section`], this is non-destructive: it
+/// parses the existing section, unions the single new entry, sorts
+/// and dedupes, and rewrites only the block between the markers.
+/// Content above and below the markers is untouched.
+pub fn add_to_managed_section(source: &Utf8Path, plaintext_abs_path: &Utf8Path) -> Result<()> {
+    let gi_path = source.join(".gitignore");
+    let existing = match std::fs::read_to_string(&gi_path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(Error::Template(format!("read {gi_path}: {e}"))),
+    };
+
+    let new_entry = plaintext_abs_path
+        .strip_prefix(source)
+        .map(|p| p.as_str().to_string())
+        .unwrap_or_else(|_| plaintext_abs_path.as_str().to_string())
+        .replace('\\', "/");
+
+    let mut managed = parse_managed_section(&existing);
+    managed.push(new_entry);
+    managed.sort();
+    managed.dedup();
+
+    let new_section = build_managed_section(&managed);
+    let updated = replace_or_append_section(&existing, &new_section);
+
+    if updated != existing {
+        std::fs::write(&gi_path, updated)?;
+    }
+    Ok(())
+}
+
+fn parse_managed_section(text: &str) -> Vec<String> {
+    let Some(start) = text.find(GITIGNORE_BEGIN) else {
+        return Vec::new();
+    };
+    let Some(end) = text.find(GITIGNORE_END) else {
+        return Vec::new();
+    };
+    if start >= end {
+        return Vec::new();
+    }
+    let body_start = start + GITIGNORE_BEGIN.len();
+    text[body_start..end]
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
 fn update_gitignore(source: &Utf8Path, rendered_abs_paths: &[Utf8PathBuf]) -> Result<()> {
     let gi_path = source.join(".gitignore");
     let existing = match std::fs::read_to_string(&gi_path) {
@@ -693,6 +751,76 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(r.join("home/foo")).unwrap(),
             "old rendered output"
+        );
+    }
+
+    #[test]
+    fn add_to_managed_creates_section_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        let r = root(&tmp);
+        // No .gitignore at all yet — first encrypt should create one
+        // with the new plaintext sibling inside the managed block.
+        let plain = r.join("home/.config/foo/private.env");
+        add_to_managed_section(&r, &plain).unwrap();
+        let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
+        assert!(gi.contains(GITIGNORE_BEGIN));
+        assert!(gi.contains(GITIGNORE_END));
+        assert!(gi.contains("home/.config/foo/private.env"));
+    }
+
+    #[test]
+    fn add_to_managed_preserves_existing_entries() {
+        let tmp = TempDir::new().unwrap();
+        let r = root(&tmp);
+        // Pre-existing managed section with a render-produced entry
+        // plus user content above + below.
+        write(
+            &r.join(".gitignore"),
+            &format!(
+                "node_modules/\n\n{GITIGNORE_BEGIN}\nhome/.gitconfig\n{GITIGNORE_END}\n\ntarget/\n"
+            ),
+        );
+        let plain = r.join("home/.config/foo/private.env");
+        add_to_managed_section(&r, &plain).unwrap();
+        let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
+        // Existing render entry still there.
+        assert!(gi.contains("home/.gitconfig"));
+        // New secret entry merged in.
+        assert!(gi.contains("home/.config/foo/private.env"));
+        // User content above + below untouched.
+        assert!(gi.contains("node_modules/"));
+        assert!(gi.contains("target/"));
+    }
+
+    #[test]
+    fn add_to_managed_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let r = root(&tmp);
+        let plain = r.join("home/secret.env");
+        add_to_managed_section(&r, &plain).unwrap();
+        add_to_managed_section(&r, &plain).unwrap();
+        let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
+        let occurrences = gi.matches("home/secret.env").count();
+        assert_eq!(occurrences, 1, "duplicate entries in: {gi}");
+    }
+
+    #[test]
+    fn add_to_managed_normalises_windows_separators() {
+        let tmp = TempDir::new().unwrap();
+        let r = root(&tmp);
+        // Synthesise a backslash-bearing absolute path the way Windows
+        // would; the managed section must always use forward slashes
+        // so the `.gitignore` works on both platforms.
+        let plain = Utf8PathBuf::from(format!("{}\\home\\.config\\foo\\private.env", r.as_str()));
+        add_to_managed_section(&r, &plain).unwrap();
+        let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
+        assert!(
+            gi.contains("home/.config/foo/private.env"),
+            "expected forward-slash entry in: {gi}"
+        );
+        assert!(
+            !gi.contains("home\\.config"),
+            "managed section should not carry backslashes: {gi}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add `render::add_to_managed_section`, a non-destructive merge into the managed `.gitignore` block (preserves all other entries — unlike `write_managed_section` which is the full-rewrite path used by `apply`).
- Call it from `cmd::secret_encrypt` right after the ciphertext is written, so the plaintext sibling can never be staged accidentally between `encrypt` and the next `apply`.
- Spell out the new behaviour in `secret encrypt --help`.

Closes #71.

## Why

`yui secret encrypt` previously wrote only `<path>.age` and left the plaintext sibling outside the managed `.gitignore` section until the next `yui apply` ran `secret::decrypt_all` and rewrote the block. A user running `git add -A` between those two commands committed the plaintext — the leak the issue describes.

This is Option **A + B** from the issue: encrypt itself closes the window, and the log line still nudges the user toward `apply` for the link side.

## Test plan

- [x] `cargo make check` (fmt + clippy + test + lock-check) green locally — 188 tests
- [x] New unit tests in `src/render.rs`:
  - `add_to_managed_creates_section_when_missing` — first encrypt creates the managed block
  - `add_to_managed_preserves_existing_entries` — existing render entries + user `.gitignore` content above/below untouched
  - `add_to_managed_is_idempotent` — running twice does not duplicate the entry
  - `add_to_managed_normalises_windows_separators` — `\` paths land as `/` in `.gitignore`
- [ ] Manual repro from the issue: `yui secret encrypt home/.config/foo/private.env && git status` — plaintext should appear ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)