### PR TITLE
feat(updater): auto-update banner via `kaishin::Checker`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -117,10 +117,35 @@ pub enum HookPhase {
     Post,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize)]
 pub struct UiConfig {
     #[serde(default)]
     pub icons: IconsMode,
+    /// When true, yui spawns a background update check on every
+    /// non-self-update invocation and shows a banner at exit if a
+    /// newer release is available. Powered by `kaishin::Checker`;
+    /// mirrors renri / rvpm.
+    #[serde(default = "default_auto_update_check")]
+    pub auto_update_check: bool,
+    /// Cadence override for the background update check (e.g.
+    /// `"24h"`, `"1d"`, `"30m"`). Parsed by `kaishin::parse_interval`.
+    /// `None` falls back to the kaishin default (24h).
+    #[serde(default)]
+    pub update_check_interval: Option<String>,
+}
+
+impl Default for UiConfig {
+    fn default() -> Self {
+        Self {
+            icons: IconsMode::default(),
+            auto_update_check: default_auto_update_check(),
+            update_check_interval: None,
+        }
+    }
+}
+
+fn default_auto_update_check() -> bool {
+    true
 }
 
 #[derive(Debug, Deserialize, Default, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,32 @@
 use anyhow::Result;
 use clap::Parser;
-use yui::cli::Cli;
+use yui::cli::{Cli, Command};
+use yui::updater;
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
     yui::init_tracing(cli.verbose);
-    cli.run()
+
+    // Background update check: same pattern as rvpm / renri. Skip on
+    // `self-update` (would race with the install) and `completion`
+    // (its output is meant to be piped into shell init, so the
+    // banner on stderr would surprise / pollute setups that capture
+    // stderr too).
+    let banner_eligible = !matches!(
+        cli.command,
+        Command::SelfUpdate { .. } | Command::Completion { .. }
+    );
+    let update_check_handle = if banner_eligible {
+        updater::maybe_spawn_auto_update_check(cli.source.as_deref())
+    } else {
+        None
+    };
+
+    let result = cli.run();
+
+    if let Some(handle) = update_check_handle {
+        updater::finalize_auto_update_check(handle);
+    }
+
+    result
 }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -8,15 +8,39 @@
 //! and binary are both `yui`, so going through `env!("CARGO_PKG_NAME")`
 //! the way renri does would produce the wrong GitHub Release URL.
 //!
-//! Auto-update banner / background `Checker` plumbing is
-//! intentionally not wired up here — that lives in a follow-up so
-//! this change stays scoped to "add the command".
+//! The module exposes two layers:
+//!
+//! - [`run_self_update`] — drives the `yui self-update` subcommand
+//!   (interactive / `--yes` / `--check`).
+//! - [`Checker`] + [`maybe_spawn_auto_update_check`] /
+//!   [`finalize_auto_update_check`] — the daily background banner
+//!   shown after every other subcommand, the way `rvpm` / `renri`
+//!   do it. `[ui] auto_update_check = false` in `config.toml` opts
+//!   out, and `[ui] update_check_interval = "..."` overrides the
+//!   default 24h cadence.
+
+use std::time::Duration;
 
 use anyhow::Result;
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::config;
+use crate::paths;
+use crate::vars::YuiVars;
 
 const OWNER: &str = "yukimemi";
 const REPO: &str = "yui";
 const BIN: &str = "yui";
+
+fn kaishin_opts() -> kaishin::KaishinOptions {
+    kaishin::KaishinOptions::new(OWNER, REPO, BIN, env!("CARGO_PKG_VERSION"))
+}
+
+fn make_runtime() -> Result<tokio::runtime::Runtime> {
+    Ok(tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?)
+}
 
 /// Run `yui self-update`. Flags map directly onto kaishin's
 /// `UpdateOptions`:
@@ -26,14 +50,212 @@ const BIN: &str = "yui";
 /// - `non_interactive` makes kaishin bail out (rather than prompt)
 ///   when stdin isn't a tty; only meaningful together with `yes`.
 pub fn run_self_update(yes: bool, check_only: bool, non_interactive: bool) -> Result<()> {
-    let opts = kaishin::KaishinOptions::new(OWNER, REPO, BIN, env!("CARGO_PKG_VERSION"));
+    let opts = kaishin_opts();
     let upd_opts = kaishin::UpdateOptions::new()
         .yes(yes)
         .check_only(check_only)
         .non_interactive(non_interactive);
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()?;
+    let rt = make_runtime()?;
     rt.block_on(async { kaishin::run_self_update(&opts, upd_opts).await })
+}
+
+/// Default interval between background update checks (24 hours).
+pub fn default_interval() -> Duration {
+    kaishin::default_interval()
+}
+
+/// Blocking facade over `kaishin::Checker` — yui's main loop is
+/// synchronous, so the async `check_and_save` call goes through a
+/// fresh `current_thread` runtime each time. Same shape as renri.
+pub struct Checker {
+    inner: kaishin::Checker,
+}
+
+impl Checker {
+    /// Build a checker pinned to yui's (owner, repo, bin) triple
+    /// and the running binary's version.
+    pub fn new() -> Result<Self> {
+        let inner = kaishin::Checker::new(BIN, kaishin_opts());
+        Ok(Self { inner })
+    }
+
+    /// Override the cadence between background checks. Pair with
+    /// `kaishin::parse_interval` when the value comes from the
+    /// `[ui] update_check_interval` config string.
+    pub fn interval(mut self, interval: Duration) -> Self {
+        self.inner = self.inner.interval(interval);
+        self
+    }
+
+    /// True if the on-disk cache is older than the configured
+    /// interval and we should fetch from GitHub again.
+    pub fn should_check(&self) -> bool {
+        self.inner.should_check()
+    }
+
+    /// Hit GitHub, write the result to the cache, and return it.
+    /// Block on an ad-hoc tokio runtime — the caller is on a
+    /// regular OS thread spawned by `std::thread::spawn`.
+    pub fn check_and_save(&self) -> Result<kaishin::LatestRelease> {
+        let rt = make_runtime()?;
+        rt.block_on(async { self.inner.check_and_save().await })
+    }
+
+    /// Latest release known from the last successful check; `None`
+    /// if no check has ever completed.
+    pub fn cached_update(&self) -> Option<kaishin::LatestRelease> {
+        self.inner.cached_update()
+    }
+
+    /// Render the `A new version is available!` banner kaishin
+    /// ships out of the box.
+    pub fn format_banner(&self, latest: &kaishin::LatestRelease) -> String {
+        self.inner.format_banner(latest)
+    }
+}
+
+/// Handle for an ongoing or cached background update check.
+/// Mirrors renri's `AutoUpdateHandle`.
+pub enum AutoUpdateHandle {
+    /// A newer version was found in the local cache from a previous
+    /// run, and we don't need to hit GitHub again on this invocation.
+    CachedAvailable {
+        checker: Checker,
+        latest: kaishin::LatestRelease,
+    },
+    /// A background check is running on a worker thread; the receiver
+    /// hands the result back to the main thread at shutdown.
+    Pending {
+        checker: Checker,
+        rx: std::sync::mpsc::Receiver<Result<kaishin::LatestRelease>>,
+        cached_latest: Option<kaishin::LatestRelease>,
+    },
+}
+
+/// Spawn a background check on `std::thread::spawn` if the user
+/// hasn't opted out and the cache is older than the configured
+/// interval. The returned handle is consumed by
+/// [`finalize_auto_update_check`] at shutdown.
+///
+/// Source-repo discovery is best-effort: we read `[ui]` config to
+/// see whether the banner is disabled, but if the repo can't be
+/// located we just skip the banner rather than fail loudly. The
+/// banner is convenience; nothing else hangs off of it.
+pub fn maybe_spawn_auto_update_check(cli_source: Option<&Utf8Path>) -> Option<AutoUpdateHandle> {
+    let source = detect_source(cli_source)?;
+    let yui = YuiVars::detect(&source);
+    let loaded = config::load(&source, &yui).ok()?;
+    if !loaded.ui.auto_update_check {
+        return None;
+    }
+
+    // Surface a malformed `update_check_interval` rather than
+    // silently rolling it into the default. A typo here is exactly
+    // the sort of thing the user would want to know about; logging
+    // through `tracing::warn!` lets `-v` reveal it without crashing
+    // the rest of the command. (PR #76 review by coderabbitai.)
+    let interval = match loaded.ui.update_check_interval.as_deref() {
+        None => default_interval(),
+        Some(s) => match kaishin::parse_interval(s) {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!(
+                    "invalid [ui] update_check_interval = {s:?} ({e}); \
+                     falling back to default {:?}",
+                    default_interval()
+                );
+                default_interval()
+            }
+        },
+    };
+
+    let checker = Checker::new().ok()?.interval(interval);
+
+    if !checker.should_check() {
+        if let Some(latest) = checker.cached_update() {
+            return Some(AutoUpdateHandle::CachedAvailable { checker, latest });
+        }
+        return None;
+    }
+
+    let cached_latest = checker.cached_update();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let checker_clone = Checker::new().ok()?.interval(interval);
+    std::thread::spawn(move || {
+        let _ = tx.send(checker_clone.check_and_save());
+    });
+
+    Some(AutoUpdateHandle::Pending {
+        checker,
+        rx,
+        cached_latest,
+    })
+}
+
+/// Print the update banner (if any) before the binary exits. Waits
+/// up to one second for an in-flight background check to finish; on
+/// timeout, falls back to the previously-cached release so the user
+/// still gets the nudge. Skips the leading newline when the banner
+/// would be empty (e.g. kaishin returning a release that doesn't
+/// actually outrank the running version). (PR #76 review by
+/// gemini-code-assist.)
+pub fn finalize_auto_update_check(handle: AutoUpdateHandle) {
+    let (checker, latest) = match handle {
+        AutoUpdateHandle::CachedAvailable { checker, latest } => (checker, Some(latest)),
+        AutoUpdateHandle::Pending {
+            checker,
+            rx,
+            cached_latest,
+        } => {
+            let latest = rx
+                .recv_timeout(Duration::from_secs(1))
+                .ok()
+                .and_then(|r| r.ok())
+                .or(cached_latest);
+            (checker, latest)
+        }
+    };
+    if let Some(latest) = latest {
+        let banner = checker.format_banner(&latest);
+        if !banner.is_empty() {
+            eprintln!("\n{banner}");
+        }
+    }
+}
+
+/// Best-effort source-repo resolution for the banner path. Honors
+/// `--source` / `$YUI_SOURCE` first, then walks cwd ancestors
+/// looking for a `config.toml`. Skips the `~/dotfiles` fallback
+/// that `cmd::resolve_source` does — the banner shouldn't surprise
+/// users running `yui` from outside their dotfiles repo.
+fn detect_source(cli_source: Option<&Utf8Path>) -> Option<Utf8PathBuf> {
+    if let Some(s) = cli_source {
+        return Some(absolutize_best_effort(s));
+    }
+    if let Ok(s) = std::env::var("YUI_SOURCE") {
+        return Some(absolutize_best_effort(Utf8Path::new(&s)));
+    }
+    let cwd = current_dir()?;
+    for ancestor in cwd.ancestors() {
+        if ancestor.join("config.toml").is_file() {
+            return Some(ancestor.to_path_buf());
+        }
+    }
+    None
+}
+
+fn absolutize_best_effort(p: &Utf8Path) -> Utf8PathBuf {
+    let expanded = paths::expand_tilde(p.as_str());
+    if expanded.is_absolute() {
+        return expanded;
+    }
+    current_dir()
+        .map(|cwd| cwd.join(&expanded))
+        .unwrap_or(expanded)
+}
+
+fn current_dir() -> Option<Utf8PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    Utf8PathBuf::from_path_buf(cwd).ok()
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #74. Wires `kaishin::Checker` into `main.rs` so every non-`self-update` / non-`completion` invocation spawns a background update check and prints a one-line "a new version is available" banner at exit when a newer release is published. Same pattern rvpm and renri use.

Closes the follow-up alluded to in #74's description ("Background auto-update banner is intentionally not wired up in this PR — left for a follow-up").

## Changes

- `src/updater.rs` — `Checker` (blocking facade around kaishin's async `Checker`), `AutoUpdateHandle` enum, and `maybe_spawn_auto_update_check` / `finalize_auto_update_check`. Source-repo discovery is best-effort: honors `--source` / `$YUI_SOURCE` first, then walks cwd ancestors for `config.toml`; silently no-ops if none found (the banner is convenience, not a hard requirement).
- `src/config.rs` — `[ui]` gains:
  - `auto_update_check: bool` (default `true`)
  - `update_check_interval: Option<String>` (parsed by `kaishin::parse_interval`, default 24h)
- `src/main.rs` — wires the spawn/finalize calls around `cli.run()` with the `SelfUpdate` / `Completion` guard so the banner doesn't race the install or pollute completion-script consumers that capture stderr.

## Behaviour notes

- Background check runs on a `std::thread::spawn` worker that owns its own `current_thread` tokio runtime. Main thread blocks for at most 1s on `recv_timeout` at shutdown and falls back to the cached release if the network call doesn't return in time.
- Net cost: at worst, `yui apply` exits ~1s later than it would have on the very first run after a release; subsequent runs hit the on-disk cache and are instantaneous.
- Opt-out: `[ui] auto_update_check = false` in `config.toml`.

## Test plan

- [x] `cargo make check` (fmt + clippy + test + lock-check) — 188 tests pass locally
- [ ] After merge + release, manually verify the banner appears on an old binary when a newer release exists, and stays silent when up-to-date.
- [ ] Manually verify `yui self-update` and `yui completion bash` do *not* spawn the background check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background auto-update checking that runs while the application operates
  * Configurable automatic update check frequency with customizable intervals
  * Update notifications appear when new versions are available
  * Users can enable or disable automatic update checks via configuration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yukimemi/yui/pull/76)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->