### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/kata-apply.yml
+++ b/.github/workflows/kata-apply.yml
@@ -19,10 +19,12 @@ name: kata-apply
 # rendered-file diff. Auto-merged when CI passes — if CI fails,
 # the PR stays open for human review.
 #
-# Source: yukimemi/pj-base. Filename carries `.template` so kata
-# strips the suffix on apply (pj-base itself has no `.kata` state,
-# so the workflow never fires there; consumer receives
-# `.github/workflows/kata-apply.yml`).
+# Source: yukimemi/pj-base. Filename carries `.tera` so kata
+# Tera-renders the file at apply time (substituting
+# `{{ vars.actions.* }}`) and strips the
+# suffix — consumer receives `.github/workflows/kata-apply.yml`.
+# pj-base itself has no `.kata` state, so the .tera source never
+# executes in GHA in this repo (GHA only invokes `.yml`/`.yaml`).
 
 on:
   schedule:

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,15 +1,15 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-05-12T14:51:04.152938828Z"
+applied_at = "2026-05-12T15:50:23.207098732Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "4c0d51572d6f7c25883a220f2f8473beab8a9c23"
-version = "0.9.0"
+rev = "b1faf3545d962952344fa4ae4e554a34d0c4e689"
+version = "0.10.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust"
-rev = "99af835c61fbc9da55b886ba3b3f22f23b8ee8b5"
-version = "0.4.2"
+rev = "20f3042ca5f4ffba2b26fb1fadd19154077e6477"
+version = "0.5.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust-cli"
@@ -36,7 +36,7 @@ content_hash = "1a4b579b1b643a41dbf97d8834ff1f3f1fe532ff863d0f861431cf3ca47d31e2
 content_hash = "ec163f67d4b75e3a3499ac45998472dac7cb24a3594a685559a250dc4f48d3d0"
 
 [files.".github/workflows/kata-apply.yml"]
-content_hash = "3aefabfef313f5c3c6343804450c6a38feb53678c4f4683bb3f0220ea6d7a24a"
+content_hash = "20d2b132c11cb0a2f382a24d0f8617411dea5565324a5405900fcc8ce4e842f6"
 
 [files.".github/workflows/release.yml"]
 content_hash = "fd5c3f524d212d7d237b9f410d0d2a0378e2a434ddac1dadef38da1bcc46fb2b"


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration metadata and template version references to maintain consistency with build infrastructure tooling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yukimemi/yui/pull/83)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->