### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.9.1
       - run: cargo check --all-targets
 
   test:
@@ -36,9 +36,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.9.1
       # `cargo test --all-targets` covers lib / bins / tests / benches
       # / examples but EXCLUDES doc tests, so run --doc separately.
       # Doc-test step is gated on `src/lib.rs` presence: `cargo test
@@ -53,7 +53,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -63,11 +63,11 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.9.1
       - run: cargo clippy --all-targets -- -D warnings
 
   lockfile:
@@ -77,7 +77,7 @@ jobs:
     name: cargo lockfile in sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.9.1
       - run: cargo check --locked --all-targets

--- a/.github/workflows/kata-apply.yml
+++ b/.github/workflows/kata-apply.yml
@@ -55,7 +55,7 @@ jobs:
       # CI from running on the auto-PR — making auto-merge wait for
       # checks that never fire. A PAT acts as a user-identity push
       # and triggers CI normally.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           token: ${{ secrets.KATA_APPLY_TOKEN }}
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Open / update PR if there are changes
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           token: ${{ secrets.KATA_APPLY_TOKEN }}
           branch: kata-apply/auto

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,9 +1,9 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-05-12T15:50:23.207098732Z"
+applied_at = "2026-05-14T04:33:56.583418087Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "b1faf3545d962952344fa4ae4e554a34d0c4e689"
+rev = "f04151faf4f0678be9621bb724c8f3120a5e4d8b"
 version = "0.10.0"
 
 [[templates]]
@@ -33,10 +33,10 @@ content_hash = "486c974de88903113ed99b4e643432b7050e88f1031276f5263e8da7b43fe11e
 content_hash = "1a4b579b1b643a41dbf97d8834ff1f3f1fe532ff863d0f861431cf3ca47d31e2"
 
 [files.".github/workflows/ci.yml"]
-content_hash = "ec163f67d4b75e3a3499ac45998472dac7cb24a3594a685559a250dc4f48d3d0"
+content_hash = "3a35eeef0bd68f37a34f7168d82133305954283d9bc724208aeafce55da20d91"
 
 [files.".github/workflows/kata-apply.yml"]
-content_hash = "20d2b132c11cb0a2f382a24d0f8617411dea5565324a5405900fcc8ce4e842f6"
+content_hash = "bc0e3def04b634949297d60322999a27f53bffc71b6cb662ae58ac8087e78bed"
 
 [files.".github/workflows/release.yml"]
 content_hash = "fd5c3f524d212d7d237b9f410d0d2a0378e2a434ddac1dadef38da1bcc46fb2b"


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->