### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,86 @@
+# Auto-tag on version bump.
+#
+# Watches `main` and, whenever a commit lands that changes
+# `[package] version` in Cargo.toml, creates a matching
+# `vX.Y.Z` tag and pushes it. The tag push then triggers the
+# tag-driven release workflow (cross-compile + GitHub Release +
+# cargo publish for CLIs, lib publish for libs).
+#
+# This file is kata-managed via `pj-rust`'s template.toml
+# (rendered out of `auto-tag.yml.tera`, the suffix stripped on
+# the consumer side). The `.tera` suffix keeps GitHub Actions
+# from running the source inside `pj-rust` itself, the same
+# protection `ci.yml.tera` and `release.yml.template` use.
+
+name: Auto-tag on version bump
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    runs-on: ubuntu-latest
+    steps:
+      # `fetch-depth: 2` so HEAD~1 (the parent commit) is in scope
+      # for the Cargo.toml diff. fetch-depth: 0 would also work but
+      # is wasteful when we only need one parent.
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 2
+
+      # Extract `version = "..."` from Cargo.toml under [package].
+      # Plain grep is enough because yukimemi/* crates are
+      # single-package (no [workspace] virtual manifest), so the
+      # first `^version =` line is always the package version.
+      - name: Detect version bump
+        id: ver
+        shell: bash
+        run: |
+          set -euo pipefail
+          extract() {
+            grep -E '^version = "' "$1" | head -n1 | sed -E 's/.*"([^"]+)".*/\1/'
+          }
+          NEW=$(extract Cargo.toml)
+          # HEAD~1 might not have Cargo.toml (very first commit on a
+          # new repo) — fall back to empty string so the diff below
+          # still classifies it as a bump.
+          OLD=$(git show HEAD~1:Cargo.toml 2>/dev/null | grep -E '^version = "' | head -n1 | sed -E 's/.*"([^"]+)".*/\1/' || true)
+          OLD="${OLD:-}"
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+          echo "old=$OLD" >> "$GITHUB_OUTPUT"
+          if [ -n "$NEW" ] && [ "$NEW" != "$OLD" ]; then
+            echo "bumped=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Detected version bump: ${OLD:-<none>} -> $NEW"
+          else
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No version change ($NEW); nothing to tag."
+          fi
+
+      - name: Create and push tag
+        if: steps.ver.outputs.bumped == 'true'
+        shell: bash
+        env:
+          # `gh` reads this; `git push` uses the default token from
+          # actions/checkout's persisted credentials.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="v${{ steps.ver.outputs.new }}"
+          # Be idempotent: if the tag already exists (e.g. someone
+          # ran `git tag` by hand before this workflow caught up),
+          # don't overwrite it — just exit successfully.
+          if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null \
+            || gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/$TAG" --silent 2>/dev/null; then
+            echo "::notice::Tag $TAG already exists; skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "$TAG"
+          git push origin "$TAG"
+          echo "::notice::Pushed tag $TAG"

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,5 +1,5 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-05-14T04:33:56.583418087Z"
+applied_at = "2026-05-15T04:38:32.911484769Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
@@ -8,7 +8,7 @@ version = "0.10.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust"
-rev = "20f3042ca5f4ffba2b26fb1fadd19154077e6477"
+rev = "8f059bb3dc6e14792915db70fff4b16f9af92080"
 version = "0.5.0"
 
 [[templates]]
@@ -31,6 +31,9 @@ content_hash = "486c974de88903113ed99b4e643432b7050e88f1031276f5263e8da7b43fe11e
 
 [files.".gitattributes"]
 content_hash = "1a4b579b1b643a41dbf97d8834ff1f3f1fe532ff863d0f861431cf3ca47d31e2"
+
+[files.".github/workflows/auto-tag.yml"]
+content_hash = "31ba3d93dfa16bfa95d81618f613a02d3975b60ecd4eda36abc0d6e18ea69972"
 
 [files.".github/workflows/ci.yml"]
 content_hash = "3a35eeef0bd68f37a34f7168d82133305954283d9bc724208aeafce55da20d91"


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->