### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,13 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.9.1
+        with:
+          # Skip cache save on PR runs — the Post step's tar.exe is
+          # flaky on windows-latest (file locks under target/ make
+          # the save fail and mark the otherwise-green job FAILURE,
+          # blocking renovate auto-merge for downstream consumers).
+          # Main keeps saving so every PR rebuild gets a warm cache.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo check --all-targets
 
   test:
@@ -39,6 +46,8 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # `cargo test --all-targets` covers lib / bins / tests / benches
       # / examples but EXCLUDES doc tests, so run --doc separately.
       # Doc-test step is gated on `src/lib.rs` presence: `cargo test
@@ -77,6 +86,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy --all-targets -- -D warnings
 
   lockfile:
@@ -89,6 +100,8 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo check --locked --all-targets
 
   coverage:
@@ -106,6 +119,8 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,5 +1,5 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-05-16T04:28:29.267137164Z"
+applied_at = "2026-05-17T04:41:09.156463694Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
@@ -8,7 +8,7 @@ version = "0.10.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust"
-rev = "247125a65701070f6bc9e124c4283bae9e902017"
+rev = "9f103ca5aaf39e1dcf1a4d84b11685821aabc62f"
 version = "0.5.0"
 
 [[templates]]
@@ -36,7 +36,7 @@ content_hash = "1a4b579b1b643a41dbf97d8834ff1f3f1fe532ff863d0f861431cf3ca47d31e2
 content_hash = "0796dfb281c7447610035360622ddada137a8e2d89efa574aea89374676d768b"
 
 [files.".github/workflows/ci.yml"]
-content_hash = "d4c0dd6f0e7c9a565a7d8f45763069386b19d38f88f878e0e4288fd60665a10d"
+content_hash = "741862d937397ea8fa0c02529cb4e7bc81266a8e628d317e590fa4687c2a3ec5"
 
 [files.".github/workflows/kata-apply.yml"]
 content_hash = "bc0e3def04b634949297d60322999a27f53bffc71b6cb662ae58ac8087e78bed"


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->