### PR TITLE
docs(readme): switch logo via <picture> for dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <p align="center">
-  <img src="assets/logo.svg" width="560" alt="yui — target-as-truth dotfiles manager" />
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.svg" />
+    <img src="assets/logo.svg" width="560" alt="yui — target-as-truth dotfiles manager" />
+  </picture>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.svg" />
-    <img src="assets/logo.svg" width="560" alt="yui — target-as-truth dotfiles manager" />
+    <img src="assets/logo.svg" width="560" alt="yui 結 — target-as-truth dotfiles manager" />
   </picture>
 </p>
 


### PR DESCRIPTION
## Summary
- The wordmark ("yui") and tagline rendered in near-black on GitHub's dark theme, making them essentially unreadable.
- Serve the existing `assets/logo-dark.svg` (with bright text) via `<picture>` + `prefers-color-scheme: dark`, while keeping `assets/logo.svg` for light mode.

## Test plan
- [ ] Open the README on GitHub in dark mode and confirm the logo text is legible.
- [ ] Open it in light mode and confirm the original rendering is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)