### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,5 +1,5 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-05-24T04:45:30.680660986Z"
+applied_at = "2026-05-28T04:47:01.776948175Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
@@ -13,8 +13,8 @@ version = "0.7.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust-cli"
-rev = "58fae0574cbf118e61312c7599c412bfd7d3d3ac"
-version = "0.2.0"
+rev = "3cc89e5f11c2a83dc4cd3c10a56c49306b444975"
+version = "0.3.0"
 
 [files.".agents/skills/renri/SKILL.md"]
 once_applied = true
@@ -55,7 +55,7 @@ content_hash = "4bebd1c3417c33f9d1c51f011694f6d82b098bbb1a5a102ba56e97ab01a866ef
 once_applied = true
 
 [files."AGENTS.md"]
-content_hash = "2a38543fca1f22128c41fe51c40159e8ea7f3331ae221fb99cddfca0194ece32"
+content_hash = "38c105d7b01a7034665facbb6840017db92b0d460e91a89edc5d2c86b6b7acad"
 
 [files."CLAUDE.md"]
 content_hash = "a76b3af252969b8120128d7ce44f2b6cfdcf88c7420ee00675732f542d047529"
@@ -80,6 +80,9 @@ once_applied = true
 
 [files."clippy.toml"]
 content_hash = "c750cb285075d0cb0c5c9ea77cd67baf7b0c4af864603cbe6c0c6692e75ed6fb"
+
+[files."examples/smoke.rs"]
+once_applied = true
 
 [files."opencode.json"]
 content_hash = "2ada1cf4347db9e98fadd67ca72cd9e29042c5bf6ab719d666b5d71f97663e81"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,4 +450,28 @@ The binary name is derived from the GitHub repo name at runtime
 identical across CLIs using these templates unless your `[[bin]] name` in
 `Cargo.toml` deliberately differs from the repo name — in that
 case override `BIN_NAME` in the workflow's `env:` block.
+
+### Release smoke target (`examples/smoke.rs`)
+
+After `cargo build --release`, `release.yml` runs
+`cargo run --release --target <T> --example smoke` on every build
+matrix entry. `cargo test` runs only library code, so the produced
+binary's startup path goes unverified — that's how shoka v0.10.0
+shipped a rustls `CryptoProvider` panic to crates.io even though
+all 13 CI checks were green.
+
+The template's default `examples/smoke.rs` body is intentionally
+no-op so kata can drop it into every consumer crate without
+breaking releases. **Override it per crate** with the smallest
+operation that exercises the regression-prone surface:
+
+- HTTPS-using CLIs: build the API client (octocrab, reqwest, etc.)
+  and issue a tiny no-auth GET — that forces the rustls handshake
+  to run inside the same binary the release publishes.
+- File-handling CLIs: write+read a temp file via the real I/O
+  helpers (catches missing crate features, permission regressions).
+- Pure library crates: leave as no-op.
+
+A failing smoke blocks the release before publishing to GitHub
+Releases / crates.io.
 <!-- kata:agents:rust-cli:end -->

--- a/examples/smoke.rs
+++ b/examples/smoke.rs
@@ -1,0 +1,33 @@
+//! `examples/smoke.rs` — release-time smoke target.
+//!
+//! `release.yml` runs `cargo run --release --target <T> --example smoke`
+//! on every build matrix entry. The intent is to catch regressions
+//! that `cargo test` misses — class signature: the lib tests pass on
+//! every runner, but the produced binary panics on real-world startup
+//! (e.g., rustls `CryptoProvider` not pre-installed before the first
+//! HTTPS handshake — shoka v0.10.0 shipped that exact bug).
+//!
+//! The default body is intentionally no-op so kata can drop this file
+//! into every consumer crate without breaking releases that haven't
+//! yet decided what to exercise. **Override this file** in each crate
+//! to call the real startup path that's most likely to regress:
+//!
+//! - HTTPS-using CLIs: build the actual API client (octocrab,
+//!   reqwest, etc.) and issue a tiny no-auth GET (e.g.,
+//!   `https://api.github.com/zen`) — that forces the rustls handshake
+//!   to run inside the same binary the release publishes.
+//! - File-handling CLIs: write+read a temp file via the real I/O
+//!   helpers (catches missing crate features, permission regressions).
+//! - Library-only crates: just exit 0; `cargo test` is sufficient.
+//!
+//! Cost: an extra ~5-second job step per platform per release.
+//! Payoff: when this fails, the release blocks before publishing to
+//! GitHub Releases / crates.io, instead of users finding the bug.
+
+fn main() {
+    eprintln!(
+        "smoke: no-op default — override examples/smoke.rs in this crate \
+         to exercise the startup path most likely to regress (HTTPS \
+         handshake, file I/O, etc.). See the file's module doc for ideas."
+    );
+}


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->