### PR TITLE
fix(updater): suppress banner when current version is already latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "kaishin"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c67a4da5995b60eac9904511d26cc49f03fd9b2103dce5c96d1d3313411bef"
+checksum = "337a1e0ca2d16f43e89e7f5009f4222401a3d2fcc365d11e10fd01e8e046f5c4"
 dependencies = [
  "anyhow",
  "console 0.16.3",
@@ -2484,9 +2484,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ indicatif = "0.18.4"
 jiff = { version = "0.2.27", features = ["serde"] }
 # Shared self-update library (`yui self-update`). Pinned exact to
 # match rvpm / renri; kaishin's surface is still 0.x.
-kaishin = "0.3.0"
+kaishin = "0.4.0"
 owo-colors = "4.3.0"
 same-file = "1.0.6"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -94,10 +94,12 @@ impl Checker {
         self.inner.should_check()
     }
 
-    /// Hit GitHub, write the result to the cache, and return it.
-    /// Block on an ad-hoc tokio runtime — the caller is on a
-    /// regular OS thread spawned by `std::thread::spawn`.
-    pub fn check_and_save(&self) -> Result<kaishin::LatestRelease> {
+    /// Hit GitHub, write the result to the cache, and return the
+    /// release *only when it actually outranks the running binary*.
+    /// `Ok(None)` is "fetched fine, no update"; `Err` is "fetch
+    /// failed". Block on an ad-hoc tokio runtime — the caller is on
+    /// a regular OS thread spawned by `std::thread::spawn`.
+    pub fn check_and_save(&self) -> Result<Option<kaishin::LatestRelease>> {
         let rt = make_runtime()?;
         rt.block_on(async { self.inner.check_and_save().await })
     }
@@ -126,9 +128,12 @@ pub enum AutoUpdateHandle {
     },
     /// A background check is running on a worker thread; the receiver
     /// hands the result back to the main thread at shutdown.
+    /// `Ok(Ok(None))` means "fetch succeeded, no update" — distinct
+    /// from a timeout/error case, where we may still want to fall back
+    /// to the cached release.
     Pending {
         checker: Checker,
-        rx: std::sync::mpsc::Receiver<Result<kaishin::LatestRelease>>,
+        rx: std::sync::mpsc::Receiver<Result<Option<kaishin::LatestRelease>>>,
         cached_latest: Option<kaishin::LatestRelease>,
     },
 }
@@ -196,10 +201,14 @@ pub fn maybe_spawn_auto_update_check(cli_source: Option<&Utf8Path>) -> Option<Au
 /// Print the update banner (if any) before the binary exits. Waits
 /// up to one second for an in-flight background check to finish; on
 /// timeout, falls back to the previously-cached release so the user
-/// still gets the nudge. Skips the leading newline when the banner
-/// would be empty (e.g. kaishin returning a release that doesn't
-/// actually outrank the running version). (PR #76 review by
-/// gemini-code-assist.)
+/// still gets the nudge.
+///
+/// kaishin 0.4 made `check_and_save` return `Result<Option<_>>`, so
+/// the "fetched, no update" case (`Ok(Ok(None))`) is now distinct
+/// from a timeout/error: in that case we skip the banner entirely
+/// instead of falling back to cache, since the cache can't be newer
+/// than the fresh fetch we just completed. Timeout/error still falls
+/// back to cache so a slow GitHub doesn't suppress the nudge.
 pub fn finalize_auto_update_check(handle: AutoUpdateHandle) {
     let (checker, latest) = match handle {
         AutoUpdateHandle::CachedAvailable { checker, latest } => (checker, Some(latest)),
@@ -208,19 +217,16 @@ pub fn finalize_auto_update_check(handle: AutoUpdateHandle) {
             rx,
             cached_latest,
         } => {
-            let latest = rx
-                .recv_timeout(Duration::from_secs(1))
-                .ok()
-                .and_then(|r| r.ok())
-                .or(cached_latest);
+            let latest = match rx.recv_timeout(Duration::from_secs(1)) {
+                Ok(Ok(Some(latest))) => Some(latest),
+                Ok(Ok(None)) => None,
+                _ => cached_latest,
+            };
             (checker, latest)
         }
     };
     if let Some(latest) = latest {
-        let banner = checker.format_banner(&latest);
-        if !banner.is_empty() {
-            eprintln!("\n{banner}");
-        }
+        eprintln!("\n{}", checker.format_banner(&latest));
     }
 }
 


### PR DESCRIPTION
## Summary

- Bug: the daily auto-update banner fired even when the running yui binary matched the latest GitHub release (e.g. `yui 0.7.20 available (current 0.7.20)`).
- Root cause was on the kaishin side; **kaishin 0.4.0** fixes the API by returning `Result<Option<LatestRelease>>` from `Checker::check_and_save`.
- This PR bumps yui to `kaishin = "0.4.0"` and adapts the consumer code.

## Why the banner fired

`Checker::check_and_save` (0.3.x) returned the latest GitHub release unconditionally, and `format_banner` always produced a non-empty string. yui's `if !banner.is_empty()` guard was defensive only — the banner was never actually empty, so it always fired after a successful background fetch.

## Migration to 0.4

- `Checker::check_and_save` now propagates the `Option<_>`.
- `AutoUpdateHandle::Pending::rx` carries `Result<Option<_>>`.
- `finalize_auto_update_check` distinguishes:
  - `Ok(Ok(Some(latest)))` → show banner.
  - `Ok(Ok(None))` → fetch succeeded, no update — skip banner outright (cache can't be newer than the fresh fetch).
  - timeout / error → fall back to cached release so a slow GitHub doesn't suppress a known-newer nudge.

Drops the now-redundant `if !banner.is_empty()` guard.

## Companion PRs

- kaishin: https://github.com/yukimemi/kaishin/pull/30 (merged → v0.4.0 on crates.io)
- renri / rvpm: separate PRs for the same migration

## Test plan
- [x] `cargo test --lib --locked` — 188/188 PASS against kaishin 0.4.0 from crates.io
- [x] `cargo check --locked` clean
- [ ] Smoke-test after merge: `yui secret encrypt …` no longer prints the bogus banner when on the latest version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)