### PR TITLE
chore: bump version to 0.7.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.7.20"
+version = "0.7.21"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."


### PR DESCRIPTION
Ships #105 (fix(updater): suppress banner when current version is already latest) and the kaishin 0.4.0 dep migration. CI green → auto-tag.yml → release.yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped from 0.7.20 to 0.7.21 (patch release).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yukimemi/yui/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->