### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,9 +1,9 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-05-31T04:51:06.88634843Z"
+applied_at = "2026-06-01T04:57:12.993876005Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "98a48d8489551fffcf08e71da8b85d00d5e74dfd"
+rev = "737d952eb9d23a8ef137be8c712983c08df1e89b"
 version = "0.12.1"
 
 [[templates]]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,11 +294,20 @@ commit-bound change. From the main checkout:
 ```sh
 renri add <branch-name>            # create a worktree (jj-first)
 renri --vcs git add <branch-name>  # force a git worktree
-renri remove <branch-name>         # cleanup after merge
+renri remove <branch-name> -y --non-interactive  # cleanup after merge (agent-safe; see note)
 renri prune                        # GC stale worktrees
 ```
 
 Read-only inspection can stay on the main checkout.
+
+**Agents / non-interactive shells:** `renri remove` prints a details
+panel and waits for a confirmation prompt — without `-y` it **hangs**,
+and `--non-interactive` *alone* errors asking for `-y`. Always pass
+`-y`, and add `--non-interactive` so a mistyped/omitted name fails
+instead of opening a fuzzy picker (the same picker-fallback applies to
+`remove` / `cd` / `exec` with no name). Use `-f`/`--force` to remove a
+worktree that still has uncommitted changes or conflicts. To sweep
+every merged-PR worktree in one shot: `renri remove --merged -y`.
 
 ### kata-managed sections
 


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->