### PR TITLE
chore(apm): refresh apm.lock.yaml

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,13 +1,13 @@
 lockfile_version: '1'
-generated_at: '2026-05-25T05:38:18.873151+00:00'
-apm_version: 0.14.2
+generated_at: '2026-06-01T05:43:55.784136+00:00'
+apm_version: 0.16.0
 dependencies:
 - repo_url: yukimemi/renri
   host: github.com
-  resolved_commit: 1e3f96e071ea49c3bd44bde5671016b60e6aa58f
+  resolved_commit: 1bc5976892f4200280b6227ca71deead6c40a574
   resolved_ref: main
   package_type: apm_package
   deployed_files:
   - .agents/skills/renri
   - .claude/skills/renri
-  content_hash: sha256:6ce0f29dbed6aa626474bcc73e035cf5a5304e2bd5010ac1e6056b54d87447a2
+  content_hash: sha256:8ac9660ed09c5fcc48e4855896466885f3c03b03c55763fda2df250819e2b065


### PR DESCRIPTION
Automated `apm install --update` (weekly schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base -->