### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,7 +4304,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.7.21"
+version = "0.8.0"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.7.21"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."


### PR DESCRIPTION
Release v0.8.0: version bump only (kaishin 0.5.0 background auto-update feature, already merged). Triggers auto-tag -> release.yml. Version-bump-only PR — skips the bot-review gate per AGENTS.md.