### PR TITLE
chore: release v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,7 +4304,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."


### PR DESCRIPTION
Version bump 0.8.0 → 0.8.1.

Ships the `cmd.rs` → `cmd/` per-subcommand refactor (#118, closes #70). Pure-refactor release — no user-facing behavior change.

Version-bump-only PR (`[package].version` + `Cargo.lock`), so per the repo's release convention it skips the bot-review gate: CI green + owner approval is enough. On merge, `auto-tag.yml` pushes `v0.8.1`, which fires `release.yml` (cross-platform binaries + crates.io publish).

https://claude.ai/code/session_016qDEgohrw1iZLo1kBJmRxr

---
_Generated by [Claude Code](https://claude.ai/code/session_016qDEgohrw1iZLo1kBJmRxr)_