### PR TITLE
fix(status): detect secret drift between .age and plaintext sibling

### DIFF
--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 
 /// `yui diff [--icons MODE] [--no-color]` — for every drifted entry
-/// (link or render), print a unified diff to stdout.
+/// (link, render, or secret), print a unified diff to stdout.
 ///
 /// Layered on top of the same drift detection `yui status` uses
 /// (`absorb::classify` + render dry-run), but actually emits the
@@ -74,6 +74,21 @@ pub fn diff(
         });
     }
 
+    // Secret drift too — same downgrade-to-warning semantics as
+    // cmd::status so a broken identity doesn't kill the diff.
+    match crate::secret::decrypt_all(&source, &config, /* dry_run */ true) {
+        Ok(secret_report) => {
+            for plaintext in &secret_report.diverged {
+                report.push(StatusItem {
+                    src: crate::secret::age_sibling(plaintext),
+                    dst: plaintext.clone(),
+                    state: StatusState::SecretDrift,
+                });
+            }
+        }
+        Err(e) => tracing::warn!("secret drift check skipped: {e}"),
+    }
+
     let mut printed = 0usize;
     for item in &report {
         if !diff_worth_printing(&item.state) {
@@ -112,12 +127,12 @@ pub fn diff(
 /// for table rendering. For `Link(_)` rows we have to re-absolutize
 /// before reading — otherwise the path resolves against the
 /// caller's cwd and we'd read an empty / wrong file. `RenderDrift`
-/// rows already carry an absolute `.tera` path (built from
-/// `render_report.diverged`, which the walker yields as absolute).
+/// and `SecretDrift` rows already carry an absolute path (built
+/// from the dry-run reports, which the walkers yield as absolute).
 /// (Caught in PR #53 review by coderabbitai.)
 pub(crate) fn resolve_diff_src(item: &StatusItem, source: &Utf8Path) -> Utf8PathBuf {
     match item.state {
-        StatusState::RenderDrift => item.src.clone(),
+        StatusState::RenderDrift | StatusState::SecretDrift => item.src.clone(),
         StatusState::Link(_) => source.join(&item.src),
     }
 }
@@ -130,6 +145,7 @@ pub(crate) fn diff_worth_printing(state: &StatusState) -> bool {
         StatusState::Link(RelinkOnly) => false, // content identical, only metadata drift
         StatusState::Link(_) => true,
         StatusState::RenderDrift => true,
+        StatusState::SecretDrift => true,
     }
 }
 
@@ -153,6 +169,7 @@ fn print_unified_diff(
 
     let header = match state {
         StatusState::RenderDrift => format!("--- render drift: {src} (template) vs {dst}"),
+        StatusState::SecretDrift => format!("--- secret drift: {src} (decrypted) vs {dst}"),
         _ => format!("--- {src} → {dst}"),
     };
     if color {
@@ -170,8 +187,25 @@ fn print_unified_diff(
     // Source side of the diff:
     //   - RenderDrift → re-render the .tera in memory (otherwise
     //     we'd surface raw Tera syntax as drift).
+    //   - SecretDrift → decrypt the .age in memory (diffing raw
+    //     ciphertext would be meaningless).
     //   - Link(_)     → read the source file from disk.
     let src_content = match state {
+        StatusState::SecretDrift => match crate::secret::decrypt_file(src, config) {
+            Ok(bytes) => match String::from_utf8(bytes) {
+                Ok(s) => s,
+                Err(_) => {
+                    println!("(binary secret — diff skipped)");
+                    println!();
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("(error decrypting {src}: {e})");
+                println!();
+                return;
+            }
+        },
         StatusState::RenderDrift => match render::render_to_string(src, source_root, config, yui) {
             Ok(Some(s)) => s,
             Ok(None) => {

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -20,7 +20,11 @@ use tracing::warn;
 /// and additionally surfaces any **render drift** — rendered files
 /// whose content has diverged from what the matching `.tera` template
 /// would produce now (i.e. the user edited the rendered file in place
-/// without reflecting the change back into the template).
+/// without reflecting the change back into the template) — and any
+/// **secret drift** — plaintext siblings that no longer match what
+/// their canonical `.age` decrypts to (i.e. the user edited the
+/// plaintext, usually through the target link, without re-encrypting
+/// via `yui secret encrypt`).
 ///
 /// Exits non-zero (via `anyhow::bail!`) when anything diverges, so
 /// `yui status && …` can gate workflows on a clean tree.
@@ -63,7 +67,29 @@ pub fn status(
         });
     }
 
-    // 2. Link drift — classify each src→dst pair under every mount.
+    // 2. Secret drift — decrypt every `.age` in dry-run mode and
+    //    surface plaintext siblings that no longer match the
+    //    ciphertext (the user edited the linked plaintext without
+    //    rolling it back via `yui secret encrypt`). Resilience
+    //    principle: status must keep working when apply would fail,
+    //    so a missing / unreadable identity downgrades to a warning
+    //    instead of bailing the whole report.
+    match crate::secret::decrypt_all(&source, &config, /* dry_run */ true) {
+        Ok(secret_report) => {
+            for plaintext in &secret_report.diverged {
+                // Show the `.age` as src — the canonical side the
+                // user re-encrypts into.
+                report.push(StatusItem {
+                    src: relative_for_display(&source, &crate::secret::age_sibling(plaintext)),
+                    dst: plaintext.clone(),
+                    state: StatusState::SecretDrift,
+                });
+            }
+        }
+        Err(e) => warn!("secret drift check skipped: {e}"),
+    }
+
+    // 3. Link drift — classify each src→dst pair under every mount.
     // Single nested-`.yuiignore` stack threaded across all mounts.
     // Seed the source-root layer so root rules apply from the start.
     let mut yuiignore = paths::YuiIgnoreStack::new();
@@ -125,6 +151,10 @@ pub(crate) enum StatusState {
     /// Rendered output diverges from current `.tera` template — user
     /// edited the rendered file directly without updating the template.
     RenderDrift,
+    /// Plaintext sibling diverges from the canonical `.age` — user
+    /// edited the decrypted file (usually through the target link)
+    /// without re-encrypting via `yui secret encrypt`.
+    SecretDrift,
 }
 
 impl StatusState {
@@ -353,6 +383,7 @@ fn state_label(s: StatusState) -> &'static str {
         StatusState::Link(NeedsConfirm) => "drift (anomaly)",
         StatusState::Link(Restore) => "missing",
         StatusState::RenderDrift => "render drift",
+        StatusState::SecretDrift => "secret drift",
     }
 }
 
@@ -365,6 +396,7 @@ fn state_icon(s: StatusState, icons: Icons) -> &'static str {
         StatusState::Link(NeedsConfirm) => icons.error,
         StatusState::Link(Restore) => icons.info,
         StatusState::RenderDrift => icons.error,
+        StatusState::SecretDrift => icons.error,
     }
 }
 
@@ -434,6 +466,7 @@ fn print_status_row(
         StatusState::Link(NeedsConfirm) => cell_state.red().to_string(),
         StatusState::Link(Restore) => cell_state.cyan().to_string(),
         StatusState::RenderDrift => cell_state.red().to_string(),
+        StatusState::SecretDrift => cell_state.red().to_string(),
     };
     let src_colored = cell_src.cyan().to_string();
     let arrow_colored = arrow.dimmed().to_string();

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -1369,6 +1369,107 @@ recipients = ["{}"]
     );
 }
 
+/// `yui status` surfaces secret drift. The plaintext sibling is
+/// hardlinked into target (forced via `[link] file_mode` so Unix
+/// runners don't fall back to symlink and dodge the scenario), so
+/// editing it keeps the link itself in-sync (same inode) — only
+/// the `.age` comparison can catch the divergence, which status
+/// used to skip entirely.
+#[test]
+fn status_reports_secret_drift() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("target"));
+    std::fs::create_dir_all(source.join("home")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+
+    let identity_path = utf8(tmp.path().join("age.txt"));
+    let (secret_key, public) = secret::generate_x25519_keypair();
+    std::fs::write(&identity_path, format!("{secret_key}\n")).unwrap();
+
+    let recipient = secret::parse_x25519_recipient(&public).unwrap();
+    let cipher = secret::encrypt_x25519(b"v1 content\n", &[recipient]).unwrap();
+    std::fs::write(source.join("home/secret.age"), &cipher).unwrap();
+
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+
+[link]
+file_mode = "hardlink"
+
+[secrets]
+identity = "{}"
+recipients = ["{}"]
+"#,
+        toml_path(&target),
+        toml_path(&identity_path),
+        public
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    // Clean apply: decrypts the sibling and links everything.
+    apply(Some(source.clone()), false).unwrap();
+    status(Some(source.clone()), None, true).unwrap();
+
+    // Edit through the target link — the hardlinked pair stays
+    // in-sync, but the plaintext now diverges from the .age.
+    std::fs::write(target.join("secret"), "edited locally\n").unwrap();
+
+    let err = status(Some(source.clone()), None, true).unwrap_err();
+    assert!(
+        format!("{err}").contains("diverged"),
+        "expected status to flag secret drift, got: {err}"
+    );
+}
+
+/// Resilience: a configured-but-broken `[secrets]` identity must
+/// not kill `yui status` — the secret check downgrades to a
+/// warning and the rest of the report still works.
+#[test]
+fn status_survives_unreadable_identity() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("target"));
+    std::fs::create_dir_all(source.join("home")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(source.join("home/.bashrc"), "echo hi\n").unwrap();
+
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+        toml_path(&target)
+    );
+    std::fs::write(source.join("config.toml"), &cfg).unwrap();
+    apply(Some(source.clone()), false).unwrap();
+
+    // Now enable secrets pointing at an identity that doesn't
+    // exist — apply would fail here, status must not.
+    let (_secret_key, public) = secret::generate_x25519_keypair();
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+
+[secrets]
+identity = "{}"
+recipients = ["{}"]
+"#,
+        toml_path(&target),
+        toml_path(&utf8(tmp.path().join("missing-identity.txt"))),
+        public
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    status(Some(source), None, true).unwrap();
+}
+
 // -- append_recipient_to_config (PR #57 review: toml_edit) --
 
 #[test]
@@ -1864,6 +1965,54 @@ fn diff_render_drift_uses_rendered_output_not_raw_template() {
     );
 }
 
+/// `yui diff` for a secret-drifted sibling must diff the
+/// **decrypted** `.age` content against the on-disk plaintext, not
+/// the raw ciphertext — the twin of the render-drift test above.
+/// Pins `secret::decrypt_file`, the helper `print_unified_diff`
+/// uses for the source side of `SecretDrift` rows.
+#[test]
+fn diff_secret_drift_uses_decrypted_content_not_ciphertext() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("target"));
+    std::fs::create_dir_all(source.join("home")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+
+    let identity_path = utf8(tmp.path().join("age.txt"));
+    let (secret_key, public) = secret::generate_x25519_keypair();
+    std::fs::write(&identity_path, format!("{secret_key}\n")).unwrap();
+    let recipient = secret::parse_x25519_recipient(&public).unwrap();
+    let cipher = secret::encrypt_x25519(b"plain v1\n", &[recipient]).unwrap();
+    let cipher_path = source.join("home/secret.age");
+    std::fs::write(&cipher_path, &cipher).unwrap();
+
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+
+[secrets]
+identity = "{}"
+recipients = ["{}"]
+"#,
+        toml_path(&target),
+        toml_path(&identity_path),
+        public
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    let yui = YuiVars::detect(&source);
+    let config = config::load(&source, &yui).unwrap();
+
+    // The on-disk bytes are armored ciphertext…
+    let on_disk = std::fs::read(&cipher_path).unwrap();
+    assert!(on_disk.starts_with(b"age-encryption.org/v1\n"));
+    // …but the diff's source side sees the decrypted plaintext.
+    let decrypted = secret::decrypt_file(&cipher_path, &config).unwrap();
+    assert_eq!(decrypted, b"plain v1\n");
+}
+
 /// Regression for the path-resolution bug coderabbitai flagged
 /// on PR #53: `StatusItem.src` is a *relative-for-display*
 /// path, so reading it directly during diff rendering would
@@ -1892,6 +2041,17 @@ fn resolve_diff_src_absolutizes_link_rows() {
         resolve_diff_src(&render_item, source),
         Utf8PathBuf::from("/dot/home/foo.tera"),
     );
+    // SecretDrift rows carry the absolute `.age` path, same as
+    // RenderDrift carries the absolute `.tera` path.
+    let secret_item = StatusItem {
+        src: Utf8PathBuf::from("/dot/home/secret.age"),
+        dst: Utf8PathBuf::from("/dot/home/secret"),
+        state: StatusState::SecretDrift,
+    };
+    assert_eq!(
+        resolve_diff_src(&secret_item, source),
+        Utf8PathBuf::from("/dot/home/secret.age"),
+    );
 }
 
 #[test]
@@ -1905,6 +2065,7 @@ fn diff_classifier_skips_uninteresting_states() {
     assert!(diff_worth_printing(&StatusState::Link(AutoAbsorb)));
     assert!(diff_worth_printing(&StatusState::Link(NeedsConfirm)));
     assert!(diff_worth_printing(&StatusState::RenderDrift));
+    assert!(diff_worth_printing(&StatusState::SecretDrift));
 }
 
 // -----------------------------------------------------------------

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -331,6 +331,24 @@ pub fn strip_age_suffix(path: &Utf8Path) -> Option<camino::Utf8PathBuf> {
     Some(parent.join(stem))
 }
 
+/// Inverse of [`strip_age_suffix`]: the canonical `.age` ciphertext
+/// path for a plaintext sibling. Used by `yui status` / `yui diff`
+/// to point the user at the file they'd re-encrypt into.
+pub fn age_sibling(plaintext: &Utf8Path) -> camino::Utf8PathBuf {
+    camino::Utf8PathBuf::from(format!("{plaintext}.age"))
+}
+
+/// Decrypt a single `*.age` file using the `[secrets]` identity
+/// from `config`. Used by `yui diff` to compute the expected
+/// plaintext of a drifted secret in memory (never written to disk).
+pub fn decrypt_file(cipher_path: &Utf8Path, config: &crate::config::Config) -> Result<Vec<u8>> {
+    let identity_path = crate::paths::expand_tilde(&config.secrets.identity);
+    let identity = load_x25519_identity(&identity_path)?;
+    let cipher_bytes = std::fs::read(cipher_path)
+        .map_err(|e| Error::Other(anyhow::anyhow!("read {cipher_path}: {e}")))?;
+    decrypt_x25519(&cipher_bytes, &identity)
+}
+
 /// Walk every `*.age` under `source`, decrypt to a sibling without
 /// the suffix, and report the plaintext paths so the caller can
 /// add them to the managed `.gitignore` section. Mirrors the
@@ -637,5 +655,13 @@ mod tests {
             None
         );
         assert_eq!(strip_age_suffix(Utf8PathBuf::from(".age").as_path()), None);
+    }
+
+    #[test]
+    fn age_sibling_round_trips_with_strip() {
+        let plain = Utf8PathBuf::from("home/.ssh/id_ed25519");
+        let cipher = age_sibling(&plain);
+        assert_eq!(cipher, Utf8PathBuf::from("home/.ssh/id_ed25519.age"));
+        assert_eq!(strip_age_suffix(&cipher), Some(plain));
     }
 }


### PR DESCRIPTION
## Problem

`yui status` reported "all in sync" even when a plaintext secret sibling (e.g. `private.ps1`) had been edited and no longer matched its canonical `.age` ciphertext.

Status only ran two checks — render drift and link drift. The plaintext sibling is hardlinked into target (same inode), so editing it through the target keeps the link classification `in-sync`; only a decrypt-and-compare against the `.age` can catch the divergence, and that walker (`secret::decrypt_all`) was only invoked by `yui apply`. The drift thus stayed invisible until the next apply bailed on it.

## Fix

- `yui status` now runs the secrets walker in dry-run mode and surfaces diverged plaintext siblings as a new `secret drift` state (red, error icon, counts toward the non-zero exit).
- `yui diff` gains the same check and prints a unified diff of decrypted-`.age` vs on-disk plaintext. Decryption happens in memory only — nothing is written.
- Resilience principle: a missing / unreadable `[secrets]` identity downgrades the check to a warning instead of failing the report, so `yui status` keeps working where `yui apply` would fail.

## Tests

- `status_reports_secret_drift` — clean apply, then edit through the target hardlink; status must flag it (fails before this change: hardlink keeps the pair in-sync, only the `.age` comparison catches it).
- `status_survives_unreadable_identity` — `[secrets]` configured with a nonexistent identity; status still succeeds.
- `age_sibling_round_trips_with_strip` — new path helper round-trips with `strip_age_suffix`.
- `diff_classifier_skips_uninteresting_states` extended with `SecretDrift`.

`cargo make check` green (fmt + clippy + 203 tests + lock check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)