### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,9 +1,9 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-06-05T04:49:16.522267832Z"
+applied_at = "2026-06-07T04:53:21.922686654Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "10af5d54488d0b70c5e7a49238724edf78190933"
+rev = "3e03ea70c4c70ea601e6ea5e1a273fe99122c0b8"
 version = "0.12.1"
 
 [[templates]]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,13 +292,23 @@ Use [`renri`](https://github.com/yukimemi/renri) for any
 commit-bound change. From the main checkout:
 
 ```sh
-renri add <branch-name>            # create a worktree (jj-first)
-renri --vcs git add <branch-name>  # force a git worktree
+renri add <branch-name> --from main@origin            # create a worktree (jj-first), off latest upstream main
+renri --vcs git add <branch-name> --from origin/main  # force a git worktree, off latest upstream main
 renri remove <branch-name> -y --non-interactive  # cleanup after merge (agent-safe; see note)
 renri prune                        # GC stale worktrees
 ```
 
 Read-only inspection can stay on the main checkout.
+
+**Always pass `--from <upstream main>`** (`main@origin` for jj,
+`origin/main` for git). Without it, `renri add` forks off the *cwd
+worktree's current HEAD* — in a long-lived main checkout that often
+lags upstream, so the PR later shows up CONFLICTING against a `main`
+that had already moved (e.g. a refactor merged upstream before the
+branch was cut), forcing a manual re-port of the whole change.
+`renri add` does fetch first, but fetching only updates `main@origin`
+— it never moves the checkout's HEAD, so an explicit `--from` is what
+guarantees a fresh base.
 
 **Agents / non-interactive shells:** `renri remove` prints a details
 panel and waits for a confirmation prompt — without `-y` it **hangs**,


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->