### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/apm-bump.yml
+++ b/.github/workflows/apm-bump.yml
@@ -78,6 +78,17 @@ jobs:
         # by Microsoft/apm. Same source the local-dev docs use
         # ("install via aka.ms/apm-unix or your platform's package
         # manager").
+        #
+        # GITHUB_TOKEN: the installer resolves apm's latest release
+        # via api.github.com, and an unauthenticated call shares the
+        # hosted runner IP's 60-req/hr quota with every other tenant
+        # — shoka's weekly run died on "API rate limit exceeded"
+        # (2026-06-01). The script honours GITHUB_APM_PAT >
+        # GITHUB_TOKEN > GH_TOKEN, so hand it the workflow's default
+        # token; no extra scopes needed for a public-repo release
+        # lookup.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           curl -fsSL https://aka.ms/apm-unix | sh

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,12 +1,23 @@
 name: claude-review
 
-# Automatic Claude Code review on every human-authored PR.
+# Automatic Claude Code review — one full pass per human-authored
+# PR, at open time (plus ready_for_review / reopened).
 #
 # Replaces the Gemini Code Assist free-tier PR review (free tier
 # discontinued upstream). Runs anthropics/claude-code-action in
 # agent mode: the workflow supplies a review prompt, Claude reads
 # the diff (and the repo's AGENTS.md conventions) and posts inline
 # comments plus a top-level summary.
+#
+# Cost model: `synchronize` is deliberately NOT in the trigger
+# list. Re-reviewing the full diff on every fix push doubled up
+# with the @claude responder (claude.yml), which already verifies
+# each fix when the author replies on the review thread with an
+# @-mention (the AGENTS.md "reply to reviewers" convention) — so
+# every fix used to cost a full review AND a focused re-check.
+# Now the cycle is: one full review at open, then cheap
+# mention-driven re-checks per fix. Need a fresh full pass after
+# a large rework? Comment `@claude please re-review the full PR`.
 #
 # Review-skip policy — mirrors the AGENTS.md "PR review cycle"
 # rules so the workflow and the docs agree on which PRs skip the
@@ -40,7 +51,7 @@ name: claude-review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened]
 
 permissions:
   contents: read
@@ -48,8 +59,9 @@ permissions:
   id-token: write
 
 concurrency:
-  # One review per PR at a time; a new push supersedes the
-  # in-flight review (reviewing a stale diff is wasted tokens).
+  # One review per PR at a time; a re-fire (reopen / ready)
+  # supersedes an in-flight run (reviewing a stale diff is wasted
+  # tokens).
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,9 +1,9 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-06-07T06:34:48.481603372Z"
+applied_at = "2026-06-08T04:56:19.715030702Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "54360f67db62bc84413c451e4eb86a7d91cbe0cb"
+rev = "643b647db5d718df3bc0555dd14ff34e69905773"
 version = "0.13.0"
 
 [[templates]]
@@ -33,7 +33,7 @@ content_hash = "486c974de88903113ed99b4e643432b7050e88f1031276f5263e8da7b43fe11e
 content_hash = "6d380d1ecc2f882c2011429d548a6f3c774b74f0c757d884453e4667172acc2a"
 
 [files.".github/workflows/apm-bump.yml"]
-content_hash = "c6a1bf2b903015298c5bd37d20126feb1029f35258e08caae1943523f1951343"
+content_hash = "d47d37312df1e5599d61b8a30a941b35e70df7ff98a93d7d746c45c7ad34a10a"
 
 [files.".github/workflows/auto-tag.yml"]
 content_hash = "5c5c9592fb47120e5278d77af38d38e0657e39841509f000a84561a0a62ea29f"
@@ -42,7 +42,7 @@ content_hash = "5c5c9592fb47120e5278d77af38d38e0657e39841509f000a84561a0a62ea29f
 content_hash = "7969eab018580d42ee36d5e1a295ef4ad3474604eaad6fb6190846fc6eed5e68"
 
 [files.".github/workflows/claude-review.yml"]
-content_hash = "e8e99a82d2ddb3e7a7e7daa4e26ad7a9a0627abdf99db6f79177d1a2fcfebbf4"
+content_hash = "44d6ba3debc255f2a448bb54904b9462e4a8e2271ce70aa70d0378fd49c22cfe"
 
 [files.".github/workflows/claude.yml"]
 content_hash = "13b455ea1b225e23c9c36906b88df3ad8b9601102593f231b38f4cba5432ef59"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,16 @@ here so each tool's auto-load behaviour still finds something.
   `chore/release-*`, `kata-apply/auto`, `apm-bump/auto`, and
   Renovate / Dependabot authors) — a missing Claude review on
   those PRs is expected, not a failure.
+- **The Claude full review fires once, at PR open** (plus
+  `ready_for_review` / `reopened`) — fix pushes do **not** re-trigger
+  it (`synchronize` is deliberately off the trigger list; a full
+  re-review per push doubled up with the mention-driven re-check
+  below and burned tokens for no extra signal). Verification of
+  fixes rides the `@claude` thread replies. After a large rework
+  that changes the PR's shape, request a fresh full pass
+  explicitly: `@claude please re-review the full PR`. CodeRabbit
+  still reviews pushes on its own cadence (its app config, not
+  this workflow).
 - **After opening a PR, immediately enter the review-monitoring
   loop — do not ask the user whether to start it.** Drive the
   cadence with `/loop` — fixed-interval mode (e.g.
@@ -271,9 +281,11 @@ here so each tool's auto-load behaviour still finds something.
   reviewers and cost the audit trail. Note `@claude` also
   triggers the interactive responder
   (`.github/workflows/claude.yml`, kata-managed) — it will
-  re-check the fix and reply on the thread; that re-check is the
-  point, but don't @-mention it for pure FYI notes that need no
-  verification.
+  re-check the fix and reply on the thread. Since fix pushes no
+  longer re-trigger the full review, this mention-driven re-check
+  is the **only** Claude-side verification of a fix — don't skip
+  it for substantive fixes; do skip it for pure FYI notes that
+  need no verification.
 - A review thread is **settled** the moment the latest bot reply
   is ack-only ("Thank you" / "Understood" / a re-review summary
   with no new findings) or 30 minutes elapse with no actionable


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->