### PR TITLE
chore(apm): refresh apm.lock.yaml

### DIFF
--- a/.agents/skills/renri/SKILL.md
+++ b/.agents/skills/renri/SKILL.md
@@ -66,6 +66,13 @@ renri remove fix/review-feedback   # or: renri prune (after main pulls)
   matches an existing branch / bookmark, attaches to it instead.
   **If `<name>` is omitted**, prompts interactively unless
   `--non-interactive` is set.
+  - `--from <ref>` forks the new branch off `<ref>` instead of the cwd
+    HEAD (commit / branch / bookmark / tag / revset). Pass the flag with
+    no value to pick from a fuzzy list of local refs. When `<ref>` names
+    a **remote-tracking** ref (`main@origin` for jj, `origin/main` for
+    git), `add` runs a `fetch` first so the worktree forks off the
+    current upstream tip rather than a stale locally-cached one. Pass
+    `--no-fetch` to skip that fetch (offline, or to pin the cached ref).
 - `renri list` (alias `ls`) — show all worktrees with name, path,
   branch, and flags.
 - `renri cd <name>` — print the absolute path of a worktree on stdout.

--- a/.claude/skills/renri/SKILL.md
+++ b/.claude/skills/renri/SKILL.md
@@ -66,6 +66,13 @@ renri remove fix/review-feedback   # or: renri prune (after main pulls)
   matches an existing branch / bookmark, attaches to it instead.
   **If `<name>` is omitted**, prompts interactively unless
   `--non-interactive` is set.
+  - `--from <ref>` forks the new branch off `<ref>` instead of the cwd
+    HEAD (commit / branch / bookmark / tag / revset). Pass the flag with
+    no value to pick from a fuzzy list of local refs. When `<ref>` names
+    a **remote-tracking** ref (`main@origin` for jj, `origin/main` for
+    git), `add` runs a `fetch` first so the worktree forks off the
+    current upstream tip rather than a stale locally-cached one. Pass
+    `--no-fetch` to skip that fetch (offline, or to pin the cached ref).
 - `renri list` (alias `ls`) — show all worktrees with name, path,
   branch, and flags.
 - `renri cd <name>` — print the absolute path of a worktree on stdout.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,13 +1,18 @@
 lockfile_version: '1'
-generated_at: '2026-06-08T05:41:19.380321+00:00'
-apm_version: 0.18.0
+generated_at: '2026-06-15T05:54:32.544578+00:00'
+apm_version: 0.20.0
 dependencies:
 - repo_url: yukimemi/renri
   host: github.com
-  resolved_commit: d9f7c890d4afdd8762ed03bcc5e96a93d15a5bdc
+  resolved_commit: ca6067fb582347ff9a681afcce02ff0fcb9abffb
   resolved_ref: main
   package_type: apm_package
   deployed_files:
   - .agents/skills/renri
+  - .agents/skills/renri/SKILL.md
   - .claude/skills/renri
-  content_hash: sha256:c49ccb7e02f09139adcde2be61f4bdd86871de150c7d37d2ca19608a97fbd9b2
+  - .claude/skills/renri/SKILL.md
+  deployed_file_hashes:
+    .agents/skills/renri/SKILL.md: sha256:b0ef8bb599b5dc116a39dc2d3712dd95c722974b91f109a26263052c8d1090d6
+    .claude/skills/renri/SKILL.md: sha256:b0ef8bb599b5dc116a39dc2d3712dd95c722974b91f109a26263052c8d1090d6
+  content_hash: sha256:a40e1701c7c10c631e309c6623c8263a209416567f53497bd372540478787381


### PR DESCRIPTION
Automated `apm install --update` (weekly schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base -->