### PR TITLE
docs: fix stale "no encryption" status in README + add secret/self-update commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ Need to absorb a single file regardless of policy? `yui absorb
 | `yui hooks list` | show configured `[[hook]]` entries + last-run state |
 | `yui hooks run [<name>] [--force]` | run hooks on demand (bypassing `when_run` with `--force`) |
 | `yui secret <init\|encrypt\|store\|unlock>` | manage `*.age` secrets + the X25519 identity — see [Secrets](#secrets-age--opt-in) |
-| `yui self-update [--check] [--yes]` | replace yui's own binary with the latest GitHub release (`--check` only reports) |
+| `yui self-update [--check] [--yes] [--non-interactive]` | replace yui's own binary with the latest GitHub release (`--check` only reports; `--non-interactive` + `--yes` drives it from scripts) |
 | `yui completion <shell>` | print shell completion (bash / zsh / fish / powershell / elvish) |
 
 `--icons` accepts `unicode` (default), `nerd` (Nerd-Font glyphs),

--- a/README.md
+++ b/README.md
@@ -441,6 +441,8 @@ Need to absorb a single file regardless of policy? `yui absorb
 | `yui gc-backup [--older-than DUR] [--dry-run]` | survey or prune `.yui/backup/` snapshots by suffix age |
 | `yui hooks list` | show configured `[[hook]]` entries + last-run state |
 | `yui hooks run [<name>] [--force]` | run hooks on demand (bypassing `when_run` with `--force`) |
+| `yui secret <init\|encrypt\|store\|unlock>` | manage `*.age` secrets + the X25519 identity — see [Secrets](#secrets-age--opt-in) |
+| `yui self-update [--check] [--yes]` | replace yui's own binary with the latest GitHub release (`--check` only reports) |
 | `yui completion <shell>` | print shell completion (bash / zsh / fish / powershell / elvish) |
 
 `--icons` accepts `unicode` (default), `nerd` (Nerd-Font glyphs),
@@ -477,8 +479,10 @@ one-time migration warning.
 
 Used in production for the author's own ~/dotfiles. Known gaps:
 
-- no built-in encryption (use `pass` / `1password-cli` from a Tera
-  template instead)
+- no `yui secret reencrypt` yet — rotating the recipient list means
+  running `yui secret encrypt --force <path>` per file for now
+- the vault item name (`yui-x25519-identity`) is hardcoded — no
+  per-repo override
 
 ## License
 


### PR DESCRIPTION
Follow-up to #138 — the README had the same secrets drift in its **Status** section, plus two shipped commands missing from the Commands table.

## Changes

1. **Stale "no built-in encryption" gap** — the `## Status` section still listed *"no built-in encryption (use `pass` / `1password-cli` from a Tera template instead)"* as a known gap, directly contradicting the whole **Secrets (`*.age`)** section above it. This is the same drift #138 removed from `AGENTS.md`. Replaced with the actual current gaps drawn from the README's own "planned"/"not yet" notes: no `yui secret reencrypt`, and the hardcoded vault item name.
2. **Commands table completeness** — added the two shipped top-level commands that were absent from the table:
   - `yui secret <init|encrypt|store|unlock>` (documented in the Secrets section but missing from the table)
   - `yui self-update` (referenced in the auto-update prose but missing from the table)

Cross-checked the rest of the README against `src/cli.rs` (full command set: `init/apply/render/link/unlink/status/list/absorb/doctor/gc-backup/hooks/update/unmanaged/diff/secret/self-update/completion`) — everything else is accurate.

## Verification

- Docs-only change; `self-update` flags (`--check` / `--yes`) verified against the `SelfUpdate` clap definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kqc3P65E5pPcjyEGPeVTAV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for `yui secret` and `yui self-update` CLI subcommands
  * Updated known limitations section with new secrets management gaps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->