### PR TITLE
refactor: migrate [vars]+Tera templating to teravars (ROADMAP step 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,15 +78,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,39 +373,6 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
 ]
 
 [[package]]
@@ -750,12 +708,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "difflib"
@@ -1279,15 +1231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "humantime"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,30 +1368,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1811,12 +1730,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "libredox"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,15 +1959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,86 +1973,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
-dependencies = [
- "pest",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.7",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
 
 [[package]]
 name = "pin-project"
@@ -3019,26 +2843,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slug"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "smallvec"
@@ -3152,24 +2960,24 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.20.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
+checksum = "38ea62bd58771b570262e11ffa274fa9eda9986bd886e6e3a1f7f42afef8024c"
 dependencies = [
- "chrono",
- "chrono-tz",
- "globwalk",
- "humansize",
- "lazy_static",
- "percent-encoding",
- "pest",
- "pest_derive",
- "rand 0.8.7",
- "regex",
  "serde",
- "serde_json",
- "slug",
- "unicode-segmentation",
+]
+
+[[package]]
+name = "teravars"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443fe898f5f3e6bd9d5d1dcfb0cd02f8e63fc26f9f407b922157c97a80e1a50d"
+dependencies = [
+ "serde",
+ "tera",
+ "thiserror 2.0.18",
+ "toml 1.1.3+spec-1.1.0",
+ "whoami",
 ]
 
 [[package]]
@@ -3524,12 +3332,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
 name = "unic-langid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3559,12 +3361,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -3887,63 +3683,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"
@@ -4135,7 +3878,7 @@ dependencies = [
  "sha2 0.11.0",
  "similar",
  "tempfile",
- "tera",
+ "teravars",
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.3+spec-1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"
 similar = "3.1.1"
-tera = "1.20.1"
+teravars = { version = "0.2.1", default-features = false }
 thiserror = "2.0.18"
 # Runtime needed by kaishin's async API. `run_self_update` drives it
 # from a blocking `current_thread` runtime so that path stays sync; the

--- a/src/cmd/absorb.rs
+++ b/src/cmd/absorb.rs
@@ -8,7 +8,7 @@ use crate::vars::YuiVars;
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use std::cell::Cell;
-use tera::Context as TeraContext;
+use teravars::Context as TeraContext;
 use tracing::{info, warn};
 
 /// Manually absorb a single target file back into source.

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -12,7 +12,7 @@ use crate::{absorb, backup, paths};
 use anyhow::{Context as _, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use std::cell::Cell;
-use tera::Context as TeraContext;
+use teravars::Context as TeraContext;
 use tracing::{info, warn};
 
 pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -9,7 +9,7 @@ use crate::vars::YuiVars;
 use crate::{absorb, paths};
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
-use tera::Context as TeraContext;
+use teravars::Context as TeraContext;
 use tracing::warn;
 
 /// Show every src→dst pair's drift state against the current host.

--- a/src/config.rs
+++ b/src/config.rs
@@ -658,7 +658,7 @@ fn resolve_vars_refs(
 fn render_strings_in_table(
     table: &mut toml::Table,
     engine: &mut template::Engine,
-    ctx: &tera::Context,
+    ctx: &teravars::Context,
     changed: &mut bool,
 ) -> Result<()> {
     for (_k, value) in table.iter_mut() {
@@ -670,7 +670,7 @@ fn render_strings_in_table(
 fn render_strings_in_value(
     value: &mut toml::Value,
     engine: &mut template::Engine,
-    ctx: &tera::Context,
+    ctx: &teravars::Context,
     changed: &mut bool,
 ) -> Result<()> {
     match value {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -30,7 +30,7 @@ use std::process::Command;
 use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use tera::Context as TeraContext;
+use teravars::Context as TeraContext;
 use tracing::info;
 
 use crate::config::{Config, HookConfig, HookPhase, WhenRun};

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -2,7 +2,7 @@
 //! Tera, evaluate `when`, drop disabled entries.
 
 use camino::{Utf8Path, Utf8PathBuf};
-use tera::Context;
+use teravars::Context;
 
 use crate::Result;
 use crate::config::{MountEntry, MountStrategy};

--- a/src/render.rs
+++ b/src/render.rs
@@ -24,7 +24,7 @@ use std::time::SystemTime;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use globset::{Glob, GlobSet, GlobSetBuilder};
-use tera::Context as TeraContext;
+use teravars::Context as TeraContext;
 
 use crate::config::{Config, RenderRule};
 use crate::paths;

--- a/src/template.rs
+++ b/src/template.rs
@@ -6,46 +6,34 @@
 //!   - `template_context` — `yui.*` + `vars.*` + `env(…)`. Used to render
 //!     `*.tera` dotfiles after the merged config is known.
 
-use std::collections::HashMap;
-
 use serde::Serialize;
-use tera::{Context, Tera, Value};
+use teravars::{Context, Engine as TeraEngine, Kwargs, State, TeraError, TeraResult, Value};
 
 use crate::Result;
 use crate::vars::YuiVars;
 
 pub struct Engine {
-    tera: Tera,
+    tera: TeraEngine,
 }
 
 impl Engine {
     pub fn new() -> Self {
-        let mut tera = Tera::default();
+        // `new_minimal` = bare Tera with no teravars helpers; yui registers only
+        // its own `env` (below), which differs from teravars' built-in `env` by
+        // returning an empty string — rather than erroring — for an unset var.
+        let mut tera = TeraEngine::new_minimal();
         tera.register_function("env", env_fn);
         Self { tera }
     }
 
     pub fn render(&mut self, src: &str, ctx: &Context) -> Result<String> {
+        // teravars::Engine::render already flattens Tera's nested error chain
+        // into its message (the reason — `variable '…' not found in context`,
+        // etc. — reaches the user), so no manual source-walk is needed here.
         self.tera
-            .render_str(src, ctx)
-            .map_err(|e| crate::Error::Template(format_tera_error(&e)))
+            .render(src, ctx)
+            .map_err(|e| crate::Error::Template(e.to_string()))
     }
-}
-
-/// Tera's `Display` impl only emits the top-level message
-/// (`Failed to render '__tera_one_off'`), leaving the actual reason
-/// (`variable 'vars.home_root' not found in context` etc.) buried in
-/// the source chain. Walk the chain and join every level so the user
-/// sees something they can act on.
-fn format_tera_error(err: &tera::Error) -> String {
-    use std::error::Error as _;
-    let mut parts: Vec<String> = vec![err.to_string()];
-    let mut src = err.source();
-    while let Some(e) = src {
-        parts.push(e.to_string());
-        src = e.source();
-    }
-    parts.join(": ")
 }
 
 impl Default for Engine {
@@ -57,15 +45,14 @@ impl Default for Engine {
 /// `env(name="VAR", default="…")` — read an env var, return `default` (or empty
 /// string) when unset. Returning a string (rather than null) keeps `default`
 /// arg simple; callers can also chain Tera's `default` filter.
-fn env_fn(args: &HashMap<String, Value>) -> tera::Result<Value> {
-    let name = args
-        .get("name")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| tera::Error::msg("env(name=…): missing or non-string 'name'"))?;
-    let default = args.get("default").cloned();
+fn env_fn(kwargs: Kwargs, _state: &State) -> TeraResult<Value> {
+    let name = kwargs
+        .get::<&str>("name")?
+        .ok_or_else(|| TeraError::message("env(name=…): missing or non-string 'name'"))?;
+    let default = kwargs.get::<Value>("default")?;
     match std::env::var(name) {
-        Ok(v) => Ok(Value::String(v)),
-        Err(_) => Ok(default.unwrap_or_else(|| Value::String(String::new()))),
+        Ok(v) => Ok(Value::from(v)),
+        Err(_) => Ok(default.unwrap_or_else(|| Value::from(""))),
     }
 }
 
@@ -164,6 +151,23 @@ mod tests {
             )
             .unwrap();
         assert_eq!(out, "fallback");
+    }
+
+    #[test]
+    fn env_function_unset_without_default_is_empty() {
+        // The load-bearing reason yui keeps a custom `env` instead of teravars'
+        // built-in (which errors on an unset var): no `default` + unset must
+        // render to an empty string, so cross-platform configs referencing a
+        // var that only exists on another OS — e.g. `env(name='LOCALAPPDATA')`
+        // on Linux — don't fail the whole render.
+        // SAFETY: single-threaded test, no other env access in this case.
+        unsafe { std::env::remove_var("YUI_TEST_UNSET_NO_DEFAULT") };
+        let mut e = Engine::new();
+        let ctx = config_context(&vars());
+        let out = e
+            .render("[{{ env(name='YUI_TEST_UNSET_NO_DEFAULT') }}]", &ctx)
+            .unwrap();
+        assert_eq!(out, "[]");
     }
 
     #[test]


### PR DESCRIPTION
Replaces yui's direct **tera 1.x** dependency with the shared [teravars](https://github.com/yukimemi/teravars) **0.2.1** layer (ROADMAP step 1 — see teravars#53), bringing **tera 2.0** transitively. teravars' design was extracted from yui, so this is largely swapping yui's local copy for the shared one.

## Changes

- **`src/template.rs`**: `Engine` now wraps `teravars::Engine::new_minimal()` and registers yui's own `env` helper — rewritten to tera 2.0's `Fn(Kwargs, &State) -> TeraResult<Value>` signature — **preserving the empty-string-when-unset behavior** (teravars' built-in `env` *errors* instead, which would break cross-platform configs like `env(name='LOCALAPPDATA')` on Linux). Uses the newly re-exported `Kwargs` / `State` / `Value` / `TeraResult` / `TeraError` from teravars 0.2.1 (teravars#54), so **no direct `tera` dependency**. `format_tera_error` is dropped — `teravars::Engine::render` already flattens the Tera error chain into its message.
- **Type-alias sweep**: `use tera::Context` → `use teravars::Context` across `render.rs`, `hook.rs`, `mount.rs`, `config.rs`, `cmd/{absorb,apply,status}.rs`. No logic change.
- **`Cargo.toml`**: `tera 1.20.1` → `teravars = { version = "0.2.1", default-features = false }` (yui registers its own `env` and keeps its own merge, so it needs neither `std-helpers` nor `merge`).

## Kept yui-side (minimal delegation)

- The **`yui.*`** context namespace (`YuiVars`), *not* teravars' `system.*` — every `{# yui:when yui.os … #}` / `{{ yui.source }}` keeps working.
- yui's own `pre_extract_vars` / `resolve_vars_refs` (tolerant of non-convergent cycles) / `deep_merge_table` / `list_config_files` and the config-load `script_*` self-ref seeding.

## Verification

200 tests pass (incl. the `script_path` undefined-error and `env` default tests); `cargo make check` green (fmt + clippy `-D warnings` + test + lock-check). Cargo.lock shrinks (tera 2.0 lighter tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template rendering reliability and error handling.
  * Environment-variable templates now consistently return configured values, specified defaults, or an empty value when unavailable.
* **Enhancements**
  * Reduced template engine overhead by using a streamlined rendering configuration.
  * Maintained compatibility across command workflows, configuration rendering, hooks, mounts, and status output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->