### PR TITLE
chore(release): v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."


### PR DESCRIPTION
Version bump only (`Cargo.toml` + `Cargo.lock`), 0.9.0 → 0.9.1. On merge, `auto-tag.yml` pushes `v0.9.1` and `release.yml` builds binaries + publishes to crates.io.

## Included since v0.9.0

- **refactor:** migrate `[vars]` + Tera templating to [teravars](https://github.com/yukimemi/teravars), dropping the direct **tera 1.x** dependency for **teravars 0.2.1 / tera 2.0** (#160)

## Patch bump rationale

Internal engine swap only — `template.rs`'s `Engine` now wraps `teravars::Engine`, with yui's own `env` helper preserved (empty-string on unset) and the `yui.*` namespace + vars/merge logic untouched. No config-syntax or behaviour change, so this is a patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)