### PR TITLE
feat(mount): honor .gitignore when walking the source tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,37 @@ shallower ones, `!negation` re-includes paths, and rules apply only to
 the subtree below the file. Put repo-wide rules at `$DOTFILES/.yuiignore`
 and per-tree rules where they belong.
 
+### `.gitignore` is honored too
+
+Because yui is target-as-truth, your source tree *is* the live config —
+so apps write runtime state (session logs, caches, credentials) straight
+into it through the links. That state is already excluded from git, and
+by default yui excludes it as well: every directory's `.gitignore` is
+layered underneath its `.yuiignore` during the walk.
+
+Without this, a tool that keeps a few hundred session files under
+`~/.some-app/` would mint a hardlink per file and bury `yui status` in
+noise it can do nothing about.
+
+Two things to know:
+
+- **`.yuiignore` wins.** It's checked first in each directory, so
+  `!home/keep.log` re-includes a file that the sibling `.gitignore`
+  excluded — the escape hatch for "git shouldn't track this, but yui
+  should still link it".
+- **yui's own generated files are exempt.** Rendered `.tera` output and
+  decrypted `.age` plaintext are listed in the auto-managed block of
+  `$DOTFILES/.gitignore` precisely *because* yui generates them. Lines
+  between the `# >>> yui rendered … >>>` markers are skipped, so this
+  can never stop apply from linking a file it just produced.
+
+Opt out to restore `.yuiignore`-only walking:
+
+```toml
+[mount]
+respect_gitignore = false
+```
+
 ## Secrets (`*.age` — opt-in)
 
 Files ending in `.age` are encrypted with [age]; on every `apply` the

--- a/src/cmd/absorb.rs
+++ b/src/cmd/absorb.rs
@@ -221,11 +221,24 @@ fn find_source_for_target(
         if let Ok(rel) = target.strip_prefix(&dst_root) {
             let src_str = engine.render(entry.src.as_str(), tera_ctx)?;
             let candidate = paths::resolve_mount_src(source, src_str.trim()).join(rel);
-            // Honor `.yuiignore` even on manual absorb — if you've
-            // ignored a path, you've explicitly opted out of yui's
-            // managing it. One-shot stack walk along the candidate's
-            // parents picks up nested `.yuiignore` files too.
-            if paths::is_ignored_at(source, &candidate, candidate.is_dir())? {
+            // Honor the ignore rules even on manual absorb — if
+            // you've ignored a path, you've explicitly opted out of
+            // yui's managing it. One-shot stack walk along the
+            // candidate's parents picks up nested ignore files too.
+            //
+            // `is_dir` comes from `target`, not `candidate`: absorbing
+            // something that doesn't exist in source yet is the normal
+            // case, and a non-existent `candidate.is_dir()` is always
+            // false — which would silently skip every directory-only
+            // pattern (`sessions/`, `cache/`) and absorb the very trees
+            // the ignore rules exclude. `target` is the thing being
+            // absorbed, so it's the authority on directory-ness.
+            if paths::is_ignored_at(
+                source,
+                &candidate,
+                target.is_dir(),
+                config.mount.respect_gitignore,
+            )? {
                 continue;
             }
             return Ok(Some(candidate));

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -111,10 +111,10 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
         info!("dry-run: nothing will be written");
     }
 
-    // Nested `.yuiignore` stack — push on dir entry, pop on exit.
-    // Seed with the source-root layer so root-level rules apply from
-    // the start without `walk_and_link` having to special-case it.
-    let mut yuiignore = paths::YuiIgnoreStack::new();
+    // Nested ignore stack — push on dir entry, pop on exit. Seed
+    // with the source-root layer so root-level rules apply from the
+    // start without `walk_and_link` having to special-case it.
+    let mut yuiignore = paths::YuiIgnoreStack::with_gitignore(config.mount.respect_gitignore);
     yuiignore.push_dir(&source)?;
     let walk_result = (|| -> Result<()> {
         for m in &mounts {

--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -39,7 +39,7 @@ pub fn diff(
 
     // Reuse classify_walk to enumerate every src→dst pair.
     let mut report: Vec<StatusItem> = Vec::new();
-    let mut yuiignore = paths::YuiIgnoreStack::new();
+    let mut yuiignore = paths::YuiIgnoreStack::with_gitignore(config.mount.respect_gitignore);
     yuiignore.push_dir(&source)?;
     let walk_result = (|| -> Result<()> {
         for m in &mounts {

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -90,9 +90,9 @@ pub fn status(
     }
 
     // 3. Link drift — classify each src→dst pair under every mount.
-    // Single nested-`.yuiignore` stack threaded across all mounts.
-    // Seed the source-root layer so root rules apply from the start.
-    let mut yuiignore = paths::YuiIgnoreStack::new();
+    // Single nested ignore stack threaded across all mounts. Seed the
+    // source-root layer so root rules apply from the start.
+    let mut yuiignore = paths::YuiIgnoreStack::with_gitignore(config.mount.respect_gitignore);
     yuiignore.push_dir(&source)?;
     let walk_result = (|| -> Result<()> {
         for m in &mounts {

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -1148,6 +1148,42 @@ dst = "{}"
     );
 }
 
+/// A directory-only ignore rule (`sessions/`) must still bite on
+/// manual absorb when the directory exists in *target* but not yet in
+/// source — which is the normal manual-absorb case. Asking the
+/// non-existent source candidate whether it's a directory always
+/// answers "no", so the pattern would be skipped and yui would absorb
+/// the very tree the rule excludes. (Caught in PR #181 review by
+/// gemini-code-assist.)
+#[test]
+fn manual_absorb_honors_dir_only_gitignore_for_target_only_dir() {
+    let tmp = TempDir::new().unwrap();
+    let (source, target) = setup_minimal_dotfiles(&tmp);
+    std::fs::write(source.join(".gitignore"), "sessions/\n").unwrap();
+
+    // Exists in target, absent from source — `candidate.is_dir()`
+    // would be false here.
+    std::fs::create_dir_all(target.join("sessions")).unwrap();
+    std::fs::write(target.join("sessions/a.log"), "runtime junk").unwrap();
+
+    let err = absorb(
+        Some(source.clone()),
+        target.join("sessions"),
+        /* dry_run */ false,
+        /* yes */ true,
+    )
+    .unwrap_err();
+
+    assert!(
+        format!("{err}").contains("no mount entry"),
+        "dir-only gitignore rule should disqualify the candidate: {err}"
+    );
+    assert!(
+        !source.join("home/sessions").exists(),
+        "gitignored dir must not be absorbed into source"
+    );
+}
+
 #[test]
 fn manual_absorb_errors_when_target_outside_known_mounts() {
     let tmp = TempDir::new().unwrap();
@@ -1205,6 +1241,118 @@ fn yuiignore_negation_re_includes_file() {
     apply(Some(source.clone()), false).unwrap();
     assert!(target.join("keep.cache").exists());
     assert!(!target.join("drop.cache").exists());
+}
+
+/// Apps write runtime state (session logs, caches) straight into the
+/// source tree through the links; `.gitignore` already excludes it,
+/// so yui shouldn't be minting hardlinks for it or listing it in
+/// `status`. On by default via `mount.respect_gitignore`.
+#[test]
+fn gitignore_excludes_file_from_linking_by_default() {
+    let tmp = TempDir::new().unwrap();
+    let (source, target) = setup_minimal_dotfiles(&tmp);
+    std::fs::create_dir_all(source.join("home/app/sessions")).unwrap();
+    std::fs::write(source.join("home/app/config.toml"), "kept").unwrap();
+    std::fs::write(source.join("home/app/sessions/a.log"), "runtime junk").unwrap();
+    // The app's own .gitignore, nested — scoped to its subtree.
+    std::fs::write(source.join("home/app/.gitignore"), "sessions/\n").unwrap();
+
+    apply(Some(source.clone()), false).unwrap();
+
+    assert!(target.join("app/config.toml").exists());
+    assert!(
+        !target.join("app/sessions").exists(),
+        "gitignored subtree should not be linked into target"
+    );
+}
+
+/// Opt-out: `respect_gitignore = false` restores the earlier
+/// behaviour of walking `.yuiignore` only.
+#[test]
+fn gitignore_opt_out_restores_linking() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("target"));
+    std::fs::create_dir_all(source.join("home")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(
+        source.join("config.toml"),
+        format!(
+            r#"
+[mount]
+respect_gitignore = false
+
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+            toml_path(&target)
+        ),
+    )
+    .unwrap();
+    std::fs::write(source.join("home/runtime.log"), "junk").unwrap();
+    std::fs::write(source.join(".gitignore"), "*.log\n").unwrap();
+
+    apply(Some(source.clone()), false).unwrap();
+
+    assert!(
+        target.join("runtime.log").exists(),
+        "respect_gitignore=false must ignore .gitignore entirely"
+    );
+}
+
+/// The regression that makes `respect_gitignore` safe to default on:
+/// yui writes its *own* generated files (rendered `.tera` output,
+/// decrypted `.age` plaintext) into the managed `.gitignore` block,
+/// precisely because they're generated. Honouring those lines would
+/// make apply refuse to link the very files it just produced, so
+/// everything between the markers is stripped before matching.
+#[test]
+fn managed_gitignore_section_never_blocks_linking() {
+    let tmp = TempDir::new().unwrap();
+    let (source, target) = setup_minimal_dotfiles(&tmp);
+    std::fs::write(source.join("home/.gitconfig.tera"), "name = {{ yui.os }}\n").unwrap();
+    std::fs::write(source.join("home/user.log"), "runtime junk").unwrap();
+    // A user rule, in place before the first apply so it gets a fair
+    // shot at `user.log`; apply appends its managed block below it.
+    std::fs::write(source.join(".gitignore"), "*.log\n").unwrap();
+
+    apply(Some(source.clone()), false).unwrap();
+
+    let gi = std::fs::read_to_string(source.join(".gitignore")).unwrap();
+    assert!(
+        gi.contains("home/.gitconfig"),
+        "managed section should list the rendered output: {gi}"
+    );
+    assert!(
+        target.join(".gitconfig").exists(),
+        "rendered output is gitignored by yui itself but must stay linked"
+    );
+    assert!(
+        !target.join("user.log").exists(),
+        "user rules outside the managed block still apply"
+    );
+}
+
+/// `.yuiignore` sits above `.gitignore` in the same directory, so a
+/// negation there can re-include something git excludes — the escape
+/// hatch for "git shouldn't track this, but yui should link it".
+#[test]
+fn yuiignore_negation_overrides_sibling_gitignore() {
+    let tmp = TempDir::new().unwrap();
+    let (source, target) = setup_minimal_dotfiles(&tmp);
+    std::fs::write(source.join("home/keep.log"), "wanted").unwrap();
+    std::fs::write(source.join("home/drop.log"), "junk").unwrap();
+    std::fs::write(source.join(".gitignore"), "*.log\n").unwrap();
+    std::fs::write(source.join(".yuiignore"), "!home/keep.log\n").unwrap();
+
+    apply(Some(source.clone()), false).unwrap();
+
+    assert!(
+        target.join("keep.log").exists(),
+        ".yuiignore negation should win over the sibling .gitignore"
+    );
+    assert!(!target.join("drop.log").exists());
 }
 
 /// Issue #47: a `.yuiignore` placed in a nested subdirectory must

--- a/src/config.rs
+++ b/src/config.rs
@@ -278,6 +278,13 @@ pub struct MountConfig {
     pub default_strategy: MountStrategy,
     #[serde(default = "default_marker_filename")]
     pub marker_filename: String,
+    /// Treat each directory's `.gitignore` as an ignore layer under
+    /// `.yuiignore` when walking the source tree. On by default: the
+    /// source *is* a git repo, so anything git already excludes is
+    /// runtime state rather than a dotfile worth linking. Yui's own
+    /// managed section is exempt — see `paths::YuiIgnoreStack`.
+    #[serde(default = "default_true")]
+    pub respect_gitignore: bool,
     #[serde(default)]
     pub entry: Vec<MountEntry>,
 }
@@ -287,6 +294,7 @@ impl Default for MountConfig {
         Self {
             default_strategy: MountStrategy::default(),
             marker_filename: default_marker_filename(),
+            respect_gitignore: true,
             entry: Vec::new(),
         }
     }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -84,7 +84,7 @@ pub fn resolve_mount_src_with(
     source.join(expanded)
 }
 
-/// One-shot `.yuiignore` test for a single path under `source`.
+/// One-shot ignore test for a single path under `source`.
 ///
 /// Builds a fresh `YuiIgnoreStack`, pushes every directory between
 /// `source` and `path.parent()` (so a deeply-nested `.yuiignore`
@@ -92,6 +92,10 @@ pub fn resolve_mount_src_with(
 /// single candidate path to check (e.g. manual `absorb`'s
 /// mount-derived candidate); for recursive walks, push/pop on the
 /// hot path with a single long-lived `YuiIgnoreStack` instead.
+///
+/// `respect_gitignore` layers `.gitignore` under `.yuiignore` — see
+/// [`YuiIgnoreStack::with_gitignore`] for the rationale and for how
+/// yui's own managed section is exempted.
 ///
 /// Patterns use full gitignore syntax: glob (`*`, `**`), negation
 /// (`!`), trailing-slash dir-only matching, comments (`#`). Paths
@@ -104,11 +108,16 @@ pub fn resolve_mount_src_with(
 /// Honouring inner whitelists here would let manual `absorb` pick a
 /// path that apply / status would never have linked. (Caught in PR
 /// #50 review.)
-pub fn is_ignored_at(source: &Utf8Path, path: &Utf8Path, is_dir: bool) -> crate::Result<bool> {
+pub fn is_ignored_at(
+    source: &Utf8Path,
+    path: &Utf8Path,
+    is_dir: bool,
+    respect_gitignore: bool,
+) -> crate::Result<bool> {
     let Ok(rel) = path.strip_prefix(source) else {
         return Ok(false);
     };
-    let mut stack = YuiIgnoreStack::new();
+    let mut stack = YuiIgnoreStack::with_gitignore(respect_gitignore);
     stack.push_dir(source)?;
     let mut cur = source.to_owned();
     for component in rel.components() {
@@ -155,9 +164,9 @@ pub fn source_walker(source: &Utf8Path) -> ignore::WalkBuilder {
     b
 }
 
-/// Stack of `.yuiignore` matchers for manual recursive walks. Each
-/// frame remembers the directory it was loaded from + the parsed
-/// matcher; testing a path walks innermost → outermost so a deeper
+/// Stack of ignore matchers for manual recursive walks. Each frame
+/// remembers the directory it was loaded from + that directory's
+/// matchers; testing a path walks innermost → outermost so a deeper
 /// `.yuiignore` overrides a shallower one (gitignore semantics).
 ///
 /// Walkers `push_dir(d)` before iterating `d`'s entries and
@@ -166,29 +175,63 @@ pub fn source_walker(source: &Utf8Path) -> ignore::WalkBuilder {
 /// the stack stays consistent across recursion.
 #[derive(Debug, Default)]
 pub struct YuiIgnoreStack {
-    layers: Vec<(Utf8PathBuf, ignore::gitignore::Gitignore)>,
+    /// Matchers for one directory, ordered most-specific-first:
+    /// `.yuiignore` before `.gitignore`, so a `.yuiignore` rule can
+    /// re-include (`!foo`) something the sibling `.gitignore` excluded.
+    layers: Vec<(Utf8PathBuf, Vec<ignore::gitignore::Gitignore>)>,
+    respect_gitignore: bool,
 }
 
 impl YuiIgnoreStack {
+    /// Stack that honours `.yuiignore` only.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Load `.yuiignore` from `dir` (if present) and push its rules
-    /// as a new layer. No-op when the file is absent.
+    /// Stack that additionally honours each directory's `.gitignore`
+    /// when `respect_gitignore` is set.
+    ///
+    /// Rationale: yui is target-as-truth, so the source tree *is* a
+    /// git repo and apps write runtime state (session logs, caches,
+    /// credentials) straight into it through the links. Those files
+    /// are already excluded from git; treating them as managed
+    /// link candidates only buys per-file hardlinks nobody wants and
+    /// a `yui status` drowned in noise.
+    ///
+    /// **Yui's own managed section is exempt.** `render.rs` lists
+    /// every rendered `.tera` output and decrypted `.age` plaintext
+    /// between the `# >>> yui rendered (auto-managed…) >>>` markers
+    /// — those files are gitignored precisely *because* yui
+    /// generates them, and they must still be linked. Lines inside
+    /// the markers are dropped before the matcher is built, so
+    /// enabling this can never stop apply from linking a generated
+    /// file.
+    pub fn with_gitignore(respect_gitignore: bool) -> Self {
+        Self {
+            layers: Vec::new(),
+            respect_gitignore,
+        }
+    }
+
+    /// Load `dir`'s ignore files (if present) and push them as one
+    /// layer. No-op when the directory has none.
     pub fn push_dir(&mut self, dir: &Utf8Path) -> crate::Result<()> {
-        let path = dir.join(".yuiignore");
-        if !path.is_file() {
-            return Ok(());
+        let mut matchers = Vec::new();
+        if let Some(gi) =
+            build_matcher(dir, &dir.join(".yuiignore"), /* strip_managed */ false)?
+        {
+            matchers.push(gi);
         }
-        let mut builder = ignore::gitignore::GitignoreBuilder::new(dir);
-        if let Some(e) = builder.add(path.as_std_path()) {
-            return Err(crate::Error::Config(format!("parsing {path}: {e}")));
+        if self.respect_gitignore {
+            if let Some(gi) =
+                build_matcher(dir, &dir.join(".gitignore"), /* strip_managed */ true)?
+            {
+                matchers.push(gi);
+            }
         }
-        let gi = builder
-            .build()
-            .map_err(|e| crate::Error::Config(format!("building {path}: {e}")))?;
-        self.layers.push((dir.to_owned(), gi));
+        if !matchers.is_empty() {
+            self.layers.push((dir.to_owned(), matchers));
+        }
         Ok(())
     }
 
@@ -202,22 +245,72 @@ impl YuiIgnoreStack {
     }
 
     /// Decide whether `path` should be ignored. Walks frames inside
-    /// → outside; the first decisive match (Ignore or Whitelist)
+    /// → outside (and within a frame, `.yuiignore` before
+    /// `.gitignore`); the first decisive match (Ignore or Whitelist)
     /// wins, so a deeper `.yuiignore` can both exclude *and*
     /// re-include paths the parent missed.
     pub fn is_ignored(&self, path: &Utf8Path, is_dir: bool) -> bool {
-        for (anchor, gi) in self.layers.iter().rev() {
+        for (anchor, matchers) in self.layers.iter().rev() {
             let Ok(rel) = path.strip_prefix(anchor) else {
                 continue;
             };
-            match gi.matched_path_or_any_parents(rel.as_std_path(), is_dir) {
-                ignore::Match::Ignore(_) => return true,
-                ignore::Match::Whitelist(_) => return false,
-                ignore::Match::None => continue,
+            for gi in matchers {
+                match gi.matched_path_or_any_parents(rel.as_std_path(), is_dir) {
+                    ignore::Match::Ignore(_) => return true,
+                    ignore::Match::Whitelist(_) => return false,
+                    ignore::Match::None => continue,
+                }
             }
         }
         false
     }
+}
+
+/// Parse one ignore file into a matcher anchored at `dir`, or `None`
+/// when the file doesn't exist.
+///
+/// `strip_managed` drops the lines yui itself wrote between the
+/// `.gitignore` managed-section markers — see
+/// [`YuiIgnoreStack::with_gitignore`]. Because that filtering happens
+/// line-by-line we feed the builder via `add_line` rather than
+/// `add`, which is also why blank lines and comments are passed
+/// straight through (the builder skips them itself).
+fn build_matcher(
+    dir: &Utf8Path,
+    path: &Utf8Path,
+    strip_managed: bool,
+) -> crate::Result<Option<ignore::gitignore::Gitignore>> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let text = std::fs::read_to_string(path.as_std_path())
+        .map_err(|e| crate::Error::Config(format!("reading {path}: {e}")))?;
+
+    let mut builder = ignore::gitignore::GitignoreBuilder::new(dir);
+    let mut in_managed = false;
+    for line in text.lines() {
+        if strip_managed {
+            let trimmed = line.trim();
+            if trimmed == crate::render::GITIGNORE_BEGIN {
+                in_managed = true;
+                continue;
+            }
+            if trimmed == crate::render::GITIGNORE_END {
+                in_managed = false;
+                continue;
+            }
+            if in_managed {
+                continue;
+            }
+        }
+        builder
+            .add_line(Some(path.as_std_path().to_owned()), line)
+            .map_err(|e| crate::Error::Config(format!("parsing {path}: {e}")))?;
+    }
+    let gi = builder
+        .build()
+        .map_err(|e| crate::Error::Config(format!("building {path}: {e}")))?;
+    Ok(Some(gi))
 }
 
 /// Mirror an absolute target path into a backup directory, dropping the drive
@@ -475,7 +568,7 @@ mod tests {
         std::fs::write(keepers.join(".yuiignore"), "!wanted.lock\n").unwrap();
         // The walkers never descend into keepers/, so manual absorb
         // must agree the file is ignored.
-        assert!(is_ignored_at(&root, &keepers.join("wanted.lock"), false).unwrap());
+        assert!(is_ignored_at(&root, &keepers.join("wanted.lock"), false, false).unwrap());
     }
 
     #[test]
@@ -487,12 +580,42 @@ mod tests {
         std::fs::create_dir_all(&leaf).unwrap();
         std::fs::write(mid.join(".yuiignore"), "secret*\n").unwrap();
         // mid/.yuiignore must be picked up when checking leaf/secret.txt
-        assert!(is_ignored_at(&root, &leaf.join("secret.txt"), false).unwrap());
-        assert!(!is_ignored_at(&root, &leaf.join("public.txt"), false).unwrap());
+        assert!(is_ignored_at(&root, &leaf.join("secret.txt"), false, false).unwrap());
+        assert!(!is_ignored_at(&root, &leaf.join("public.txt"), false, false).unwrap());
         // Path outside the source root is not ignored.
         let outside =
             Utf8PathBuf::from_path_buf(tmp.path().parent().unwrap().to_path_buf()).unwrap();
-        assert!(!is_ignored_at(&root, &outside.join("anywhere"), false).unwrap());
+        assert!(!is_ignored_at(&root, &outside.join("anywhere"), false, false).unwrap());
+    }
+
+    #[test]
+    fn is_ignored_at_respects_gitignore() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        let mid = root.join("mid");
+        let leaf = mid.join("leaf");
+        std::fs::create_dir_all(&leaf).unwrap();
+
+        // Write .gitignore excluding secret.txt
+        std::fs::write(mid.join(".gitignore"), "secret.txt\n").unwrap();
+
+        // When respect_gitignore is false, it's not ignored
+        assert!(!is_ignored_at(&root, &leaf.join("secret.txt"), false, false).unwrap());
+        // When respect_gitignore is true, it is ignored
+        assert!(is_ignored_at(&root, &leaf.join("secret.txt"), false, true).unwrap());
+
+        // Test that yui's auto-managed section in .gitignore is exempt
+        let gitignore_content = format!(
+            "ignored.txt\n{}\nexempt.txt\n{}\n",
+            crate::render::GITIGNORE_BEGIN,
+            crate::render::GITIGNORE_END
+        );
+        std::fs::write(mid.join(".gitignore"), gitignore_content).unwrap();
+
+        // ignored.txt is ignored
+        assert!(is_ignored_at(&root, &mid.join("ignored.txt"), false, true).unwrap());
+        // exempt.txt is inside the markers, so it should not be ignored
+        assert!(!is_ignored_at(&root, &mid.join("exempt.txt"), false, true).unwrap());
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -32,8 +32,12 @@ use crate::template::{self, Engine};
 use crate::vars::YuiVars;
 use crate::{Error, Result};
 
-const GITIGNORE_BEGIN: &str = "# >>> yui rendered (auto-managed, do not edit) >>>";
-const GITIGNORE_END: &str = "# <<< yui rendered (auto-managed) <<<";
+/// Markers around yui's managed `.gitignore` block. Visible to the
+/// crate because `paths::build_matcher` must skip the lines between
+/// them — they name yui's own generated files, which stay linkable
+/// even when `mount.respect_gitignore` is on.
+pub(crate) const GITIGNORE_BEGIN: &str = "# >>> yui rendered (auto-managed, do not edit) >>>";
+pub(crate) const GITIGNORE_END: &str = "# <<< yui rendered (auto-managed) <<<";
 
 /// A render-drift case: the on-disk rendered file's content differs
 /// from what the template would produce now. Carries the template


### PR DESCRIPTION
## Problem

`yui status` on a real dotfiles repo listed **129 entries, 99 of which were one tool's session logs** — `~/.kimi-code/sessions/**/wire.jsonl`, `tasks/*.json`, `logs/*.log`. Every one of them was also a managed hardlink created by `apply`.

This is structural, not specific to that tool. yui is target-as-truth: the source tree *is* the live config, so apps write runtime state (session logs, caches, credentials) straight into it through the links. `~/.kimi-code/.gitignore` already excluded all of it — but the source walk only ever consulted `.yuiignore`, which most repos don't have at all.

## Change

Layer each directory's `.gitignore` underneath its `.yuiignore` in `YuiIgnoreStack`, gated on a new `mount.respect_gitignore` (default `true`).

- **`.yuiignore` still wins.** It's matched first within a directory, so `!home/keep.log` re-includes a file the sibling `.gitignore` excluded — the escape hatch for "git shouldn't track this, but yui should link it".
- **Opt out** with `[mount] respect_gitignore = false`.
- Scope is the link-management walks — `status`, `apply`, `diff`, `absorb`. The `source_walker` consumers (`render`, `secret`, `list`, `unmanaged`) are untouched: they hunt for `.tera` / `.age` / markers, which are never gitignored.

## The part that makes it safe to default on

yui writes its **own** generated files into the managed `.gitignore` block — rendered `.tera` output and decrypted `.age` plaintext — precisely *because* it generates them. Honoring those lines would make `apply` refuse to link the very files it just produced.

So everything between the `# >>> yui rendered (auto-managed…) >>>` markers is stripped before the matcher is built. `managed_gitignore_section_never_blocks_linking` is the regression guard: it renders a template, confirms the output lands in the managed block, and asserts the link still exists — while a user rule outside the block still bites.

## Verification

Against the author's live dotfiles, old binary vs new:

```
old: 129 entries · all in sync
new:  30 entries · all in sync
```

Diffed the two path sets: the 99 dropped entries are **all** `.kimi-code` session files, and **nothing was added**. No rendered output or secret plaintext lost its link.

`cargo make check` green — 207 tests (4 new integration tests + 1 unit test for the ignore stack).

## Test plan

- [x] `gitignore_excludes_file_from_linking_by_default` — nested `.gitignore` keeps a subtree out of target
- [x] `gitignore_opt_out_restores_linking` — `respect_gitignore = false`
- [x] `managed_gitignore_section_never_blocks_linking` — yui's generated files stay linked
- [x] `yuiignore_negation_overrides_sibling_gitignore` — precedence
- [x] `is_ignored_at_respects_gitignore` — one-shot path used by manual `absorb`
- [x] Verified against a real 129-entry dotfiles repo

## Note for review

Default-on is a behavior change: after upgrading, files that are gitignored stop being tracked as managed links. Existing links on disk are left alone (yui never unlinks on apply), so the practical effect is that they stop appearing in `status` and stop being re-linked. Flagging it explicitly in case you'd rather ship this opt-in for a release first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiLF7dkRWs8zabVcGPQ5Jy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Directory `.gitignore` rules are now respected by default when walking mounted sources.
  * Added `mount.respect_gitignore` configuration to disable this behavior and restore `.yuiignore`-only handling.
  * Generated and managed artifacts remain eligible for processing despite matching the managed `.gitignore` section.

* **Documentation**
  * Updated the README with ignore-rule behavior, managed artifact handling, and configuration details.

* **Bug Fixes**
  * Improved ignore-rule consistency across apply, diff, status, and absorb operations.
  * `.yuiignore` exceptions can re-include files excluded by `.gitignore`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->