### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."


### PR DESCRIPTION
Version bump only: `0.9.2` → `0.10.0`. Diff is `Cargo.toml` + `Cargo.lock`, nothing else.

## Why minor, not patch

#181 changed default behavior: `mount.respect_gitignore` defaults to `true`, so each directory's `.gitignore` now layers under its `.yuiignore` when yui walks the source tree. Files that git already excludes stop being tracked as managed links.

Under semver a 0.x crate signals breaking changes with the **minor** field, so `0.10.0` is the correct bump. It also means cargo won't float existing `0.9` dependents onto it — `0.9` and `0.10` are incompatible ranges, so nobody gets the behavior change without opting in.

## Upgrade note for the release

Existing links on disk are left alone (apply never unlinks), so the practical effect is that gitignored files stop appearing in `yui status` and stop being re-linked. Anything you want git to ignore but yui to keep linking can be re-included from `.yuiignore`, which is matched first:

```gitignore
# $DOTFILES/.yuiignore
!home/.config/some-app/machine-local.toml
```

Opt out entirely with:

```toml
[mount]
respect_gitignore = false
```

## Verification

`cargo make check` green — 208 tests.

Per AGENTS.md, version-bump-only PRs skip the bot-review gate: CI green + owner approval is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiLF7dkRWs8zabVcGPQ5Jy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.10.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->