### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/apm-bump.yml
+++ b/.github/workflows/apm-bump.yml
@@ -68,7 +68,7 @@ jobs:
       # uses it: PRs pushed via GITHUB_TOKEN don't trigger CI,
       # which would block the auto-merge gate. PAT-owned identity
       # restores the trigger chain.
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v6.1.0
         with:
           token: ${{ secrets.KATA_APPLY_TOKEN }}
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v6.1.0
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.9.1
         with:
@@ -51,7 +51,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v6.1.0
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.9.1
         with:
@@ -74,7 +74,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v6.1.0
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -93,7 +93,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v6.1.0
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -113,7 +113,7 @@ jobs:
     name: cargo lockfile in sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v6.1.0
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.9.1
         with:
@@ -134,7 +134,7 @@ jobs:
     name: coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v6.1.0
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -82,7 +82,7 @@ jobs:
     # GHA's 360-minute default.
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v6.1.0
         with:
           fetch-depth: 1
           # The action exchanges its own App token for git/API

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -63,7 +63,7 @@ jobs:
     # GHA's 360-minute default.
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v6.1.0
         with:
           fetch-depth: 1
           # The action exchanges its own App token for git/API

--- a/.github/workflows/kata-apply.yml
+++ b/.github/workflows/kata-apply.yml
@@ -55,7 +55,7 @@ jobs:
       # CI from running on the auto-PR — making auto-merge wait for
       # checks that never fire. A PAT acts as a user-identity push
       # and triggers CI normally.
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v6.1.0
         with:
           token: ${{ secrets.KATA_APPLY_TOKEN }}
 

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,5 +1,5 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-06-09T04:44:03.988011579Z"
+applied_at = "2026-07-22T04:25:23.17893406Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
@@ -33,22 +33,22 @@ content_hash = "486c974de88903113ed99b4e643432b7050e88f1031276f5263e8da7b43fe11e
 content_hash = "6d380d1ecc2f882c2011429d548a6f3c774b74f0c757d884453e4667172acc2a"
 
 [files.".github/workflows/apm-bump.yml"]
-content_hash = "d47d37312df1e5599d61b8a30a941b35e70df7ff98a93d7d746c45c7ad34a10a"
+content_hash = "e7140a937a36ec588351ab68be92345bdcc4c020e57060802a9e3709bd105b07"
 
 [files.".github/workflows/auto-tag.yml"]
-content_hash = "5c5c9592fb47120e5278d77af38d38e0657e39841509f000a84561a0a62ea29f"
+content_hash = "406943795e69542d92d37a0d70051f22a899956dc0cbd1d70ebc16aea13d655a"
 
 [files.".github/workflows/ci.yml"]
-content_hash = "7969eab018580d42ee36d5e1a295ef4ad3474604eaad6fb6190846fc6eed5e68"
+content_hash = "917be127933843d794f8f3074472b8d9e90cdb22ec90c025b5a8aa2607d1778f"
 
 [files.".github/workflows/claude-review.yml"]
-content_hash = "44d6ba3debc255f2a448bb54904b9462e4a8e2271ce70aa70d0378fd49c22cfe"
+content_hash = "8804c503c1960abdda86578c0bb0bdd727daf41c0d482975d45947d27768b2ec"
 
 [files.".github/workflows/claude.yml"]
-content_hash = "13b455ea1b225e23c9c36906b88df3ad8b9601102593f231b38f4cba5432ef59"
+content_hash = "81eb918f932e08a95f3deb8e64c13e57976691bc5723c4d7cb56501d6566994c"
 
 [files.".github/workflows/kata-apply.yml"]
-content_hash = "a63f0e30f6c010e497ab3c3feb7061cfc59ca397ffef2c4ecec356ff99253641"
+content_hash = "45e8fc324f046621343be84f99ed8f3a338fa6d0ea007e87f5ce0c81b0ae2335"
 
 [files.".github/workflows/release.yml"]
 content_hash = "ef4db54ac86c63962de0e95bcdca4fe7d6ca8f6b28c358a65c98686aa984b5f0"


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository automation to use the latest checkout action version.
  * Refreshed workflow tracking metadata to reflect the updated automation configuration.
  * No changes to application functionality, user-facing behavior, or workflow outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->