### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,5 +1,5 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-07-22T04:25:23.17893406Z"
+applied_at = "2026-07-26T04:27:30.744664613Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
@@ -8,12 +8,12 @@ version = "0.13.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust"
-rev = "45af1969561402fc213d76ae51372a5853a33512"
+rev = "4431c1cc08174025128ce7a2d7bb68af2dfffa93"
 version = "0.8.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust-cli"
-rev = "a6302f8d4e134fad71683d23c01676f28e2abe95"
+rev = "25189b4c1450b3aa9b6db6ada3c43703e13d4d98"
 version = "0.4.1"
 
 [files.".agents/skills/renri/SKILL.md"]
@@ -62,7 +62,7 @@ content_hash = "393b2b94540e792790ef9357e46e5bc259eb3064605794ca2373ae458999cb23
 once_applied = true
 
 [files."AGENTS.md"]
-content_hash = "38c105d7b01a7034665facbb6840017db92b0d460e91a89edc5d2c86b6b7acad"
+content_hash = "3d4378e2d4ecae3df56dc942321246c0bf1a44b72b2ae97f075a4445073fd12e"
 
 [files."CLAUDE.md"]
 content_hash = "a76b3af252969b8120128d7ce44f2b6cfdcf88c7420ee00675732f542d047529"
@@ -86,7 +86,7 @@ once_applied = true
 once_applied = true
 
 [files."clippy.toml"]
-content_hash = "c750cb285075d0cb0c5c9ea77cd67baf7b0c4af864603cbe6c0c6692e75ed6fb"
+content_hash = "089f90baf996c8e39253746a6c46ddc9951ed656364e1ff2a14c1c5ac9c15468"
 
 [files."examples/smoke.rs"]
 once_applied = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -549,10 +549,12 @@ auto-tag" — that block also covers the `KATA_APPLY_TOKEN` and
 `delete_branch_on_merge` setup. What `release.yml` then does for
 a **CLI** crate:
 
-1. Cross-compiles binaries for x86_64 Linux / Windows / macOS,
-   plus aarch64 macOS (Apple Silicon) — full triples
-   `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`,
-   `x86_64-apple-darwin`, `aarch64-apple-darwin`.
+1. Cross-compiles binaries for **three** targets — full triples
+   `x86_64-unknown-linux-musl`, `x86_64-pc-windows-msvc`,
+   `aarch64-apple-darwin`. Linux is musl (statically linked, so the
+   binary runs on any glibc vintage); the Linux job installs
+   `musl-tools` first. Intel Mac (`x86_64-apple-darwin`) is
+   deliberately **not** built — Apple Silicon only.
 2. Uploads them as a GitHub Release with auto-generated notes.
 3. `cargo publish --locked` to crates.io using the
    `CARGO_REGISTRY_TOKEN` repo secret.

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,7 +3,21 @@
 # `kata apply` (overwrite always). Local edits don't survive
 # `kata apply` — push the change here.
 
-# MSRV — keeps `cargo clippy` from suggesting features that are
-# stable on `stable` but not yet on the project's pinned MSRV.
-# Bumped together with `package.rust-version` in Cargo.toml.
-msrv = "1.85"
+# MSRV is deliberately NOT set here.
+#
+# Clippy reads `package.rust-version` (or `workspace.package.
+# rust-version`) from Cargo.toml on its own, so pinning it a second
+# time in this file just creates a value that can disagree with the
+# manifest — and clippy warns when it does:
+#
+#   warning: the MSRV in `clippy.toml` and `Cargo.toml` differ
+#
+# That is not hypothetical: a project that raises its floor for a
+# dependency (yukimemi/yaiba went to 1.91 for iroh 1.0) starts warning
+# on every `cargo clippy` run, and can't fix it locally because this
+# file is overwritten on the next `kata apply`. Pinning a single
+# shared MSRV across every consumer is also wrong in principle —
+# projects have different dependency floors.
+#
+# Leaving it unset makes Cargo.toml the one place an MSRV is
+# declared, which is where `cargo` already enforces it.


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->