### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -134,10 +134,14 @@ jobs:
       - uses: actions/checkout@v6.1.0
         with:
           fetch-depth: 1
-          # The action exchanges its own App token for git/API
-          # access; the checkout-persisted credential is unused.
-          # Same hardening as apm-bump.yml.tera.
-          persist-credentials: false
+          # persist-credentials stays ON (the default) on purpose: the
+          # action's setupBranch runs `git fetch origin <branch>` BEFORE
+          # it configures its own git auth, so with the credential
+          # scrubbed the fetch dies with "could not read Username for
+          # 'https://github.com'" on private repos — public repos only
+          # survive because the anonymous fetch happens to succeed
+          # (anthropics/claude-code-action#1236). The App token the
+          # action exchanges covers API calls, not that first fetch.
 
       - uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,16 +52,42 @@ concurrency:
 
 jobs:
   claude:
+    # Two conditions, and the first is new because the bottom of this
+    # file now hands the run a shell.
+    #
+    # `issue_comment` and friends always run the workflow from the
+    # default branch *with secrets*, and the mention used to be the only
+    # gate — so on a public repo any stranger could start this job. That
+    # was survivable while the action had no way to execute anything:
+    # the worst case was a wasted run. It stops being survivable the
+    # moment `Bash(cargo test:*)` is in the allow-list, because
+    # compiling a branch runs its `build.rs`, its proc-macros and its
+    # test bodies. Gating on the author's association keeps "can run
+    # code here" and "can push code here" the same set of people.
+    #
+    # The association lives under a different key per event type, and an
+    # absent key is the empty string — so `||` picks the first one that
+    # is present. The commenter's comes first, which is the one that
+    # matters on a comment event; the issue author's is the fallback for
+    # `issues`.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+               github.event.comment.author_association ||
+               github.event.review.author_association ||
+               github.event.issue.author_association) &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     # Same rationale as claude-review.yml.tera: the action has no
     # wall-clock timeout of its own; bound a hung run well below
-    # GHA's 360-minute default.
-    timeout-minutes: 30
+    # GHA's 360-minute default. 45 rather than 30 to match the review
+    # job, for the same reason it went there — a mention that asks
+    # "does this actually hold?" may now compile from a cold cache.
+    timeout-minutes: 45
     steps:
       # Same guard as claude-review.yml.tera: an empty credential
       # makes claude-code-action exit 0 without responding, so a
@@ -86,11 +112,30 @@ jobs:
       - uses: actions/checkout@v6.1.0
         with:
           fetch-depth: 1
-          # The action exchanges its own App token for git/API
-          # access; the checkout-persisted credential is unused.
-          # Same hardening as apm-bump.yml.tera.
-          persist-credentials: false
+          # persist-credentials stays ON (the default) on purpose: the
+          # action's setupBranch runs `git fetch origin <branch>` BEFORE
+          # it configures its own git auth, so with the credential
+          # scrubbed the fetch dies with "could not read Username for
+          # 'https://github.com'" on private repos — public repos only
+          # survive because the anonymous fetch happens to succeed
+          # (anthropics/claude-code-action#1236). The App token the
+          # action exchanges covers API calls, not that first fetch.
 
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The same list `claude-review.yml.tera` carries, and for the
+          # same reason: asked "is this claim true?", the responder had
+          # no way to find out. It read the diff and reasoned, which is
+          # worth something and is not worth as much as running the
+          # thing — a review that verified by tracing missed a test
+          # whose assertion was satisfied by an unrelated line, and only
+          # caught it on the repo where it could edit a file and look.
+          #
+          # Deliberately no `git`, no `gh pr edit`, no writes: answering
+          # a mention must not be able to change the branch it is
+          # answering about. Compiling still executes `build.rs` and
+          # test code, so this list bounds intent rather than
+          # capability — which is why the job now checks who is asking.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(cargo make:*),Bash(cargo test:*),Bash(cargo clippy:*),Bash(cargo check:*),Bash(cargo fmt:*),Bash(bun install:*),Bash(bun test:*),Bash(bun run build:*),Bash(bun run test:*),Bash(bun run lint:*),Bash(bun run check:*),Bash(bun run typecheck:*)"

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,15 +1,15 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-08-02T04:26:57.112956726Z"
+applied_at = "2026-08-04T04:23:59.957174537Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "9f3a4087bc33b5f3fd08d8a02edd21a2ccd8159d"
-version = "0.13.0"
+rev = "b5f394660d08ef671e6c29204c366b3e7984868c"
+version = "0.14.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust"
-rev = "4431c1cc08174025128ce7a2d7bb68af2dfffa93"
-version = "0.8.0"
+rev = "6409c21b281d21f53a294f4928c89ad6f2e2c399"
+version = "0.8.1"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust-cli"
@@ -42,10 +42,10 @@ content_hash = "406943795e69542d92d37a0d70051f22a899956dc0cbd1d70ebc16aea13d655a
 content_hash = "917be127933843d794f8f3074472b8d9e90cdb22ec90c025b5a8aa2607d1778f"
 
 [files.".github/workflows/claude-review.yml"]
-content_hash = "78b669b6a0965f84855acb8c21fdc1ad8a6877437a88d5919877c769e6bf44f1"
+content_hash = "9c07be16af6dc6f1e86b8a845a64a5c54b0d9092b8b34a9c4eefe31e84269509"
 
 [files.".github/workflows/claude.yml"]
-content_hash = "615406a64ab9faed907078fee7c31d17812d893f2d84c48dcec71c2456716c3f"
+content_hash = "2db473008ec9528565097a8e543c7a5586a6dd383d8f3e32e094ca78e8e9c2f5"
 
 [files.".github/workflows/kata-apply.yml"]
 content_hash = "45e8fc324f046621343be84f99ed8f3a338fa6d0ea007e87f5ce0c81b0ae2335"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -543,6 +543,40 @@ gh pr merge --auto --squash --delete-branch
 Once CI is green the PR auto-merges. `auto-tag.yml` then pushes
 `vX.Y.Z`, which fires `release.yml`.
 
+**In a workspace, the version is in more than one place.** A member
+that is published and depended on by another member is declared
+with both a `path` and a `version` — crates.io needs a
+requirement it can resolve for somebody who is not building from
+the checkout, so a bare `path` will not do:
+
+```toml
+my-core = { path = "crates/my-core", version = "0.4.2" }
+```
+
+That literal does not follow `[workspace.package] version`.
+Nothing in Cargo makes it, and the release above will not either.
+
+**It fails late and quietly.** `version = "0.4.2"` means `^0.4.2`,
+so a stale pin keeps resolving through every *patch* release and
+stops only at the first bump that crosses the minor — where
+`cargo build` refuses with `candidate versions found which didn't
+match`, in the middle of cutting the release. Two repos on these
+templates hit exactly this, one of them three releases after its
+pins were last correct, and the other had already written the
+hazard down in prose and drifted anyway.
+
+So bump the pins in the same commit, keep them in
+`[workspace.dependencies]` rather than in each member, and assert
+it rather than remembering it. A test is the cheapest place —
+`cargo test` already runs in CI, and it needs no toolchain a Rust
+workspace does not have. [pj-rust-workspace's
+README](https://github.com/yukimemi/pj-rust-workspace#the-internal-version-pin-and-the-check-for-it)
+carries one to copy into any member's
+`tests/check_versions.rs`: `internal_pins_match_the_workspace_version`
+fails when a pin and the workspace version disagree, and
+`members_inherit_the_workspace_version` fails when a member writes
+its own version or reaches for a sibling by path.
+
 **Repo settings to set once:** enable
 `delete_branch_on_merge=true` (Settings → General →
 "Automatically delete head branches"). The `--delete-branch`


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated review workflow reliability for private repositories.
  - Restricted automated assistant triggers to authorized repository participants.
  - Added safeguards limiting automated actions to approved commenting, code review, and project verification commands.
  - Extended the automated review job timeout to 45 minutes.

- **Documentation**
  - Added release guidance for keeping internal dependency versions and workspace configuration synchronized.
  - Documented recommended checks for validating dependency version consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->