### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.1.0
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2.9.1
+      - uses: Swatinem/rust-cache@v2.9.2
         with:
           # Skip cache save on PR runs — the Post step's tar.exe is
           # flaky on windows-latest (file locks under target/ make
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.1.0
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2.9.1
+      - uses: Swatinem/rust-cache@v2.9.2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
         # See the check job above for why continue-on-error is set
@@ -97,7 +97,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2.9.1
+      - uses: Swatinem/rust-cache@v2.9.2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
         # See the check job above for why continue-on-error is set
@@ -115,7 +115,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.1.0
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2.9.1
+      - uses: Swatinem/rust-cache@v2.9.2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
         # See the check job above for why continue-on-error is set
@@ -138,7 +138,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2.9.1
+      - uses: Swatinem/rust-cache@v2.9.2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
         # See the check job above for why continue-on-error is set

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,5 +1,5 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-08-06T04:24:07.627993086Z"
+applied_at = "2026-08-07T04:12:21.489486022Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
@@ -39,7 +39,7 @@ content_hash = "e7140a937a36ec588351ab68be92345bdcc4c020e57060802a9e3709bd105b07
 content_hash = "406943795e69542d92d37a0d70051f22a899956dc0cbd1d70ebc16aea13d655a"
 
 [files.".github/workflows/ci.yml"]
-content_hash = "917be127933843d794f8f3074472b8d9e90cdb22ec90c025b5a8aa2607d1778f"
+content_hash = "521b8e878a7b463a74b3006a8774ace3009d24abc62f2cba0a9dc0166384ec3b"
 
 [files.".github/workflows/claude-review.yml"]
 content_hash = "9c07be16af6dc6f1e86b8a845a64a5c54b0d9092b8b34a9c4eefe31e84269509"


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration environment to use the latest Rust caching action version.
  * Refreshed automated change-tracking metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->