### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,5 +1,5 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-08-10T03:57:33.623731762Z"
+applied_at = "2026-08-11T03:53:05.714119373Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application tracking metadata with a new timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->