### PR TITLE
fix(secret): normalize relative path components before adding to gitignore

### DIFF
--- a/src/cmd/common.rs
+++ b/src/cmd/common.rs
@@ -67,10 +67,10 @@ pub(crate) fn absolutize(p: &Utf8Path) -> Result<Utf8PathBuf> {
     // Expand `~` first so callers can pass `--source ~/dotfiles` directly.
     let expanded = paths::expand_tilde(p.as_str());
     if expanded.is_absolute() {
-        return Ok(expanded);
+        return Ok(crate::paths::normalize(&expanded));
     }
     let cwd = current_dir_utf8()?;
-    Ok(cwd.join(expanded))
+    Ok(crate::paths::normalize(&cwd.join(expanded)))
 }
 
 pub(crate) fn current_dir_utf8() -> Result<Utf8PathBuf> {

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -2677,3 +2677,36 @@ fn link_file_with_backup_short_circuits_when_quit_requested() {
         "no backup should be produced when quit is requested"
     );
 }
+
+#[test]
+fn secret_encrypt_with_relative_dot_path_updates_gitignore_cleanly() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let gcal_dir = source.join("home/.config/gcal");
+    std::fs::create_dir_all(&gcal_dir).unwrap();
+
+    let (_secret_key, public) = secret::generate_x25519_keypair();
+    let cfg = format!(
+        r#"
+[secrets]
+recipients = ["{public}"]
+"#
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    let plain_file = gcal_dir.join("credentials.json");
+    std::fs::write(&plain_file, "{ \"test\": true }").unwrap();
+
+    let rel_dot_path = source.join("home/.config/gcal/./credentials.json");
+    secret_encrypt(Some(source.clone()), rel_dot_path, false, false).unwrap();
+
+    let gi = std::fs::read_to_string(source.join(".gitignore")).unwrap();
+    assert!(
+        gi.contains("home/.config/gcal/credentials.json"),
+        ".gitignore should contain normalized entry: {gi}"
+    );
+    assert!(
+        !gi.contains("home/.config/gcal/./credentials.json"),
+        ".gitignore should NOT contain dot component: {gi}"
+    );
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -363,6 +363,23 @@ pub fn append_timestamp(path: &Utf8Path, ts: &str) -> Utf8PathBuf {
     parent.join(new_name)
 }
 
+/// Normalize a path by eliminating redundant `.` components without accessing
+/// the filesystem, preserving `..` to maintain symlink semantics.
+pub fn normalize(path: &Utf8Path) -> Utf8PathBuf {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            Utf8Component::CurDir => {}
+            _ => components.push(component),
+        }
+    }
+    if components.is_empty() {
+        Utf8PathBuf::from(".")
+    } else {
+        components.into_iter().collect()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -634,5 +651,19 @@ mod tests {
             expand_tilde_with("/foo/~/bar", home),
             Utf8PathBuf::from("/foo/~/bar")
         );
+    }
+
+    #[test]
+    fn normalize_paths() {
+        assert_eq!(
+            normalize(Utf8Path::new("home/.config/gcal/./credentials.json")),
+            Utf8PathBuf::from("home/.config/gcal/credentials.json")
+        );
+        assert_eq!(
+            normalize(Utf8Path::new("a/b/./c/./d")),
+            Utf8PathBuf::from("a/b/c/d")
+        );
+        assert_eq!(normalize(Utf8Path::new("./foo")), Utf8PathBuf::from("foo"));
+        assert_eq!(normalize(Utf8Path::new(".")), Utf8PathBuf::from("."));
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -379,10 +379,13 @@ pub fn add_to_managed_section(source: &Utf8Path, plaintext_abs_path: &Utf8Path) 
         Err(e) => return Err(Error::Template(format!("read {gi_path}: {e}"))),
     };
 
-    let new_entry = plaintext_abs_path
-        .strip_prefix(source)
+    let norm_source = crate::paths::normalize(source);
+    let norm_plaintext = crate::paths::normalize(plaintext_abs_path);
+
+    let new_entry = norm_plaintext
+        .strip_prefix(&norm_source)
         .map(|p| p.as_str().to_string())
-        .unwrap_or_else(|_| plaintext_abs_path.as_str().to_string())
+        .unwrap_or_else(|_| norm_plaintext.as_str().to_string())
         .replace('\\', "/");
 
     let mut managed = parse_managed_section(&existing);
@@ -426,10 +429,16 @@ fn update_gitignore(source: &Utf8Path, rendered_abs_paths: &[Utf8PathBuf]) -> Re
         Err(e) => return Err(Error::Template(format!("read {gi_path}: {e}"))),
     };
 
+    let norm_source = crate::paths::normalize(source);
+
     let mut managed: Vec<String> = rendered_abs_paths
         .iter()
-        .filter_map(|p| p.strip_prefix(source).ok())
-        .map(|p| p.as_str().replace('\\', "/"))
+        .map(|p| crate::paths::normalize(p))
+        .filter_map(|p| {
+            p.strip_prefix(&norm_source)
+                .ok()
+                .map(|rel| rel.as_str().replace('\\', "/"))
+        })
         .collect();
     managed.sort();
     managed.dedup();
@@ -865,6 +874,17 @@ mod tests {
             !gi.contains("home\\.config"),
             "managed section should not carry backslashes: {gi}"
         );
+    }
+
+    #[test]
+    fn add_to_managed_normalises_dot_components() {
+        let tmp = TempDir::new().unwrap();
+        let r = root(&tmp);
+        let plain = r.join("home/.config/gcal/./credentials.json");
+        add_to_managed_section(&r, &plain).unwrap();
+        let gi = std::fs::read_to_string(r.join(".gitignore")).unwrap();
+        assert!(gi.contains("home/.config/gcal/credentials.json"));
+        assert!(!gi.contains("home/.config/gcal/./credentials.json"));
     }
 
     #[test]


### PR DESCRIPTION
Normalize relative path components when executing yui secret encrypt so that .gitignore managed entries do not contain redundant dot components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized file paths now consistently remove redundant `.` and resolve `..` components.
  * `.gitignore` entries generated during secret encryption now use clean, correct relative paths.
  * Improved handling of Windows-style path separators and relative source or target paths.
  * Tilde expansion and current-directory path handling remain supported.

* **Tests**
  * Added coverage for normalized paths and `.gitignore` updates involving `./` components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->