### PR TITLE
feat!: declare links centrally with a config.toml [[link]] table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ src/
   vars.rs       — built-in `yui.*` vars (os/arch/host/user/source)
   paths.rs      — backup-path mirroring + timestamp-suffix utilities
   marker.rs     — `.yuilink` marker detection
+  links.rs      — `[[link]]` entry schema shared by `config.toml` +
+                  `.yuilink`, plus the per-dir plan the walkers consult
   mount.rs      — `[[mount.entry]]` resolution (Tera dst, when filter)
   link.rs       — link mode resolution + cross-platform link/unlink
   render.rs     — Tera rendering of `*.tera` files + .gitignore management
@@ -85,11 +87,27 @@ before reverting any of them.
   Windows: hardlink for files + junction for dirs. The Windows defaults
   avoid requiring Developer Mode / admin. `symlink` is opt-in for
   Windows users who do want it.
-- **`.yuilink` marker decides where junctions land.** A directory
-  containing the marker is junctioned as a unit and recursion stops.
-  Without the marker, `yui` recurses and hardlinks individual files.
-  This is so apps creating new files inside a junctioned dir land
-  directly in source (no "untracked" detection needed for that case).
+- **`[[link]]` decides where dir-level links land**, declared either in
+  `config.toml`'s central table (`src` required, relative to
+  `$DOTFILES`) or in a `<dir>/.yuilink` marker (`src` optional, relative
+  to the marker's dir). A dir-scoped entry links that directory as a
+  unit; without one, `yui` recurses and links individual files. The
+  point of dir-level linking is that apps creating new files inside the
+  linked dir land directly in source (no "untracked" detection needed
+  for that case). Both spellings exist on purpose: the central table
+  keeps the tree free of marker files (which are also visible from the
+  target side once the dir is junctioned), while a marker travels with
+  its directory and can't rot into a dangling entry.
+- **Markers do not stop the walk (v0.6+).** It keeps descending and
+  aggregates entries, so a descendant *adds* destinations on top of its
+  ancestors. Exact duplicates (same `src` / `dst` / `when`) collapse so
+  declaring one mapping twice doesn't double the work or the report
+  rows. Marker discovery is gated on `MountStrategy::Marker`; central
+  entries are explicit instructions and apply under `per-file` too.
+- **Link modes live in `[mount]`** (`file_mode` / `dir_mode`). They used
+  to be a `[link]` table; that key is now the `[[link]]` array, and
+  `config::load` intercepts the old table shape with a migration error
+  rather than letting serde emit a type error about a sequence.
 - **Templates are `*.tera` files; rendered output goes to the *same
   directory* as the template.** `home/.gitconfig.tera` →
   `home/.gitconfig`. Rendered files are listed in a managed section

--- a/README.md
+++ b/README.md
@@ -115,10 +115,23 @@ dst  = "{{ env(name='APPDATA') }}"
 when = "yui.os == 'windows'"
 ```
 
-Add files under `home/` and they'll link into `~`. Add a `.yuilink`
-file to a directory to junction the whole directory as one unit (so
-files an app creates inside that dir land back in source
-automatically).
+Add files under `home/` and they'll link into `~`. Directory-level
+linking — junction the whole directory as one unit, so files an app
+creates inside it land back in source automatically — is declared with a
+`[[link]]` entry, either centrally in `config.toml` or as a `.yuilink`
+marker in the directory itself. See
+[Explicit links (`[[link]]`)](#explicit-links-link).
+
+Link *mechanism* is `[mount]`'s business:
+
+```toml
+[mount]
+file_mode = "auto"   # auto | symlink | hardlink
+dir_mode  = "auto"   # auto | symlink | junction
+```
+
+`auto` is symlink on Unix, hardlink (files) + junction (dirs) on
+Windows — the pair that needs no Developer Mode or admin.
 
 `src` is the path *to* yui's source for that mount; it accepts
 relative paths (resolved against `$DOTFILES`), absolute paths, `~`
@@ -149,29 +162,45 @@ loads after `config.*.toml` so its values win.
 
 [Tera]: https://keats.github.io/tera/
 
-## One source → many targets
+## Explicit links (`[[link]]`)
 
-If you want the same source directory linked to different places on
-different OSes — common for editor configs (`~/.config/nvim` on Unix,
-`%LOCALAPPDATA%\nvim` on Windows) — drop a `.yuilink` with content:
+A `[[link]]` entry says "link *this* source path to *that* target". It
+covers the two things mount entries can't express: a directory linked as
+one unit, and a target outside the mount's dst root (`%LOCALAPPDATA%`,
+`Documents/PowerShell`, …).
+
+Entries live in either of two places, with the same schema:
+
+| where | `src` | when to prefer it |
+|-------|-------|-------------------|
+| `$DOTFILES/config.toml` | **required**, relative to `$DOTFILES` | everything in one file; nothing extra in the tree, nothing extra visible from the target side |
+| `<dir>/.yuilink` | optional, relative to the marker's dir; omitted = the marker's dir | the declaration travels with the directory — rename or delete it and the rule goes too |
 
 ```toml
-# $DOTFILES/home/.config/nvim/.yuilink
+# $DOTFILES/config.toml — central table
 [[link]]
-dst = "~/.config/nvim"
+src = "home/.config/nvim"
+dst = "{{ env(name='LOCALAPPDATA') }}/nvim"
+when = "yui.os == 'windows'"
+```
 
+```toml
+# $DOTFILES/home/.config/nvim/.yuilink — same rule, declared in place
 [[link]]
 dst = "{{ env(name='LOCALAPPDATA') }}/nvim"
 when = "yui.os == 'windows'"
 ```
 
+An empty `.yuilink` is shorthand for "link this dir at the mount's
+natural dst" — the one thing the central table has no spelling for,
+since it always names its `dst` explicitly.
+
 `yui list` shows each link and which `when` would activate it.
 
-### Stacking markers and file-level entries
+### One source → many targets
 
-Markers compose. A parent `.yuilink` no longer stops the walker, so
-you can junction a whole `~/.config` and *also* layer extra dsts onto
-specific subdirs:
+Entries stack. Nothing stops the walker, so a whole `~/.config` can be
+one junction while individual subdirs add extra dsts on top:
 
 ```toml
 # $DOTFILES/home/.config/.yuilink — junction the whole .config dir
@@ -187,12 +216,15 @@ when = "yui.os == 'windows'"
 ```
 
 Both links land — the parent takes care of the natural placement, the
-child adds its OS-specific alternate.
+child adds its OS-specific alternate. Central entries join the same
+stack; an entry that duplicates a marker exactly (same `src`, `dst` and
+`when`) collapses into it instead of doubling the `list` / `status` rows.
 
-A `[[link]]` may also carry a `src = "<filename>"` to scope the link to
-a single sibling file rather than the directory itself. Useful for
-paths that don't follow `~/.config/<app>/` conventions, like the
-PowerShell profile on Windows:
+### File-scoped entries
+
+A `src` naming a file scopes the link to that file rather than its
+directory. Useful for paths that don't follow `~/.config/<app>/`
+conventions, like the PowerShell profile on Windows:
 
 ```toml
 # $DOTFILES/home/.config/powershell/.yuilink
@@ -202,10 +234,27 @@ dst = "{{ env(name='USERPROFILE') }}/Documents/PowerShell/Microsoft.PowerShell_p
 when = "yui.os == 'windows'"
 ```
 
-`src` must be a single filename (no path separators); the file lives
-right next to the marker. The rest of the directory still falls
+File scope doesn't claim the directory, so the rest of it still falls
 through to whatever placement an ancestor (or the parent mount)
 provides.
+
+### Rules for `src`
+
+- Relative, and it has to stay inside its base: `..`, absolute paths and
+  `.` are rejected. Subdirectories are fine (`src = "sub/profile.ps1"`).
+- In a `.yuilink`, `src` names a **file**. Directory scope is what the
+  marker itself means, so pointing one at a subdirectory is an error
+  that tells you to put a marker there (or use the central table).
+- A central `src` may name a file **or** a directory. Existence is
+  checked when the walk reaches it, after `when` — `*.tera` output and
+  `*.age` plaintext siblings don't exist until `apply` has run, so a
+  load-time check would fail `list` / `status` on a fresh clone.
+- A central entry whose directory lies outside every mount's subtree
+  can't be reached by any walk. `apply` / `status` warn about it rather
+  than linking nothing in silence.
+- Markers are only read when the mount's strategy is `marker` (the
+  default). Central entries are explicit instructions and apply under
+  `per-file` too.
 
 ## `.yuiignore` — exclude paths from being linked
 

--- a/src/cmd/absorb.rs
+++ b/src/cmd/absorb.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::config::{self, Config};
 use crate::link::{resolve_dir_mode, resolve_file_mode};
-use crate::marker::{self, MarkerSpec};
+use crate::links::LinkPlan;
 use crate::paths;
 use crate::template;
 use crate::vars::YuiVars;
@@ -76,11 +76,13 @@ pub fn absorb(
     }
 
     let backup_root = source.join(&config.backup.dir);
+    let plan = LinkPlan::from_config(&source, &config.link)?;
     let ctx = ApplyCtx {
         config: &config,
         source: &source,
-        file_mode: resolve_file_mode(config.link.file_mode),
-        dir_mode: resolve_dir_mode(config.link.dir_mode),
+        plan: &plan,
+        file_mode: resolve_file_mode(config.mount.file_mode),
+        dir_mode: resolve_dir_mode(config.mount.dir_mode),
         backup_root: &backup_root,
         dry_run: false,
         sticky_anomaly: Cell::new(None),
@@ -199,9 +201,9 @@ fn prompt_yes_no(question: &str) -> Result<bool> {
     Ok(answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes"))
 }
 
-/// Walk mount entries + `.yuilink` Override markers to find the source
-/// file/dir that the given target maps back to. Returns `None` when no
-/// mount or marker claims the path.
+/// Walk mount entries + every `[[link]]` declaration (central table and
+/// `.yuilink` markers) to find the source file/dir that the given target
+/// maps back to. Returns `None` when nothing claims the path.
 fn find_source_for_target(
     source: &Utf8Path,
     config: &Config,
@@ -245,40 +247,16 @@ fn find_source_for_target(
         }
     }
 
-    // 2. `.yuilink` Override markers — walk source, parse, render each
-    //    `[[link]] dst`, see if target is the rendered dst (or nested
-    //    inside a junction'd dir). `source_walker` skips `.yui/` and
-    //    honours nested `.yuiignore` files automatically, so markers
-    //    inside ignored subtrees never reach this loop.
-    let walker = paths::source_walker(source).build();
+    // 2. `[[link]]` declarations — render each `dst`, see if target is
+    //    that dst (or nested inside a junction'd dir). Marker discovery
+    //    goes through `source_walker`, which skips `.yui/` and honours
+    //    nested `.yuiignore` files, so declarations under ignored
+    //    subtrees stay invisible here too.
+    let plan = LinkPlan::from_config(source, &config.link)?;
     let marker_filename = &config.mount.marker_filename;
-    for ent in walker {
-        let ent = match ent {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        if !ent.file_type().map(|t| t.is_file()).unwrap_or(false) {
-            continue;
-        }
-        if ent.path().file_name().and_then(|n| n.to_str()) != Some(marker_filename.as_str()) {
-            continue;
-        }
-        let dir = match ent.path().parent() {
-            Some(d) => d,
-            None => continue,
-        };
-        let dir_utf8 = match Utf8PathBuf::from_path_buf(dir.to_path_buf()) {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-        let spec = match marker::read_spec(&dir_utf8, marker_filename)? {
-            Some(s) => s,
-            None => continue,
-        };
-        let MarkerSpec::Explicit { links } = spec else {
-            continue;
-        };
-        for link in &links {
+    for dir in plan.declared_dirs(source, marker_filename) {
+        let spec = plan.dir_spec(&dir, marker_filename, true)?;
+        for link in &spec.links {
             if let Some(when) = &link.when {
                 if !template::eval_truthy(when, engine, tera_ctx)? {
                     continue;
@@ -286,30 +264,28 @@ fn find_source_for_target(
             }
             let dst_str = engine.render(&link.dst, tera_ctx)?;
             let dst = paths::expand_tilde(dst_str.trim());
-            // File-level entry: dst points at a single file, so a match
-            // resolves directly to `<marker-dir>/<src filename>`. Mirror
-            // the existence check that apply / status do so a missing
-            // sibling produces the same clear message regardless of
-            // entry point — consistent with the `marker at … src=… not
-            // found` shape users already see from those flows.
-            if let Some(filename) = &link.src {
-                let file_src = dir_utf8.join(filename);
+            // File-scoped entry: dst points at a single file, so a match
+            // resolves directly to `<dir>/<rel>`. Test the target first —
+            // this is a *search* over every declaration, so a stale entry
+            // elsewhere in the config must not abort the lookup for the
+            // path the user actually asked about. Once it matches, mirror
+            // the existence check apply / status do so the message shape
+            // is the same from every entry point.
+            if let Some(rel) = &link.rel {
+                if target != dst {
+                    continue;
+                }
+                let file_src = dir.join(rel);
                 if !file_src.is_file() {
-                    anyhow::bail!(
-                        "marker at {dir_utf8}: [[link]] src={filename:?} \
-                         not found"
-                    );
+                    anyhow::bail!("{} not found", link.describe(&dir));
                 }
-                if target == dst {
-                    return Ok(Some(file_src));
-                }
-                continue;
+                return Ok(Some(file_src));
             }
             if target == dst {
-                return Ok(Some(dir_utf8));
+                return Ok(Some(dir));
             }
             if let Ok(rel) = target.strip_prefix(&dst) {
-                return Ok(Some(dir_utf8.join(rel)));
+                return Ok(Some(dir.join(rel)));
             }
         }
     }

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::config::{self, Config, HookPhase, MountStrategy};
 use crate::hook;
 use crate::link::{self, EffectiveDirMode, EffectiveFileMode, resolve_dir_mode, resolve_file_mode};
-use crate::marker::{self, MarkerSpec};
+use crate::links::{self, LinkPlan};
 use crate::mount::{self, ResolvedMount};
 use crate::render::{self, RenderReport};
 use crate::secret;
@@ -94,11 +94,14 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
     )?;
 
     let backup_root = source.join(&config.backup.dir);
+    let plan = links::LinkPlan::from_config(&source, &config.link)?;
+    plan.warn_unreachable(mounts.iter().map(|m| m.src.as_path()));
     let ctx = ApplyCtx {
         config: &config,
         source: &source,
-        file_mode: resolve_file_mode(config.link.file_mode),
-        dir_mode: resolve_dir_mode(config.link.dir_mode),
+        plan: &plan,
+        file_mode: resolve_file_mode(config.mount.file_mode),
+        dir_mode: resolve_dir_mode(config.mount.dir_mode),
         backup_root: &backup_root,
         dry_run,
         sticky_anomaly: Cell::new(None),
@@ -213,6 +216,9 @@ pub(crate) struct ApplyCtx<'a> {
     pub(crate) config: &'a Config,
     /// Source repo root — needed for git-clean checks during absorb.
     pub(crate) source: &'a Utf8Path,
+    /// Central `[[link]]` declarations from `config.toml`, keyed by the
+    /// source dir the walk has to reach for them to fire.
+    pub(crate) plan: &'a LinkPlan,
     pub(crate) file_mode: EffectiveFileMode,
     pub(crate) dir_mode: EffectiveDirMode,
     pub(crate) backup_root: &'a Utf8Path,
@@ -293,58 +299,57 @@ fn walk_and_link_body(
     let marker_filename = &ctx.config.mount.marker_filename;
     let mut covered = parent_covered;
 
-    if strategy == MountStrategy::Marker {
-        match marker::read_spec(src_dir, marker_filename)? {
-            None => {} // no marker — fall through to recursive walk
-            Some(MarkerSpec::PassThrough) => {
-                // Empty marker = junction this dir at the natural
-                // mount-derived dst. Subsequent recursion keeps going so
-                // descendant markers can layer on extra dsts.
-                link_dir_with_backup(src_dir, dst_dir, ctx)?;
-                covered = true;
-            }
-            Some(MarkerSpec::Explicit { links }) => {
-                let mut emitted_dir_link = false;
-                let mut emitted_any = false;
-                for link in &links {
-                    // Nested ifs (not let-chains) so the crate's MSRV
-                    // (rust-version = "1.85") stays buildable.
-                    if let Some(when) = &link.when {
-                        if !template::eval_truthy(when, engine, tera_ctx)? {
-                            continue;
-                        }
-                    }
-                    let dst_str = engine.render(&link.dst, tera_ctx)?;
-                    let dst = paths::expand_tilde(dst_str.trim());
-                    if let Some(filename) = &link.src {
-                        let file_src = src_dir.join(filename);
-                        if !file_src.is_file() {
-                            anyhow::bail!(
-                                "marker at {src_dir}: [[link]] src={filename:?} \
-                                 not found"
-                            );
-                        }
-                        link_file_with_backup(&file_src, &dst, ctx)?;
-                    } else {
-                        link_dir_with_backup(src_dir, &dst, ctx)?;
-                        emitted_dir_link = true;
-                    }
-                    emitted_any = true;
-                }
-                if !emitted_any {
-                    // v0.6+ semantics: with no active links, the walker
-                    // still descends and per-file defaults still apply.
-                    // Phrase it so users don't read "skipping" as
-                    // "subtree blocked" (the v0.5 behaviour).
-                    info!(
-                        "marker at {src_dir} had no active links \
-                         — falling back to defaults"
-                    );
-                }
-                if emitted_dir_link {
-                    covered = true;
+    // `[[link]]` declarations for this dir: the `.yuilink` marker (only
+    // when the mount honours markers) merged with the central entries
+    // keyed here. A central entry is an explicit instruction rather than
+    // a discovered marker, so `per-file` mounts still honour it.
+    let spec = ctx
+        .plan
+        .dir_spec(src_dir, marker_filename, strategy == MountStrategy::Marker)?;
+    if spec.passthrough {
+        // Empty marker = junction this dir at the natural mount-derived
+        // dst. Subsequent recursion keeps going so descendant markers
+        // can layer on extra dsts.
+        link_dir_with_backup(src_dir, dst_dir, ctx)?;
+        covered = true;
+    }
+    if !spec.links.is_empty() {
+        let mut emitted_dir_link = false;
+        let mut emitted_any = false;
+        for link in &spec.links {
+            // Nested ifs (not let-chains) so the crate's MSRV
+            // (rust-version = "1.85") stays buildable.
+            if let Some(when) = &link.when {
+                if !template::eval_truthy(when, engine, tera_ctx)? {
+                    continue;
                 }
             }
+            let dst_str = engine.render(&link.dst, tera_ctx)?;
+            let dst = paths::expand_tilde(dst_str.trim());
+            match &link.rel {
+                Some(rel) => {
+                    let file_src = src_dir.join(rel);
+                    if !file_src.is_file() {
+                        anyhow::bail!("{} not found", link.describe(src_dir));
+                    }
+                    link_file_with_backup(&file_src, &dst, ctx)?;
+                }
+                None => {
+                    link_dir_with_backup(src_dir, &dst, ctx)?;
+                    emitted_dir_link = true;
+                }
+            }
+            emitted_any = true;
+        }
+        if !emitted_any {
+            // v0.6+ semantics: with no active links, the walker
+            // still descends and per-file defaults still apply.
+            // Phrase it so users don't read "skipping" as
+            // "subtree blocked" (the v0.5 behaviour).
+            info!("no active [[link]] for {src_dir} — falling back to defaults");
+        }
+        if emitted_dir_link {
+            covered = true;
         }
     }
 

--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::config::{self, Config, IconsMode};
 use crate::icons::Icons;
+use crate::links::LinkPlan;
 use crate::mount;
 use crate::render;
 use crate::template;
@@ -41,6 +42,7 @@ pub fn diff(
     let mut report: Vec<StatusItem> = Vec::new();
     let mut yuiignore = paths::YuiIgnoreStack::with_gitignore(config.mount.respect_gitignore);
     yuiignore.push_dir(&source)?;
+    let plan = LinkPlan::from_config(&source, &config.link)?;
     let walk_result = (|| -> Result<()> {
         for m in &mounts {
             let src_root = m.src.clone();
@@ -51,6 +53,7 @@ pub fn diff(
                 &src_root,
                 &m.dst,
                 &config,
+                &plan,
                 m.strategy,
                 &mut engine,
                 &tera_ctx,

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -173,12 +173,12 @@ const SKELETON_CONFIG: &str = r#"# yui config — see https://github.com/yukimem
 [vars]
 # user-defined values; templates can reference these as {{ vars.foo }}
 
-# [link]
-# file_mode = "auto"   # auto | symlink | hardlink
-# dir_mode  = "auto"   # auto | symlink | junction
-
 [mount]
 default_strategy = "marker"
+# How links are made. `auto` = symlink on Unix, hardlink (files) +
+# junction (dirs) on Windows, which needs no Developer Mode / admin.
+# file_mode = "auto"   # auto | symlink | hardlink
+# dir_mode  = "auto"   # auto | symlink | junction
 
 [[mount.entry]]
 src = "home"
@@ -190,6 +190,14 @@ dst = "~"
 # dst  = "{{ env(name='APPDATA') }}"
 # # NOTE: write `when` as a *bare* expression (no `{{ … }}`) so it survives
 # # config.toml's whole-file Tera render and shows up cleanly in `yui list`.
+# when = "yui.os == 'windows'"
+
+# Explicit links, declared centrally instead of with a `.yuilink`
+# marker file in the tree. `src` is relative to $DOTFILES and may name
+# a directory (linked as one unit) or a single file.
+# [[link]]
+# src = "home/.config/nvim"
+# dst = "{{ env(name='LOCALAPPDATA') }}/nvim"
 # when = "yui.os == 'windows'"
 "#;
 

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::config::{self, Config, IconsMode};
 use crate::icons::Icons;
-use crate::marker::{self, MarkerSpec};
+use crate::links::LinkPlan;
 use crate::paths;
 use crate::template;
 use crate::vars::YuiVars;
@@ -83,43 +83,22 @@ fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Resu
         });
     }
 
-    // 2. .yuilink overrides under source
-    let walker = paths::source_walker(source).build();
+    // 2. `[[link]]` declarations — central entries from config.toml plus
+    //    every `.yuilink` under source. Both normalize to the same
+    //    shape, so one loop covers both.
+    let plan = LinkPlan::from_config(source, &config.link)?;
     let marker_filename = &config.mount.marker_filename;
-    for entry in walker {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+    for dir in plan.declared_dirs(source, marker_filename) {
+        let spec = plan.dir_spec(&dir, marker_filename, true)?;
+        // PassThrough markers are already implied by the mount entry.
+        if spec.links.is_empty() {
             continue;
         }
-        if entry.path().file_name().and_then(|n| n.to_str()) != Some(marker_filename.as_str()) {
-            continue;
-        }
-        let dir = match entry.path().parent() {
-            Some(d) => d,
-            None => continue,
-        };
-        let dir_utf8 = match Utf8PathBuf::from_path_buf(dir.to_path_buf()) {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-        // .yuiignore filtering happens in `source_walker` via
-        // `add_custom_ignore_filename` — markers under ignored
-        // subtrees never reach here.
-        let spec = match marker::read_spec(&dir_utf8, marker_filename)? {
-            Some(s) => s,
-            None => continue,
-        };
-        let MarkerSpec::Explicit { links } = spec else {
-            continue; // PassThrough markers are already implied by mount entry
-        };
-        let rel = dir_utf8
+        let rel = dir
             .strip_prefix(source)
             .map(Utf8PathBuf::from)
-            .unwrap_or(dir_utf8);
-        for link in &links {
+            .unwrap_or_else(|_| dir.clone());
+        for link in &spec.links {
             let active = match &link.when {
                 None => true,
                 Some(w) => template::eval_truthy(w, &mut engine, &tera_ctx)?,
@@ -128,12 +107,12 @@ fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Resu
                 .render(&link.dst, &tera_ctx)
                 .map(|s| paths::expand_tilde(s.trim()).to_string())
                 .unwrap_or_else(|_| link.dst.clone());
-            // File-level entry (`[[link]] src = "<filename>"`) targets a
-            // single file inside the marker dir; show that file path
-            // instead of the bare dir so `yui list` makes the scope
-            // obvious at a glance.
-            let src_display = match &link.src {
-                Some(filename) => rel.join(filename),
+            // File-scoped entry (`[[link]] src = "<path>"`) targets a
+            // single file inside the dir; show that file path instead of
+            // the bare dir so `yui list` makes the scope obvious at a
+            // glance.
+            let src_display = match &link.rel {
+                Some(r) => rel.join(r),
                 None => rel.clone(),
             };
             items.push(ListItem {

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::config::{self, Config, IconsMode, MountStrategy};
 use crate::icons::Icons;
-use crate::marker::{self, MarkerSpec};
+use crate::links::LinkPlan;
 use crate::mount;
 use crate::render;
 use crate::template;
@@ -94,6 +94,8 @@ pub fn status(
     // source-root layer so root rules apply from the start.
     let mut yuiignore = paths::YuiIgnoreStack::with_gitignore(config.mount.respect_gitignore);
     yuiignore.push_dir(&source)?;
+    let plan = LinkPlan::from_config(&source, &config.link)?;
+    plan.warn_unreachable(mounts.iter().map(|m| m.src.as_path()));
     let walk_result = (|| -> Result<()> {
         for m in &mounts {
             let src_root = m.src.clone();
@@ -105,6 +107,7 @@ pub fn status(
                 &src_root,
                 &m.dst,
                 &config,
+                &plan,
                 m.strategy,
                 &mut engine,
                 &tera_ctx,
@@ -168,6 +171,7 @@ pub(crate) fn classify_walk(
     src_dir: &Utf8Path,
     dst_dir: &Utf8Path,
     config: &Config,
+    plan: &LinkPlan,
     strategy: MountStrategy,
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
@@ -179,6 +183,7 @@ pub(crate) fn classify_walk(
         src_dir,
         dst_dir,
         config,
+        plan,
         strategy,
         engine,
         tera_ctx,
@@ -194,6 +199,7 @@ fn classify_walk_inner(
     src_dir: &Utf8Path,
     dst_dir: &Utf8Path,
     config: &Config,
+    plan: &LinkPlan,
     strategy: MountStrategy,
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
@@ -212,6 +218,7 @@ fn classify_walk_inner(
         src_dir,
         dst_dir,
         config,
+        plan,
         strategy,
         engine,
         tera_ctx,
@@ -229,6 +236,7 @@ fn classify_walk_inner_body(
     src_dir: &Utf8Path,
     dst_dir: &Utf8Path,
     config: &Config,
+    plan: &LinkPlan,
     strategy: MountStrategy,
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
@@ -240,56 +248,57 @@ fn classify_walk_inner_body(
     let marker_filename = &config.mount.marker_filename;
     let mut covered = parent_covered;
 
-    if strategy == MountStrategy::Marker {
-        match marker::read_spec(src_dir, marker_filename)? {
-            None => {}
-            Some(MarkerSpec::PassThrough) => {
-                let decision = absorb::classify(src_dir, dst_dir)?;
-                report.push(StatusItem {
-                    src: relative_for_display(source_root, src_dir),
-                    dst: dst_dir.to_path_buf(),
-                    state: StatusState::Link(decision),
-                });
-                covered = true;
-            }
-            Some(MarkerSpec::Explicit { links }) => {
-                let mut emitted_dir_link = false;
-                for link in &links {
-                    if let Some(when) = &link.when {
-                        if !template::eval_truthy(when, engine, tera_ctx)? {
-                            continue;
-                        }
-                    }
-                    let dst_str = engine.render(&link.dst, tera_ctx)?;
-                    let dst = paths::expand_tilde(dst_str.trim());
-                    if let Some(filename) = &link.src {
-                        let file_src = src_dir.join(filename);
-                        if !file_src.is_file() {
-                            anyhow::bail!(
-                                "marker at {src_dir}: [[link]] src={filename:?} \
-                                 not found"
-                            );
-                        }
-                        let decision = absorb::classify(&file_src, &dst)?;
-                        report.push(StatusItem {
-                            src: relative_for_display(source_root, &file_src),
-                            dst,
-                            state: StatusState::Link(decision),
-                        });
-                    } else {
-                        let decision = absorb::classify(src_dir, &dst)?;
-                        report.push(StatusItem {
-                            src: relative_for_display(source_root, src_dir),
-                            dst,
-                            state: StatusState::Link(decision),
-                        });
-                        emitted_dir_link = true;
-                    }
-                }
-                if emitted_dir_link {
-                    covered = true;
+    let spec = plan.dir_spec(src_dir, marker_filename, strategy == MountStrategy::Marker)?;
+    if spec.passthrough {
+        let decision = absorb::classify(src_dir, dst_dir)?;
+        report.push(StatusItem {
+            src: relative_for_display(source_root, src_dir),
+            dst: dst_dir.to_path_buf(),
+            state: StatusState::Link(decision),
+        });
+        covered = true;
+    }
+    if !spec.links.is_empty() {
+        let mut emitted_dir_link = false;
+        for link in &spec.links {
+            if let Some(when) = &link.when {
+                if !template::eval_truthy(when, engine, tera_ctx)? {
+                    continue;
                 }
             }
+            let dst_str = engine.render(&link.dst, tera_ctx)?;
+            let dst = paths::expand_tilde(dst_str.trim());
+            match &link.rel {
+                Some(rel) => {
+                    let file_src = src_dir.join(rel);
+                    if !file_src.is_file() {
+                        // Resilience principle: status has to keep
+                        // reporting when apply would fail. `apply` bails
+                        // on this (it's about to write), but here one bad
+                        // declaration must not suppress every other row.
+                        warn!("{} not found", link.describe(src_dir));
+                        continue;
+                    }
+                    let decision = absorb::classify(&file_src, &dst)?;
+                    report.push(StatusItem {
+                        src: relative_for_display(source_root, &file_src),
+                        dst,
+                        state: StatusState::Link(decision),
+                    });
+                }
+                None => {
+                    let decision = absorb::classify(src_dir, &dst)?;
+                    report.push(StatusItem {
+                        src: relative_for_display(source_root, src_dir),
+                        dst,
+                        state: StatusState::Link(decision),
+                    });
+                    emitted_dir_link = true;
+                }
+            }
+        }
+        if emitted_dir_link {
+            covered = true;
         }
     }
 
@@ -313,6 +322,7 @@ fn classify_walk_inner_body(
                 &src_path,
                 &dst_path,
                 config,
+                plan,
                 strategy,
                 engine,
                 tera_ctx,

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::config::{self, Config};
 use crate::link::{resolve_dir_mode, resolve_file_mode};
+use crate::links::LinkPlan;
 use crate::render;
 use crate::secret;
 use crate::vars::YuiVars;
@@ -1556,7 +1557,7 @@ recipients = ["{}"]
 }
 
 /// `yui status` surfaces secret drift. The plaintext sibling is
-/// hardlinked into target (forced via `[link] file_mode` so Unix
+/// hardlinked into target (forced via `[mount] file_mode` so Unix
 /// runners don't fall back to symlink and dodge the scenario), so
 /// editing it keeps the link itself in-sync (same inode) — only
 /// the `.age` comparison can catch the divergence, which status
@@ -1583,7 +1584,7 @@ fn status_reports_secret_drift() {
 src = "home"
 dst = "{}"
 
-[link]
+[mount]
 file_mode = "hardlink"
 
 [secrets]
@@ -1908,6 +1909,317 @@ dst = "{}"
 
     let err = apply(Some(source.clone()), false).unwrap_err();
     assert!(format!("{err:#}").contains("missing.ps1"));
+}
+
+// -----------------------------------------------------------------
+// central [[link]] table (config.toml)
+// -----------------------------------------------------------------
+
+/// A central `[[link]]` naming a directory links it as one unit — the
+/// same result a `.yuilink` in that directory produces, without the
+/// marker file. Proof is behavioural: a file created on the target side
+/// after apply shows up in source, which only happens when the dir
+/// itself is the link (per-file links would leave the new file behind).
+#[test]
+fn central_link_links_dir_as_one_unit() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("home"));
+    std::fs::create_dir_all(source.join("home/.omp/agent")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(source.join("home/.omp/agent/config.yml"), "model: opus\n").unwrap();
+
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{0}"
+
+[[link]]
+src = "home/.omp"
+dst = "{0}/.omp"
+"#,
+        toml_path(&target)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    apply(Some(source.clone()), false).unwrap();
+
+    assert!(target.join(".omp/agent/config.yml").exists());
+    // App writes a brand-new file into the target dir → it lands in
+    // source because the directory is linked as a unit.
+    std::fs::write(target.join(".omp/sessions.json"), "[]").unwrap();
+    assert!(
+        source.join("home/.omp/sessions.json").exists(),
+        "target-side file must land in source through the dir link"
+    );
+}
+
+/// `src` may name a single file, which keys the entry on its parent
+/// directory so the rest of that directory keeps its default placement.
+#[test]
+fn central_link_targets_specific_file() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let parent_target = utf8(tmp.path().join("home"));
+    let docs_target = utf8(tmp.path().join("docs"));
+    std::fs::create_dir_all(source.join("home/.config/powershell")).unwrap();
+    std::fs::create_dir_all(&parent_target).unwrap();
+    std::fs::create_dir_all(&docs_target).unwrap();
+    std::fs::write(
+        source.join("home/.config/powershell/profile.ps1"),
+        "# profile\n",
+    )
+    .unwrap();
+    std::fs::write(source.join("home/.config/powershell/extra.txt"), "extra\n").unwrap();
+
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+
+[[link]]
+src = "home/.config/powershell/profile.ps1"
+dst = "{}/Microsoft.PowerShell_profile.ps1"
+"#,
+        toml_path(&parent_target),
+        toml_path(&docs_target)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    apply(Some(source.clone()), false).unwrap();
+
+    assert!(
+        docs_target
+            .join("Microsoft.PowerShell_profile.ps1")
+            .exists()
+    );
+    // File-level scope doesn't claim the dir, so default placement
+    // still covers every file in it.
+    assert!(
+        parent_target
+            .join(".config/powershell/profile.ps1")
+            .exists()
+    );
+    assert!(parent_target.join(".config/powershell/extra.txt").exists());
+}
+
+/// A central entry and a marker declaring different dsts stack, exactly
+/// as two markers would.
+#[test]
+fn central_link_stacks_with_marker() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let parent_target = utf8(tmp.path().join("home"));
+    let extra_target = utf8(tmp.path().join("extra"));
+    std::fs::create_dir_all(source.join("home/.config/nvim")).unwrap();
+    std::fs::create_dir_all(&parent_target).unwrap();
+    std::fs::create_dir_all(&extra_target).unwrap();
+    std::fs::write(source.join("home/.config/nvim/init.lua"), "-- cfg\n").unwrap();
+    // Marker claims the natural placement…
+    std::fs::write(source.join("home/.config/nvim/.yuilink"), "").unwrap();
+
+    // …and the central table adds an OS-specific alternate.
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+
+[[link]]
+src = "home/.config/nvim"
+dst = "{}/nvim"
+"#,
+        toml_path(&parent_target),
+        toml_path(&extra_target)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    apply(Some(source.clone()), false).unwrap();
+
+    assert!(parent_target.join(".config/nvim/init.lua").exists());
+    assert!(extra_target.join("nvim/init.lua").exists());
+}
+
+/// `default_strategy = "per-file"` turns marker discovery off, but a
+/// central entry is an explicit instruction — silently dropping it
+/// would be the worse surprise.
+#[test]
+fn central_link_applies_under_per_file_strategy() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("home"));
+    let marker_target = utf8(tmp.path().join("marker-dst"));
+    std::fs::create_dir_all(source.join("home/.omp")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(source.join("home/.omp/config.yml"), "model: opus\n").unwrap();
+    // Marker with its *own* dst, so the two declarations can't be
+    // confused for each other: if markers were read under `per-file`,
+    // `marker_target` would exist.
+    std::fs::write(
+        source.join("home/.omp/.yuilink"),
+        format!("[[link]]\ndst = \"{}\"\n", toml_path(&marker_target)),
+    )
+    .unwrap();
+
+    let cfg = format!(
+        r#"
+[mount]
+default_strategy = "per-file"
+
+[[mount.entry]]
+src = "home"
+dst = "{0}"
+
+[[link]]
+src = "home/.omp"
+dst = "{0}/.omp"
+"#,
+        toml_path(&target)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    apply(Some(source.clone()), false).unwrap();
+
+    std::fs::write(target.join(".omp/sessions.json"), "[]").unwrap();
+    assert!(
+        source.join("home/.omp/sessions.json").exists(),
+        "central entry must link the dir even when markers are off"
+    );
+    assert!(
+        !marker_target.exists(),
+        "marker dst must not be linked under per-file strategy"
+    );
+}
+
+/// A central `src` that doesn't exist fails when the walk reaches it —
+/// same point (and same message shape) as a marker's, quoting `src` as
+/// the user wrote it rather than the bare file name.
+#[test]
+fn central_link_missing_src_errors() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("home"));
+    std::fs::create_dir_all(source.join("home")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{0}"
+
+[[link]]
+src = "home/.nope"
+dst = "{0}/.nope"
+"#,
+        toml_path(&target)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    let err = apply(Some(source.clone()), false).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("home/.nope"), "got {msg}");
+    assert!(msg.contains("not found"), "got {msg}");
+}
+
+/// `when = false` + a `src` that isn't there is not an error: the entry
+/// is inactive on this host, so the walk skips it before looking at the
+/// filesystem. Same order markers use.
+#[test]
+fn central_link_inactive_entry_ignores_missing_src() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("home"));
+    std::fs::create_dir_all(source.join("home")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(source.join("home/.bashrc"), "x\n").unwrap();
+
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{0}"
+
+[[link]]
+src = "home/.nope"
+dst = "{0}/.nope"
+when = "yui.os == 'no-such-os'"
+"#,
+        toml_path(&target)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    apply(Some(source.clone()), false).unwrap();
+    assert!(target.join(".bashrc").exists());
+    assert!(!target.join(".nope").exists());
+}
+
+/// A central entry may legitimately name a file that only exists after
+/// `apply` — `*.tera` output is gitignored and rendered on demand. So
+/// `yui list` on a fresh clone must not fail just because the rendered
+/// sibling isn't there yet.
+#[test]
+fn central_link_to_rendered_output_does_not_break_list() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("home"));
+    std::fs::create_dir_all(source.join("home")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(source.join("home/.gitconfig.tera"), "[user]\nname = x\n").unwrap();
+
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{0}"
+
+[[link]]
+src = "home/.gitconfig"
+dst = "{0}/.gitconfig-alt"
+"#,
+        toml_path(&target)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    // Rendered output doesn't exist yet — listing must still work.
+    assert!(!source.join("home/.gitconfig").exists());
+    list(Some(source.clone()), false, None, true).unwrap();
+
+    // And after apply (which renders first) the link lands.
+    apply(Some(source.clone()), false).unwrap();
+    assert!(target.join(".gitconfig-alt").exists());
+}
+
+/// The pre-0.11 `[link] file_mode / dir_mode` table now collides with
+/// the `[[link]]` array. Serde's own type error says nothing about
+/// where the keys went, so `load` intercepts the old shape.
+#[test]
+fn legacy_link_mode_table_errors_with_migration_hint() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("home"));
+    std::fs::create_dir_all(source.join("home")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+
+    let cfg = format!(
+        r#"
+[link]
+file_mode = "hardlink"
+
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+        toml_path(&target)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    let err = apply(Some(source.clone()), false).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("[mount]"), "got {msg}");
+    assert!(msg.contains("file_mode"), "got {msg}");
 }
 
 // -----------------------------------------------------------------
@@ -2527,12 +2839,12 @@ fn gc_backup_prune_handles_directory_snapshot() {
 /// owns the `Config` + paths so the borrow in `ApplyCtx` is valid
 /// for the test scope. Callers can mutate the `Cell` fields in
 /// place.
-fn ctx_for_test(tmp: &TempDir) -> (Config, Utf8PathBuf, Utf8PathBuf) {
+fn ctx_for_test(tmp: &TempDir) -> (Config, Utf8PathBuf, Utf8PathBuf, LinkPlan) {
     let source = utf8(tmp.path().join("src"));
     let backup_root = source.join(".yui/backup");
     std::fs::create_dir_all(&source).unwrap();
     let cfg = Config::default();
-    (cfg, source, backup_root)
+    (cfg, source, backup_root, LinkPlan::default())
 }
 
 #[test]
@@ -2542,7 +2854,7 @@ fn prompt_anomaly_short_circuits_on_quit_requested() {
     // in-flight dir merge) returns `Quit` immediately so we don't
     // re-prompt or block on stdin during teardown.
     let tmp = TempDir::new().unwrap();
-    let (cfg, source, backup_root) = ctx_for_test(&tmp);
+    let (cfg, source, backup_root, plan) = ctx_for_test(&tmp);
     let src_file = source.join("a");
     let dst_file = utf8(tmp.path().join("dst"));
     std::fs::write(&src_file, "X").unwrap();
@@ -2551,8 +2863,9 @@ fn prompt_anomaly_short_circuits_on_quit_requested() {
     let ctx = ApplyCtx {
         config: &cfg,
         source: &source,
-        file_mode: resolve_file_mode(cfg.link.file_mode),
-        dir_mode: resolve_dir_mode(cfg.link.dir_mode),
+        plan: &plan,
+        file_mode: resolve_file_mode(cfg.mount.file_mode),
+        dir_mode: resolve_dir_mode(cfg.mount.dir_mode),
         backup_root: &backup_root,
         dry_run: false,
         sticky_anomaly: Cell::new(None),
@@ -2570,7 +2883,7 @@ fn prompt_anomaly_short_circuits_on_sticky_choice() {
     // re-prompting. We verify by pre-setting the cell and calling the
     // prompt with stdin/stderr that would otherwise prompt.
     let tmp = TempDir::new().unwrap();
-    let (cfg, source, backup_root) = ctx_for_test(&tmp);
+    let (cfg, source, backup_root, plan) = ctx_for_test(&tmp);
     let src_file = source.join("a");
     let dst_file = utf8(tmp.path().join("dst"));
     std::fs::write(&src_file, "X").unwrap();
@@ -2579,8 +2892,9 @@ fn prompt_anomaly_short_circuits_on_sticky_choice() {
     let ctx = ApplyCtx {
         config: &cfg,
         source: &source,
-        file_mode: resolve_file_mode(cfg.link.file_mode),
-        dir_mode: resolve_dir_mode(cfg.link.dir_mode),
+        plan: &plan,
+        file_mode: resolve_file_mode(cfg.mount.file_mode),
+        dir_mode: resolve_dir_mode(cfg.mount.dir_mode),
         backup_root: &backup_root,
         dry_run: false,
         sticky_anomaly: Cell::new(Some(AnomalyChoice::Overwrite)),
@@ -2598,7 +2912,7 @@ fn overwrite_source_into_target_replaces_target_and_backs_up() {
     // target's old content is preserved under backup so it is
     // recoverable.
     let tmp = TempDir::new().unwrap();
-    let (cfg, source, backup_root) = ctx_for_test(&tmp);
+    let (cfg, source, backup_root, plan) = ctx_for_test(&tmp);
     let src_file = source.join("a");
     let dst_file = utf8(tmp.path().join("dst"));
     std::fs::write(&src_file, "from source").unwrap();
@@ -2607,8 +2921,9 @@ fn overwrite_source_into_target_replaces_target_and_backs_up() {
     let ctx = ApplyCtx {
         config: &cfg,
         source: &source,
-        file_mode: resolve_file_mode(cfg.link.file_mode),
-        dir_mode: resolve_dir_mode(cfg.link.dir_mode),
+        plan: &plan,
+        file_mode: resolve_file_mode(cfg.mount.file_mode),
+        dir_mode: resolve_dir_mode(cfg.mount.dir_mode),
         backup_root: &backup_root,
         dry_run: false,
         sticky_anomaly: Cell::new(None),
@@ -2645,7 +2960,7 @@ fn link_file_with_backup_short_circuits_when_quit_requested() {
     // on_anomaly=force, which would otherwise absorb) and verify
     // nothing changed.
     let tmp = TempDir::new().unwrap();
-    let (mut cfg, source, backup_root) = ctx_for_test(&tmp);
+    let (mut cfg, source, backup_root, plan) = ctx_for_test(&tmp);
     cfg.absorb.on_anomaly = crate::config::AnomalyAction::Force;
 
     let src_file = source.join("a");
@@ -2660,8 +2975,9 @@ fn link_file_with_backup_short_circuits_when_quit_requested() {
     let ctx = ApplyCtx {
         config: &cfg,
         source: &source,
-        file_mode: resolve_file_mode(cfg.link.file_mode),
-        dir_mode: resolve_dir_mode(cfg.link.dir_mode),
+        plan: &plan,
+        file_mode: resolve_file_mode(cfg.mount.file_mode),
+        dir_mode: resolve_dir_mode(cfg.mount.dir_mode),
         backup_root: &backup_root,
         dry_run: false,
         sticky_anomaly: Cell::new(None),

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::Deserialize;
 
+use crate::links::LinkEntry;
 use crate::vars::YuiVars;
 use crate::{Error, Result, template};
 
@@ -22,8 +23,11 @@ pub struct Config {
     #[serde(default)]
     pub vars: toml::Table,
 
+    /// Central `[[link]]` table — explicit source→target declarations
+    /// that would otherwise need a `.yuilink` marker in the tree. See
+    /// [`crate::links`] for the shared schema.
     #[serde(default)]
-    pub link: LinkConfig,
+    pub link: Vec<LinkEntry>,
 
     #[serde(default)]
     pub mount: MountConfig,
@@ -246,14 +250,6 @@ pub enum IconsMode {
     Ascii,
 }
 
-#[derive(Debug, Deserialize, Default)]
-pub struct LinkConfig {
-    #[serde(default)]
-    pub file_mode: FileLinkMode,
-    #[serde(default)]
-    pub dir_mode: DirLinkMode,
-}
-
 #[derive(Debug, Deserialize, Default, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum FileLinkMode {
@@ -285,6 +281,14 @@ pub struct MountConfig {
     /// managed section is exempt — see `paths::YuiIgnoreStack`.
     #[serde(default = "default_true")]
     pub respect_gitignore: bool,
+    /// How a *file* is linked into the target: `auto` (Unix symlink /
+    /// Windows hardlink), `symlink`, or `hardlink`.
+    #[serde(default)]
+    pub file_mode: FileLinkMode,
+    /// How a *directory* is linked into the target: `auto` (Unix
+    /// symlink / Windows junction), `symlink`, or `junction`.
+    #[serde(default)]
+    pub dir_mode: DirLinkMode,
     #[serde(default)]
     pub entry: Vec<MountEntry>,
 }
@@ -295,6 +299,8 @@ impl Default for MountConfig {
             default_strategy: MountStrategy::default(),
             marker_filename: default_marker_filename(),
             respect_gitignore: true,
+            file_mode: FileLinkMode::default(),
+            dir_mode: DirLinkMode::default(),
             entry: Vec::new(),
         }
     }
@@ -552,6 +558,20 @@ pub fn load(source: &Utf8Path, yui: &YuiVars) -> Result<Config> {
             deep_merge_table(&mut vars_acc, file_vars.clone());
         }
         deep_merge_table(&mut merged, parsed);
+    }
+
+    // `[link]` used to be a single table holding `file_mode` /
+    // `dir_mode`; it is now the array-of-tables that declares links.
+    // Deserializing a table into `Vec<LinkEntry>` fails anyway, but with
+    // a serde type error that says nothing about where the keys went.
+    if let Some(toml::Value::Table(t)) = merged.get("link") {
+        return Err(Error::Config(format!(
+            "`[link]` is now the array-of-tables that declares links \
+             (`[[link]]` with src / dst / when). The link *modes* moved to \
+             `[mount]`: rewrite `[link]` {} as `[mount] file_mode` / \
+             `[mount] dir_mode`",
+            t.keys().map(String::as_str).collect::<Vec<_>>().join(" / ")
+        )));
     }
 
     let cfg: Config = toml::Value::Table(merged)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod git;
 pub mod hook;
 pub mod icons;
 pub mod link;
+pub mod links;
 pub mod marker;
 pub mod mount;
 pub mod paths;

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,0 +1,510 @@
+//! `[[link]]` — explicit source→target declarations.
+//!
+//! Two places declare them and they share one schema:
+//!
+//!   - **`$DOTFILES/config.toml`** — a central `[[link]]` table. `src`
+//!     is required and relative to `$DOTFILES`. Use this when you don't
+//!     want marker files scattered through the tree (a marker inside a
+//!     junctioned dir is also visible from the target side, which some
+//!     people would rather not ship into an app's config dir).
+//!   - **`<dir>/.yuilink`** — a marker. `src` is optional and relative
+//!     to the marker's own directory; omitting it declares the marker's
+//!     directory itself. Keeping the declaration next to the directory
+//!     means it moves and dies with that directory, which a central
+//!     table can't do — hence both, not one.
+//!
+//! Both normalize to the same shape: a list of [`DirLink`] hanging off
+//! one source directory, which is exactly what the apply / status walk
+//! consults when it arrives at that directory. Keying on the directory
+//! is what makes coverage work — a dir-scoped link at `X` means the
+//! walk must not also emit per-file links for `X`'s children.
+//!
+//! Marker discovery stays inside the walk (`dir_spec` reads the marker
+//! for the directory it is asked about), so `.yuiignore` semantics are
+//! unchanged: a marker under an ignored subtree is never read because
+//! the walk never gets there. Central entries are validated up front
+//! instead — `src` has to exist in the source tree, because a typo in
+//! the central table has no walk-time symptom to notice.
+
+use std::collections::{BTreeSet, HashMap};
+
+use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
+use serde::Deserialize;
+use tracing::warn;
+
+use crate::marker::{self, MarkerSpec};
+use crate::paths;
+use crate::{Error, Result};
+
+/// One `[[link]]` entry exactly as written by the user.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LinkEntry {
+    /// Relative path to the thing being linked. Relative to
+    /// `$DOTFILES` in `config.toml`, to the marker's directory in a
+    /// `.yuilink`. Omitted (markers only) = the marker's directory.
+    #[serde(default)]
+    pub src: Option<Utf8PathBuf>,
+    /// Target path. Tera-rendered, `~` expanded.
+    pub dst: String,
+    /// Tera expression gating the entry.
+    #[serde(default)]
+    pub when: Option<String>,
+}
+
+/// Diagnostic prefix for the central table. Every `config.toml`-sourced
+/// message starts with it, so it lives in one place.
+pub const CONFIG_LABEL: &str = "config.toml: [[link]]";
+
+/// Where an entry was declared. Error messages only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Origin {
+    Config,
+    Marker,
+}
+
+impl Origin {
+    /// Prefix for diagnostics, so a complaint says which file the user
+    /// has to go fix.
+    pub fn label(self, dir: &Utf8Path) -> String {
+        match self {
+            Self::Config => CONFIG_LABEL.to_string(),
+            Self::Marker => format!("marker at {dir}: [[link]]"),
+        }
+    }
+}
+
+/// A `[[link]]` entry resolved against the directory it hangs off.
+#[derive(Debug, Clone)]
+pub struct DirLink {
+    /// Path relative to the owning directory, or `None` when the entry
+    /// links the directory itself.
+    pub rel: Option<Utf8PathBuf>,
+    /// `src` as the user wrote it. A central entry's `rel` is only the
+    /// file name (it keys on the parent dir), so diagnostics quote this
+    /// instead — otherwise `src=.nope` would replace `src=home/.nope`.
+    pub declared: Option<Utf8PathBuf>,
+    pub dst: String,
+    pub when: Option<String>,
+    pub origin: Origin,
+}
+
+impl DirLink {
+    /// `<where declared>: [[link]] src=<as written>` — the prefix for
+    /// anything that goes wrong with this entry.
+    pub fn describe(&self, dir: &Utf8Path) -> String {
+        match &self.declared {
+            Some(src) => format!("{} src={src}", self.origin.label(dir)),
+            None => self.origin.label(dir),
+        }
+    }
+}
+
+/// Every `[[link]]` declaration that applies to one source directory.
+#[derive(Debug, Default)]
+pub struct DirSpec {
+    /// An empty (`PassThrough`) marker was present — link this
+    /// directory at the mount's natural dst.
+    pub passthrough: bool,
+    pub links: Vec<DirLink>,
+}
+
+/// Central `[[link]]` entries, keyed by the source directory the walk
+/// has to be standing in for them to fire.
+#[derive(Debug, Default)]
+pub struct LinkPlan {
+    by_dir: HashMap<Utf8PathBuf, Vec<DirLink>>,
+}
+
+impl LinkPlan {
+    /// Normalize `config.toml`'s `[[link]]` table.
+    ///
+    /// A `src` naming a directory keys on that directory itself;
+    /// anything else keys on its parent so the walk emits it while
+    /// iterating that directory's entries.
+    ///
+    /// Only the *shape* of `src` is checked here, never its existence.
+    /// Two things in the source tree don't exist until `apply` creates
+    /// them — `*.tera` output and `*.age` plaintext siblings, both
+    /// gitignored — so a load-time existence error would make `yui list`
+    /// / `status` fail on a fresh clone for a perfectly correct entry.
+    /// A `when`-gated entry has the same problem in reverse. The walk
+    /// checks existence *after* the `when` filter, exactly as it does
+    /// for markers, which is where a typo surfaces with the path
+    /// attached.
+    pub fn from_config(source: &Utf8Path, entries: &[LinkEntry]) -> Result<Self> {
+        let mut by_dir: HashMap<Utf8PathBuf, Vec<DirLink>> = HashMap::new();
+        for entry in entries {
+            let Some(src) = &entry.src else {
+                return Err(Error::Config(format!(
+                    "{CONFIG_LABEL} requires `src` (a path relative to $DOTFILES); \
+                     only a `.yuilink` may omit it (there it means \"this directory\")"
+                )));
+            };
+            validate_src(src, CONFIG_LABEL)?;
+            let abs = source.join(src);
+            let (dir, rel) = if abs.is_dir() {
+                (abs, None)
+            } else {
+                let parent = abs.parent().map(Utf8Path::to_path_buf).ok_or_else(|| {
+                    Error::Config(format!("{CONFIG_LABEL} src={src} has no parent directory"))
+                })?;
+                let name = abs.file_name().ok_or_else(|| {
+                    Error::Config(format!("{CONFIG_LABEL} src={src} has no file name"))
+                })?;
+                (parent, Some(Utf8PathBuf::from(name)))
+            };
+            by_dir.entry(dir).or_default().push(DirLink {
+                rel,
+                declared: Some(src.clone()),
+                dst: entry.dst.clone(),
+                when: entry.when.clone(),
+                origin: Origin::Config,
+            });
+        }
+        Ok(Self { by_dir })
+    }
+
+    /// Merge the `.yuilink` marker at `dir` (when the mount strategy
+    /// honours markers) with the central entries keyed at `dir`.
+    ///
+    /// Exact duplicates — same `rel`, `dst` and `when` — collapse to
+    /// one link, so declaring the same mapping centrally *and* in a
+    /// marker doesn't double up the work or the `status` / `list` rows.
+    pub fn dir_spec(
+        &self,
+        dir: &Utf8Path,
+        marker_filename: &str,
+        honor_markers: bool,
+    ) -> Result<DirSpec> {
+        let mut spec = DirSpec::default();
+        if honor_markers {
+            match marker::read_spec(dir, marker_filename)? {
+                None => {}
+                Some(MarkerSpec::PassThrough) => spec.passthrough = true,
+                Some(MarkerSpec::Explicit { links }) => {
+                    spec.links.extend(links.into_iter().map(|e| DirLink {
+                        rel: e.src.clone(),
+                        declared: e.src,
+                        dst: e.dst,
+                        when: e.when,
+                        origin: Origin::Marker,
+                    }));
+                }
+            }
+        }
+        if let Some(central) = self.by_dir.get(dir) {
+            spec.links.extend(central.iter().cloned());
+        }
+        let mut seen: BTreeSet<(Option<Utf8PathBuf>, String, Option<String>)> = BTreeSet::new();
+        spec.links
+            .retain(|l| seen.insert((l.rel.clone(), l.dst.clone(), l.when.clone())));
+        Ok(spec)
+    }
+
+    /// Every source directory carrying a `[[link]]` declaration —
+    /// central entries plus every `.yuilink` under `source`.
+    ///
+    /// For commands that don't walk mounts (`list`, `absorb`'s reverse
+    /// lookup) this is the set of directories to ask [`Self::dir_spec`]
+    /// about. `.yuiignore` / gitignore filtering comes from
+    /// [`paths::source_walker`], so markers under ignored subtrees stay
+    /// invisible here too.
+    pub fn declared_dirs(&self, source: &Utf8Path, marker_filename: &str) -> BTreeSet<Utf8PathBuf> {
+        let mut dirs: BTreeSet<Utf8PathBuf> = self.by_dir.keys().cloned().collect();
+        for ent in paths::source_walker(source).build() {
+            let Ok(ent) = ent else { continue };
+            if !ent.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                continue;
+            }
+            if ent.path().file_name().and_then(|n| n.to_str()) != Some(marker_filename) {
+                continue;
+            }
+            let Some(parent) = ent.path().parent() else {
+                continue;
+            };
+            if let Ok(p) = Utf8PathBuf::from_path_buf(parent.to_path_buf()) {
+                dirs.insert(p);
+            }
+        }
+        dirs
+    }
+
+    /// Warn about central entries no walk will ever reach.
+    ///
+    /// A central entry only fires when a mount walk arrives at its
+    /// directory. Point one outside every mount's `src` subtree and it
+    /// parses, validates, shows up in `yui list` — and silently never
+    /// links anything. That's exactly the class of mistake a central
+    /// table invites (the declaration is nowhere near the tree it talks
+    /// about), so say it out loud. A warning rather than an error per
+    /// the resilience principle: the entry may be legitimately dormant
+    /// (e.g. its subtree is `.yuiignore`d on this host), and one
+    /// questionable declaration must not take the whole run down.
+    pub fn warn_unreachable<'a>(&self, mount_roots: impl IntoIterator<Item = &'a Utf8Path>) {
+        let roots: Vec<&Utf8Path> = mount_roots.into_iter().collect();
+        for dir in self.by_dir.keys() {
+            if roots
+                .iter()
+                .any(|root| dir == *root || dir.starts_with(root))
+            {
+                continue;
+            }
+            warn!(
+                "config.toml: [[link]] under {dir} is outside every mount \
+                 — no walk reaches it, so it will not be linked"
+            );
+        }
+    }
+}
+
+/// `src` must stay inside the declaration's base directory: a relative
+/// path made of plain components only.
+///
+/// Rejecting `..` and absolute paths is what keeps `src` meaningful —
+/// an escaping `src` would link something the declaration's directory
+/// doesn't own, and for a marker it would silently reach outside the
+/// subtree the marker is supposed to describe.
+pub fn validate_src(src: &Utf8Path, origin_label: &str) -> Result<()> {
+    let raw = src.as_str();
+    if raw.trim().is_empty() {
+        return Err(Error::Config(format!(
+            "{origin_label} src must not be empty"
+        )));
+    }
+    let all_normal = src
+        .components()
+        .all(|c| matches!(c, Utf8Component::Normal(_)));
+    if !all_normal || src.is_absolute() {
+        return Err(Error::Config(format!(
+            "{origin_label} src must be a relative path inside the declaring \
+             directory (no `.`/`..`, no absolute paths), got {raw:?}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn root(tmp: &TempDir) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap()
+    }
+
+    fn entry(src: &str, dst: &str) -> LinkEntry {
+        LinkEntry {
+            src: Some(Utf8PathBuf::from(src)),
+            dst: dst.to_string(),
+            when: None,
+        }
+    }
+
+    #[test]
+    fn config_dir_entry_keys_on_the_directory_itself() {
+        let tmp = TempDir::new().unwrap();
+        let source = root(&tmp);
+        std::fs::create_dir_all(source.join("home/.omp")).unwrap();
+        let plan = LinkPlan::from_config(&source, &[entry("home/.omp", "/t/.omp")]).unwrap();
+
+        let spec = plan
+            .dir_spec(&source.join("home/.omp"), ".yuilink", true)
+            .unwrap();
+        assert_eq!(spec.links.len(), 1);
+        assert!(spec.links[0].rel.is_none(), "dir-scoped entry has no rel");
+        assert_eq!(spec.links[0].dst, "/t/.omp");
+
+        // Nothing hangs off the parent — coverage must not leak upward.
+        let parent = plan
+            .dir_spec(&source.join("home"), ".yuilink", true)
+            .unwrap();
+        assert!(parent.links.is_empty());
+    }
+
+    #[test]
+    fn config_file_entry_keys_on_the_parent_dir() {
+        let tmp = TempDir::new().unwrap();
+        let source = root(&tmp);
+        std::fs::create_dir_all(source.join("home/.config/powershell")).unwrap();
+        std::fs::write(source.join("home/.config/powershell/profile.ps1"), "x").unwrap();
+        let plan = LinkPlan::from_config(
+            &source,
+            &[entry("home/.config/powershell/profile.ps1", "/t/p.ps1")],
+        )
+        .unwrap();
+
+        let spec = plan
+            .dir_spec(&source.join("home/.config/powershell"), ".yuilink", true)
+            .unwrap();
+        assert_eq!(spec.links.len(), 1);
+        assert_eq!(
+            spec.links[0].rel.as_deref(),
+            Some(Utf8Path::new("profile.ps1"))
+        );
+    }
+
+    #[test]
+    fn config_entry_without_src_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let err = LinkPlan::from_config(
+            &root(&tmp),
+            &[LinkEntry {
+                src: None,
+                dst: "/t".to_string(),
+                when: None,
+            }],
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("requires `src`"));
+    }
+
+    /// A `src` that doesn't exist yet is not a load-time error: `*.tera`
+    /// output and `*.age` plaintext siblings only appear once `apply`
+    /// runs, so `list` / `status` on a fresh clone must not blow up. It
+    /// keys on the parent as a file entry, and the walk reports it after
+    /// the `when` filter — with the path as written.
+    #[test]
+    fn config_entry_with_missing_src_keys_on_parent() {
+        let tmp = TempDir::new().unwrap();
+        let source = root(&tmp);
+        std::fs::create_dir_all(source.join("home")).unwrap();
+        let plan =
+            LinkPlan::from_config(&source, &[entry("home/.gitconfig", "/t/.gitconfig")]).unwrap();
+
+        let spec = plan
+            .dir_spec(&source.join("home"), ".yuilink", true)
+            .unwrap();
+        assert_eq!(spec.links.len(), 1);
+        assert_eq!(
+            spec.links[0].rel.as_deref(),
+            Some(Utf8Path::new(".gitconfig"))
+        );
+        // Diagnostics quote `src` as written, not the bare file name.
+        assert_eq!(
+            spec.links[0].describe(&source.join("home")),
+            "config.toml: [[link]] src=home/.gitconfig"
+        );
+    }
+
+    #[test]
+    fn escaping_src_is_rejected() {
+        for bad in ["..", "../outside", "home/../../etc", ".", "/abs/path"] {
+            let err = validate_src(Utf8Path::new(bad), "test: [[link]]").unwrap_err();
+            assert!(
+                format!("{err}").contains("relative path"),
+                "expected rejection for {bad:?}, got {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn nested_relative_src_is_accepted() {
+        validate_src(Utf8Path::new("sub/dir/file.txt"), "test: [[link]]").unwrap();
+    }
+
+    /// Same mapping declared centrally and in a marker → one link, not
+    /// two. Without this, `status` reports the identical pair twice.
+    #[test]
+    fn identical_central_and_marker_entries_collapse() {
+        let tmp = TempDir::new().unwrap();
+        let source = root(&tmp);
+        std::fs::create_dir_all(source.join("home/.omp")).unwrap();
+        std::fs::write(
+            source.join("home/.omp/.yuilink"),
+            "[[link]]\ndst = \"/t/.omp\"\n",
+        )
+        .unwrap();
+        let plan = LinkPlan::from_config(&source, &[entry("home/.omp", "/t/.omp")]).unwrap();
+
+        let spec = plan
+            .dir_spec(&source.join("home/.omp"), ".yuilink", true)
+            .unwrap();
+        assert_eq!(spec.links.len(), 1, "duplicate declarations collapse");
+    }
+
+    /// Differing dsts stack — that's the documented marker behaviour and
+    /// central entries join it rather than replacing it.
+    #[test]
+    fn differing_central_and_marker_entries_stack() {
+        let tmp = TempDir::new().unwrap();
+        let source = root(&tmp);
+        std::fs::create_dir_all(source.join("home/.config/nvim")).unwrap();
+        std::fs::write(
+            source.join("home/.config/nvim/.yuilink"),
+            "[[link]]\ndst = \"/local/nvim\"\n",
+        )
+        .unwrap();
+        let plan = LinkPlan::from_config(&source, &[entry("home/.config/nvim", "/t/.config/nvim")])
+            .unwrap();
+
+        let spec = plan
+            .dir_spec(&source.join("home/.config/nvim"), ".yuilink", true)
+            .unwrap();
+        assert_eq!(spec.links.len(), 2);
+    }
+
+    /// `per-file` mounts ignore markers; a central entry is an explicit
+    /// instruction and still applies.
+    #[test]
+    fn markers_can_be_skipped_while_central_entries_remain() {
+        let tmp = TempDir::new().unwrap();
+        let source = root(&tmp);
+        std::fs::create_dir_all(source.join("home/.omp")).unwrap();
+        std::fs::write(source.join("home/.omp/.yuilink"), "").unwrap();
+        let plan = LinkPlan::from_config(&source, &[entry("home/.omp", "/t/.omp")]).unwrap();
+
+        let spec = plan
+            .dir_spec(&source.join("home/.omp"), ".yuilink", false)
+            .unwrap();
+        assert!(!spec.passthrough, "marker ignored when honor_markers=false");
+        assert_eq!(spec.links.len(), 1, "central entry still applies");
+    }
+
+    #[test]
+    fn declared_dirs_unions_markers_and_central_entries() {
+        let tmp = TempDir::new().unwrap();
+        let source = root(&tmp);
+        std::fs::create_dir_all(source.join("home/.config/nvim")).unwrap();
+        std::fs::create_dir_all(source.join("home/.omp")).unwrap();
+        std::fs::write(source.join("home/.config/nvim/.yuilink"), "").unwrap();
+        let plan = LinkPlan::from_config(&source, &[entry("home/.omp", "/t/.omp")]).unwrap();
+
+        let dirs = plan.declared_dirs(&source, ".yuilink");
+        assert!(dirs.contains(&source.join("home/.config/nvim")));
+        assert!(dirs.contains(&source.join("home/.omp")));
+        assert_eq!(dirs.len(), 2);
+    }
+
+    /// A central entry outside every mount subtree parses fine but no
+    /// walk reaches it. `warn_unreachable` is what tells the user; here
+    /// we pin the reachability rule it applies (`==` or descendant),
+    /// since that's the part worth regressing on.
+    #[test]
+    fn reachability_covers_the_dir_itself_and_descendants() {
+        let tmp = TempDir::new().unwrap();
+        let source = root(&tmp);
+        std::fs::create_dir_all(source.join("home/.config/nvim")).unwrap();
+        std::fs::create_dir_all(source.join("elsewhere")).unwrap();
+        let plan = LinkPlan::from_config(
+            &source,
+            &[
+                entry("home/.config/nvim", "/t/nvim"),
+                entry("elsewhere", "/t/elsewhere"),
+            ],
+        )
+        .unwrap();
+
+        let mount_root = source.join("home");
+        let reachable: Vec<&Utf8PathBuf> = plan
+            .by_dir
+            .keys()
+            .filter(|d| *d == &mount_root || d.starts_with(&mount_root))
+            .collect();
+        assert_eq!(reachable.len(), 1, "only the entry under home/ is reached");
+        assert!(reachable[0].ends_with("nvim"));
+
+        // Doesn't panic, and the unreachable one is what it complains
+        // about (message content is a log line, not a contract).
+        plan.warn_unreachable([mount_root.as_path()]);
+    }
+}

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -16,9 +16,9 @@
 //! when = "yui.os == 'windows'"
 //! ```
 //!
-//! Each `[[link]]` may carry an optional `src = "<filename>"` that scopes
-//! the link to a specific file inside the marker's directory rather than
-//! the directory itself:
+//! Each `[[link]]` may carry an optional `src` — a relative path to a
+//! file inside the marker's directory — that scopes the link to that
+//! file rather than the directory itself:
 //!
 //! ```toml
 //! # $DOTFILES/home/.config/powershell/.yuilink
@@ -27,6 +27,13 @@
 //! dst = "{{ env(name='USERPROFILE') }}/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"
 //! when = "yui.os == 'windows'"
 //! ```
+//!
+//! `src` may descend (`src = "sub/profile.ps1"`) but never escape: `..`
+//! and absolute paths are rejected, and a `src` naming a *directory* is
+//! rejected too — directory scope is what the marker itself means, so
+//! put a marker in that directory or declare it in `config.toml`'s
+//! central `[[link]]` table (see [`crate::links`], which owns the
+//! shared entry schema).
 //!
 //! Stacking semantics (v0.6+): a marker no longer stops the walker. The
 //! walker keeps descending past markers and aggregates link entries from
@@ -43,15 +50,16 @@
 //!   - **Directory-scoped `[[link]]`** (no `src`) — fully defines the
 //!     directory's placement. The parent mount's natural dst is *not*
 //!     implied; only what's listed here is linked at this dir.
-//!   - **File-scoped `[[link]]`** (with `src = "<filename>"`) — applies
-//!     only to the named sibling file. It does *not* claim
-//!     directory-level coverage, so per-file defaults from the parent
-//!     mount still apply to the rest of the dir (and to the same file
-//!     too, in addition to the explicit dst).
+//!   - **File-scoped `[[link]]`** (with `src`) — applies only to the
+//!     named file. It does *not* claim directory-level coverage, so
+//!     per-file defaults from the parent mount still apply to the rest
+//!     of the dir (and to the same file too, in addition to the
+//!     explicit dst).
 
 use camino::Utf8Path;
 use serde::Deserialize;
 
+use crate::links::{self, LinkEntry};
 use crate::{Error, Result};
 
 #[derive(Debug, Clone)]
@@ -60,26 +68,13 @@ pub enum MarkerSpec {
     PassThrough,
     /// Explicit links. Each entry maps the marker's directory (or a
     /// specific file inside it via `src`) to a destination.
-    Explicit { links: Vec<MarkerLink> },
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct MarkerLink {
-    /// Optional file scope. When set, this entry links the file at
-    /// `<marker-dir>/<src>` to `dst` instead of the directory itself.
-    /// Must be a single component (no path separators) so it stays a
-    /// sibling file of the marker.
-    #[serde(default)]
-    pub src: Option<String>,
-    pub dst: String,
-    #[serde(default)]
-    pub when: Option<String>,
+    Explicit { links: Vec<LinkEntry> },
 }
 
 #[derive(Deserialize)]
 struct MarkerFile {
     #[serde(default)]
-    link: Vec<MarkerLink>,
+    link: Vec<LinkEntry>,
 }
 
 /// Read and parse a `.yuilink` from `dir`.
@@ -106,18 +101,15 @@ pub fn read_spec(dir: &Utf8Path, marker_filename: &str) -> Result<Option<MarkerS
     }
     for link in &parsed.link {
         if let Some(src) = &link.src {
-            // Reject anything that isn't a plain sibling file. `.` /
-            // `..` would point at the marker dir itself or its parent,
-            // and path separators would let the entry escape the dir
-            // entirely — neither matches the "single filename" promise.
-            if src.is_empty()
-                || src == "."
-                || src == ".."
-                || src.contains('/')
-                || src.contains('\\')
-            {
+            links::validate_src(src, &format!("parse {path}: [[link]]"))?;
+            // A marker's `src` scopes the entry to a file. Directory
+            // scope is what the marker itself expresses (omit `src`),
+            // so pointing one at a subdirectory would give the same dst
+            // two owners with different coverage rules. Say so instead.
+            if dir.join(src).is_dir() {
                 return Err(Error::Config(format!(
-                    "parse {path}: [[link]] src must be a single filename (no path separators or `.`/`..`), got {src:?}"
+                    "parse {path}: [[link]] src={src} is a directory — put a \
+                     {marker_filename} in it, or declare it as a [[link]] in config.toml"
                 )));
             }
         }
@@ -214,7 +206,7 @@ when = "yui.os == 'windows'"
         match spec {
             MarkerSpec::Explicit { links } => {
                 assert_eq!(links.len(), 1);
-                assert_eq!(links[0].src.as_deref(), Some("profile.ps1"));
+                assert_eq!(links[0].src.as_deref(), Some(Utf8Path::new("profile.ps1")));
                 assert_eq!(
                     links[0].dst,
                     "~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"
@@ -224,8 +216,10 @@ when = "yui.os == 'windows'"
         }
     }
 
+    /// v0.11+: `src` may descend into a subdirectory. It only has to
+    /// stay inside the marker's directory.
     #[test]
-    fn marker_src_with_path_separator_errors() {
+    fn marker_src_with_path_separator_parses() {
         let tmp = TempDir::new().unwrap();
         std::fs::write(
             tmp.path().join(".yuilink"),
@@ -236,15 +230,21 @@ dst = "/anywhere"
 "#,
         )
         .unwrap();
-        let err = read_spec(&root(&tmp), ".yuilink").unwrap_err();
-        assert!(format!("{err}").contains("single filename"));
+        let spec = read_spec(&root(&tmp), ".yuilink").unwrap().unwrap();
+        match spec {
+            MarkerSpec::Explicit { links } => {
+                assert_eq!(links[0].src.as_deref(), Some(Utf8Path::new("sub/file.txt")));
+            }
+            _ => panic!("expected Explicit"),
+        }
     }
 
     #[test]
-    fn marker_src_dot_or_dotdot_errors() {
-        // `.` / `..` would silently escape the marker dir or point at
-        // the dir itself; neither is what `[[link]] src` is for.
-        for bad in [".", ".."] {
+    fn marker_src_escaping_the_dir_errors() {
+        // `.` points at the marker dir itself (that's what omitting
+        // `src` means) and `..` / absolute paths leave the subtree the
+        // marker is supposed to describe.
+        for bad in [".", "..", "../outside.txt"] {
             let tmp = TempDir::new().unwrap();
             std::fs::write(
                 tmp.path().join(".yuilink"),
@@ -259,10 +259,25 @@ dst = "/anywhere"
             .unwrap();
             let err = read_spec(&root(&tmp), ".yuilink").unwrap_err();
             assert!(
-                format!("{err}").contains("single filename"),
+                format!("{err}").contains("relative path"),
                 "expected rejection for src = {bad:?}, got {err}"
             );
         }
+    }
+
+    /// Directory scope is what the marker itself expresses, so a `src`
+    /// naming a subdirectory is a config bug with a clear fix.
+    #[test]
+    fn marker_src_naming_a_directory_errors() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join("nvim")).unwrap();
+        std::fs::write(
+            tmp.path().join(".yuilink"),
+            "[[link]]\nsrc = \"nvim\"\ndst = \"/anywhere\"\n",
+        )
+        .unwrap();
+        let err = read_spec(&root(&tmp), ".yuilink").unwrap_err();
+        assert!(format!("{err}").contains("is a directory"), "got {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Why

Directory-level linking could only be declared by putting a `.yuilink` marker in the directory itself. Two problems with that being the *only* way:

- The marker has to live in the tree, and because the directory is exposed to the target as one unit, the marker is visible from the app's own config dir too (`~/.omp/.yuilink`, `~/.config/.yuilink`). The per-file path skips the marker (`apply.rs`'s walk ignores `marker_filename`); a dir link structurally can't.
- `[[mount.entry]]` looks like an alternative but isn't. It only opens a new dst *root*, so `src = "home/.omp"` / `dst = "~/.omp"` under an existing `home` → `~` mount emits no link of its own (the first walk already claimed those paths) and only duplicates the `list` / `status` rows. Verified before writing this: the entry logs `mount:` and then nothing, and `status` prints the same pair twice.

Writing `[[link]]` in `config.toml` was also *almost* possible already — it parsed as the old `[link]` mode table and failed with `wanted exactly 1 element, more than 1 element in \`link\``, which tells the user nothing.

## What

- **New `links` module** — one `LinkEntry` schema (`src` / `dst` / `when`) shared by `config.toml`'s central `[[link]]` table and `.yuilink` markers. Both normalize into a `LinkPlan` keyed by the source directory the walk has to reach for an entry to fire, which is what makes coverage (`covered`) work uniformly. `apply`, `status`, `list`, `diff` and `absorb`'s reverse lookup all go through `LinkPlan::dir_spec` now instead of each re-implementing the marker branch.
- **`src` grammar unified** — a relative path that must stay inside its base (`..`, absolute paths and `.` rejected). Markers previously accepted a single filename only; subdirectories now work (`src = "sub/profile.ps1"`).
  - central `src` is required, may name a file **or** a directory, and must exist — a typo in the central table has no walk-time symptom, so it fails at load.
  - marker `src` must name a file. Directory scope is what the marker itself expresses, so pointing one at a subdirectory errors with the fix in the message.
- **Duplicates collapse** — the same `src` / `dst` / `when` declared centrally *and* in a marker becomes one link instead of two identical rows.
- **Strategy gating** — marker discovery stays gated on `MountStrategy::Marker`; a central entry is an explicit instruction, so it also applies under `per-file`.

## Breaking change

`[link] file_mode / dir_mode` → `[mount] file_mode / dir_mode`. The `link` key is now the array-of-tables.

`config::load` intercepts the old table shape before serde does, so the error names the new location instead of complaining about a sequence:

```
Error: config: `[link]` is now the array-of-tables that declares links (`[[link]]` with
src / dst / when). The link *modes* moved to `[mount]`: rewrite `[link]` file_mode as
`[mount] file_mode` / `[mount] dir_mode`
```

## Verification

`cargo make check` green (fmt + clippy + 228 tests + lock-check). New coverage: 10 unit tests in `links`, 3 reworked marker parser tests, 6 integration tests in `cmd::tests` (dir-as-one-unit, file scope, stacking with a marker, `per-file` strategy, missing `src`, legacy table migration).

Smoke-tested against a scratch dotfiles repo on Windows — central entry only, no marker:

```
INFO modes: file=Hardlink dir=Junction
INFO link dir: …\src\home\.omp → …/target/.omp

# atomic save (tmp + rename) on the target side:
src now: model: sonnet          # landed in source — the dir link held
status:  [+] in-sync  home/.omp -> …/target/.omp     (1 entry, no duplicate row)
list:    home       -> …/target        (always)
         home/.omp  -> …/target/.omp   (always)
```

The dir-as-one-unit integration test asserts this behaviourally rather than by poking at reparse points: it writes a new file into the target after apply and requires it to appear in source.

## Follow-up

Per-entry `mode` override (`[[link]] mode = "symlink"`) is filed separately as #232 — the schema here is what it hangs off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable file and directory links using `[[link]]` declarations.
  * Supports central and marker-based links, conditional destinations, file-scoped links, directory links, passthroughs, and duplicate collapsing.
  * Added configurable file and directory mount modes, including platform-specific defaults.
* **Bug Fixes**
  * Improved validation for invalid paths, missing sources, and unsupported directory targets.
  * Added clear migration guidance for legacy `[link]` configurations.
* **Documentation**
  * Updated the README, generated configuration, and contributor guidance with the new link syntax and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->