### PR TITLE
chore: release v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."


### PR DESCRIPTION
Minor bump for the breaking config change in #233.

`[link] file_mode / dir_mode` → `[mount] file_mode / dir_mode`; `[[link]]` is now the central table that declares links. Pre-0.11 configs carrying the old `[link]` table fail with a migration error naming the new location, so nobody silently falls back to default modes.

Version-bump-only PR (`package.version` + `Cargo.lock`), so it skips the bot-review gate per AGENTS.md.