### PR TITLE
fix: stage dir absorb aside instead of deleting the target in place

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,28 @@ before reverting any of them.
   - source newer + content differs → anomaly, diff + ask (or skip/force per `[absorb] on_anomaly`)
   - source repo dirty (uncommitted) and `require_clean_git=true` → escalate "auto-absorb" to "ask"
   - target missing → restore from source
+- **Dir-level relinks stage the target aside; they never delete in
+  place.** `absorb_target_dir_into_source` /
+  `overwrite_source_dir_into_target` rename the target to a sibling
+  (`<name>.yui-absorb.<ts>` / `<name>.yui-discard.<ts>`), put the link
+  up immediately, and only then merge / `remove_dir_all` the staged
+  tree. Rationale: `remove_dir_all` on a real `~/.config` is O(tree)
+  and non-atomic, so the old "merge → delete → link" order left a
+  half-deleted target and no link if it was interrupted. Sibling
+  placement is mandatory — `rename` is only atomic within one volume,
+  which is also why the staging dir is not under `.yui/backup/`.
+  A refused rename (open handles on Windows) warns and falls back to
+  the in-place teardown.
+- **The staging name is the crash journal.** `Absorb` means "content
+  may not have reached source yet → merge, then delete"; `Discard`
+  means "already in `.yui/backup/` → delete unread". Each invariant is
+  established by the rename itself (the overwrite path backs up
+  *before* staging precisely so `Discard` holds), so recovery needs no
+  state file. `recover_staged` runs at the top of
+  `link_dir_with_backup`, **before `absorb::classify`** — a recovered
+  target reads `InSync`, so classifying first would strand the
+  leftover. Recovery is idempotent: re-merging an already-merged tree
+  is per-file content-classified, hence a no-op.
 - **backup path scheme**: mirror absolute target into
   `$DOTFILES/.yui/backup/<abs-path>` with the drive colon stripped on
   Windows (`C:\…` → `C/…`), then suffix the basename with the timestamp.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,27 @@ marker is consent for the *whole-tree* merge, but a single file
 where the source side is newer is still a real anomaly worth
 surfacing.
 
+A whole-directory absorb is ordered for crash safety, which matters
+once the tree is a real `~/.config`. The target is moved aside with a
+single same-volume rename, the link goes up immediately, and only then
+does the slow work — merging content into source, deleting the moved
+tree — run against the staged copy. So the expensive steps happen
+while the live path already resolves to source: pull the power in the
+middle and you are left with a working target plus a
+`<target>.yui-absorb.<timestamp>` directory beside it, never a
+half-deleted config dir.
+
+That leftover is also its own retry plan — the name says what is still
+owed, so no journal file is involved. The next `apply` sweeps it
+before doing anything else: `.yui-absorb.` trees are merged into
+source and then removed (they may hold the only copy of a target-side
+edit), `.yui-discard.` trees are removed unread (their content already
+reached `$DOTFILES/.yui/backup/` before the rename). Recovery runs
+ahead of the classifier on purpose — a relinked target reads `InSync`,
+so classification alone would walk right past the leftover. If the
+rename itself is refused — a file held open inside the tree on
+Windows, say — `yui` warns and falls back to deleting in place.
+
 ## Install
 
 ```sh

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -1214,7 +1214,7 @@ fn unstage(staged: &Utf8Path, dst: &Utf8Path) -> Result<()> {
 /// content-classified per file, so re-running it over an
 /// already-merged tree is a no-op rather than a second overwrite.
 fn recover_staged(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>) -> Result<()> {
-    for (staged, kind) in paths::scan_staged(dst)? {
+    for (staged, kind) in paths::scan_staged(dst) {
         if ctx.dry_run {
             info!("[dry-run] finish interrupted {kind:?} staging: {staged}");
             continue;

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -1160,14 +1160,20 @@ fn merge_resolve_file_conflict(
 /// *working* target plus a directory that says what it still owes,
 /// rather than a half-deleted tree and no link.
 ///
-/// `Ok(None)` means `dst` was already gone; the caller just links.
-/// `Err` means the rename was refused — open handles inside the tree
-/// on Windows, a mount point in the way, permissions. That is not
-/// fatal: callers warn and fall back to the in-place teardown, which
-/// is exactly what yui did before staging existed.
+/// `Ok(None)` means `dst` was genuinely absent; the caller just links.
+/// `Err` means we could not stage: the rename was refused (open
+/// handles inside the tree on Windows, a mount point in the way,
+/// permissions), or `dst` could not even be stat'd. Neither is fatal
+/// — callers warn and fall back to the in-place teardown, which is
+/// exactly what yui did before staging existed. What we must not do
+/// is treat an unreadable-but-present `dst` as absent: that skips the
+/// backup and the merge, and hands the caller a `link_dir` that fails
+/// with "already exists" instead of the real cause.
 fn stage_aside(dst: &Utf8Path, kind: paths::StagedKind) -> Result<Option<Utf8PathBuf>> {
-    if std::fs::symlink_metadata(dst).is_err() {
-        return Ok(None);
+    match std::fs::symlink_metadata(dst) {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(anyhow::Error::new(e).context(format!("stat {dst} before staging"))),
     }
     let ts = backup::current_timestamp("%Y%m%d_%H%M%S%3f")?;
     let staged = paths::staged_path(dst, kind, &ts)

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -833,9 +833,22 @@ fn source_repo_is_clean(source: &Utf8Path) -> bool {
     }
 }
 
-fn link_dir_with_backup(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>) -> Result<()> {
+pub(crate) fn link_dir_with_backup(
+    src: &Utf8Path,
+    dst: &Utf8Path,
+    ctx: &ApplyCtx<'_>,
+) -> Result<()> {
     use absorb::AbsorbDecision::*;
 
+    if ctx.quit_requested.get() {
+        return Ok(());
+    }
+
+    // Finish any staging left by an interrupted run before classifying.
+    // Order matters: a recovered target reads `InSync`, so classify
+    // would walk away and strand target-side content that never made
+    // it into source.
+    recover_staged(src, dst, ctx)?;
     if ctx.quit_requested.get() {
         return Ok(());
     }
@@ -1136,12 +1149,114 @@ fn merge_resolve_file_conflict(
     }
 }
 
+/// Rename `dst` out of the way to a sibling staging directory.
+///
+/// This is the atomic half of a dir-level relink. A same-volume rename
+/// is one metadata operation, so the live path stops pointing at the
+/// old tree in a single step instead of being carved out entry by
+/// entry by `remove_dir_all`. Callers put the link up immediately
+/// afterwards and only then run the slow work (merge, recursive
+/// delete) against the staging name — so an interrupted run leaves a
+/// *working* target plus a directory that says what it still owes,
+/// rather than a half-deleted tree and no link.
+///
+/// `Ok(None)` means `dst` was already gone; the caller just links.
+/// `Err` means the rename was refused — open handles inside the tree
+/// on Windows, a mount point in the way, permissions. That is not
+/// fatal: callers warn and fall back to the in-place teardown, which
+/// is exactly what yui did before staging existed.
+fn stage_aside(dst: &Utf8Path, kind: paths::StagedKind) -> Result<Option<Utf8PathBuf>> {
+    if std::fs::symlink_metadata(dst).is_err() {
+        return Ok(None);
+    }
+    let ts = backup::current_timestamp("%Y%m%d_%H%M%S%3f")?;
+    let staged = paths::staged_path(dst, kind, &ts)
+        .with_context(|| format!("cannot derive a staging name for {dst}"))?;
+    std::fs::rename(dst, &staged).with_context(|| format!("stage aside {dst} → {staged}"))?;
+    Ok(Some(staged))
+}
+
+/// Delete a staged tree.
+///
+/// Failure is a warning, never an error: by the time we get here the
+/// content is already reflected in source (`Absorb`) or in
+/// `.yui/backup/` (`Discard`), so a leftover directory is litter, not
+/// data loss — and `recover_staged` sweeps it on the next run.
+fn remove_staged(staged: &Utf8Path) {
+    if let Err(e) = std::fs::remove_dir_all(staged) {
+        warn!("staged tree left behind at {staged} ({e}) — next apply retries the cleanup");
+    }
+}
+
+/// Undo a staging rename: drop the link we put up and move the tree
+/// back to the live path. Used when the user quits mid-merge, so the
+/// target ends up as the real directory it was before apply touched
+/// it instead of a link to a half-merged source.
+fn unstage(staged: &Utf8Path, dst: &Utf8Path) -> Result<()> {
+    link::unlink(dst).with_context(|| format!("remove {dst} before restoring {staged}"))?;
+    std::fs::rename(staged, dst).with_context(|| format!("restore {staged} → {dst}"))?;
+    Ok(())
+}
+
+/// Finish whatever a previous interrupted run left staged next to
+/// `dst`. Runs *before* `absorb::classify` because the leftover is
+/// invisible to it: once the link is up the target reads `InSync`,
+/// and a staged `Absorb` tree may still hold the only copy of a
+/// target-side edit.
+///
+/// The staging kind is the whole recovery plan — see
+/// [`paths::StagedKind`]. No journal file, no partial-state parsing:
+/// the rename that created the directory is what made its invariant
+/// true.
+///
+/// Source is not re-backed-up here. The interrupted run already took
+/// its snapshot before staging, and the merge below is
+/// content-classified per file, so re-running it over an
+/// already-merged tree is a no-op rather than a second overwrite.
+fn recover_staged(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>) -> Result<()> {
+    for (staged, kind) in paths::scan_staged(dst)? {
+        if ctx.dry_run {
+            info!("[dry-run] finish interrupted {kind:?} staging: {staged}");
+            continue;
+        }
+        match kind {
+            paths::StagedKind::Absorb => {
+                if !src.is_dir() {
+                    warn!(
+                        "staged tree {staged} left as-is: source dir {src} is missing, \
+                         so there is nothing to merge it into"
+                    );
+                    continue;
+                }
+                info!("resuming interrupted absorb: {staged} → {src}");
+                merge_dir_target_into_source(&staged, src, ctx)?;
+                if ctx.quit_requested.get() {
+                    warn!("recovery interrupted by user quit; {staged} kept");
+                    return Ok(());
+                }
+                remove_staged(&staged);
+            }
+            paths::StagedKind::Discard => {
+                info!("discarding staged tree from interrupted overwrite: {staged}");
+                remove_staged(&staged);
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Back up source-side, merge target's content into source (target
 /// wins on conflict), then replace target with a junction to source.
 /// "Target wins" — yui's core philosophy, generalised from the file
 /// path to whole directories so a chezmoi-style migrated `~/.config/`
 /// keeps every file the user actually had instead of stranding most
 /// of them in `.yui/backup/...`.
+///
+/// Ordering is chosen for crash safety on big trees: stage the target
+/// aside (atomic rename), put the link up (instant), *then* merge and
+/// delete. The two expensive steps therefore run while the live path
+/// already resolves to source, so losing power in the middle of a
+/// 50k-file `~/.config` costs a leftover directory, not a target.
 pub(crate) fn absorb_target_dir_into_source(
     src: &Utf8Path,
     dst: &Utf8Path,
@@ -1149,25 +1264,45 @@ pub(crate) fn absorb_target_dir_into_source(
 ) -> Result<()> {
     info!("absorb dir: {dst} → {src}");
     backup_existing(src, ctx.backup_root, /* is_dir */ true)?;
-    merge_dir_target_into_source(dst, src, ctx)?;
-    // If the user picked `[q]uit` at a prompt during the merge, do not
-    // proceed with the teardown/relink that would finish the absorb
-    // the user just asked us to abandon. `dst` keeps its (partially
-    // populated) tree intact, source has whatever content was already
-    // merged before the quit, and the source-side backup taken at the
-    // top of this function is the recovery anchor.
-    if ctx.quit_requested.get() {
-        warn!(
-            "absorb dir interrupted by user quit: {dst} \
-             — leaving target tree intact; source backup at {}",
-            ctx.backup_root
-        );
-        return Ok(());
-    }
-    // Source now carries every regular file from target. Tear down the
-    // original target dir and re-expose source via a junction.
-    remove_dir_link_or_real(dst)?;
+
+    let staged = match stage_aside(dst, paths::StagedKind::Absorb) {
+        Ok(Some(staged)) => staged,
+        // Target vanished under us between classify and now — there is
+        // nothing left to absorb, so just expose source.
+        Ok(None) => return link::link_dir(src, dst, ctx.dir_mode).map_err(Into::into),
+        Err(e) => {
+            warn!("cannot stage {dst} aside ({e:#}) — falling back to in-place teardown");
+            merge_dir_target_into_source(dst, src, ctx)?;
+            if ctx.quit_requested.get() {
+                warn!(
+                    "absorb dir interrupted by user quit: {dst} \
+                     — leaving target tree intact; source backup at {}",
+                    ctx.backup_root
+                );
+                return Ok(());
+            }
+            remove_dir_link_or_real(dst)?;
+            link::link_dir(src, dst, ctx.dir_mode)?;
+            return Ok(());
+        }
+    };
+
     link::link_dir(src, dst, ctx.dir_mode)?;
+    merge_dir_target_into_source(&staged, src, ctx)?;
+
+    // If the user picked `[q]uit` at a prompt during the merge, put the
+    // target back the way we found it rather than finishing an absorb
+    // they just asked us to abandon. The merge only reads from the
+    // staged tree (bar an explicit `[o]verwrite` choice), so what
+    // lands back at `dst` is the tree the user started with. Source
+    // keeps whatever was merged before the quit; its pre-absorb state
+    // is in the backup taken at the top of this function.
+    if ctx.quit_requested.get() {
+        warn!("absorb dir interrupted by user quit: restoring {dst}");
+        return unstage(&staged, dst);
+    }
+
+    remove_staged(&staged);
     Ok(())
 }
 
@@ -1175,6 +1310,11 @@ pub(crate) fn absorb_target_dir_into_source(
 /// content as-is, back up target's diverged content, then re-expose
 /// source via a junction at the target path. Used when the user
 /// picks `[o]verwrite` for a dir-level anomaly.
+///
+/// The backup runs *before* staging, not after. That ordering is what
+/// lets a leftover `Discard` tree be deleted unread during recovery:
+/// the rename only happens once the content is already safe in
+/// `.yui/backup/`.
 fn overwrite_source_dir_into_target(
     src: &Utf8Path,
     dst: &Utf8Path,
@@ -1182,8 +1322,18 @@ fn overwrite_source_dir_into_target(
 ) -> Result<()> {
     info!("overwrite dir: {src} → {dst}");
     backup_existing(dst, ctx.backup_root, /* is_dir */ true)?;
-    remove_dir_link_or_real(dst)?;
-    link::link_dir(src, dst, ctx.dir_mode)?;
+    match stage_aside(dst, paths::StagedKind::Discard) {
+        Ok(Some(staged)) => {
+            link::link_dir(src, dst, ctx.dir_mode)?;
+            remove_staged(&staged);
+        }
+        Ok(None) => link::link_dir(src, dst, ctx.dir_mode)?,
+        Err(e) => {
+            warn!("cannot stage {dst} aside ({e:#}) — falling back to in-place teardown");
+            remove_dir_link_or_real(dst)?;
+            link::link_dir(src, dst, ctx.dir_mode)?;
+        }
+    }
     Ok(())
 }
 

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -3026,3 +3026,155 @@ recipients = ["{public}"]
         ".gitignore should NOT contain dot component: {gi}"
     );
 }
+
+/// Build a live `ApplyCtx` for the dir-absorb staging tests. Kept
+/// separate from `ctx_for_test` because these need the borrowed
+/// pieces to outlive the call, so the caller owns the tuple.
+fn dir_absorb_fixture(tmp: &TempDir) -> (Config, Utf8PathBuf, Utf8PathBuf, LinkPlan) {
+    let (cfg, source, backup_root, plan) = ctx_for_test(tmp);
+    std::fs::create_dir_all(&backup_root).unwrap();
+    (cfg, source, backup_root, plan)
+}
+
+macro_rules! dir_ctx {
+    ($cfg:expr, $source:expr, $plan:expr, $backup_root:expr) => {
+        ApplyCtx {
+            config: &$cfg,
+            source: &$source,
+            plan: &$plan,
+            file_mode: resolve_file_mode($cfg.mount.file_mode),
+            dir_mode: resolve_dir_mode($cfg.mount.dir_mode),
+            backup_root: &$backup_root,
+            dry_run: false,
+            sticky_anomaly: Cell::new(None),
+            quit_requested: Cell::new(false),
+        }
+    };
+}
+
+#[test]
+fn absorb_dir_stages_target_aside_and_cleans_up() {
+    // The staged-aside rename is an implementation detail, but its
+    // *absence afterwards* is a contract: a completed absorb must not
+    // leave a second copy of the tree sitting next to the target.
+    let tmp = TempDir::new().unwrap();
+    let (cfg, source, backup_root, plan) = dir_absorb_fixture(&tmp);
+    let src_dir = source.join("nvim");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(src_dir.join("init.lua"), "from source").unwrap();
+
+    let dst_dir = utf8(tmp.path().join("target/nvim"));
+    std::fs::create_dir_all(dst_dir.join("lua")).unwrap();
+    std::fs::write(dst_dir.join("lua/only-in-target.lua"), "T").unwrap();
+
+    let ctx = dir_ctx!(cfg, source, plan, backup_root);
+    absorb_target_dir_into_source(&src_dir, &dst_dir, &ctx).unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(src_dir.join("lua/only-in-target.lua")).unwrap(),
+        "T",
+        "target-only content must land in source"
+    );
+    assert_eq!(
+        absorb::classify(&src_dir, &dst_dir).unwrap(),
+        absorb::AbsorbDecision::InSync,
+        "target must end up linked to source"
+    );
+    assert!(
+        paths::scan_staged(&dst_dir).unwrap().is_empty(),
+        "staging must be swept once the merge succeeded"
+    );
+}
+
+#[test]
+fn interrupted_absorb_staging_is_resumed_before_classify() {
+    // Crash window: the staging rename landed but the process died
+    // before the link went up. `dst` is missing, so `classify` would
+    // say `Restore` and link straight over the top — stranding the
+    // only copy of the user's target-side file in the staging dir.
+    // Recovery has to run first.
+    let tmp = TempDir::new().unwrap();
+    let (cfg, source, backup_root, plan) = dir_absorb_fixture(&tmp);
+    let src_dir = source.join("nvim");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(src_dir.join("init.lua"), "from source").unwrap();
+
+    let dst_dir = utf8(tmp.path().join("target/nvim"));
+    std::fs::create_dir_all(dst_dir.parent().unwrap()).unwrap();
+    let staged =
+        paths::staged_path(&dst_dir, paths::StagedKind::Absorb, "20260101_000000000").unwrap();
+    std::fs::create_dir_all(staged.join("lua")).unwrap();
+    std::fs::write(staged.join("lua/rescued.lua"), "R").unwrap();
+
+    let ctx = dir_ctx!(cfg, source, plan, backup_root);
+    link_dir_with_backup(&src_dir, &dst_dir, &ctx).unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(src_dir.join("lua/rescued.lua")).unwrap(),
+        "R",
+        "interrupted staging must be merged into source, not dropped"
+    );
+    assert!(!staged.exists(), "staging removed once merged");
+    assert_eq!(
+        absorb::classify(&src_dir, &dst_dir).unwrap(),
+        absorb::AbsorbDecision::InSync,
+        "recovery still finishes the link"
+    );
+}
+
+#[test]
+fn interrupted_overwrite_staging_is_discarded_not_merged() {
+    // The `Discard` kind means "already in .yui/backup/". Recovery
+    // must delete it unread — merging it would resurrect exactly the
+    // content the user chose to throw away.
+    let tmp = TempDir::new().unwrap();
+    let (cfg, source, backup_root, plan) = dir_absorb_fixture(&tmp);
+    let src_dir = source.join("nvim");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(src_dir.join("init.lua"), "from source").unwrap();
+
+    let dst_dir = utf8(tmp.path().join("target/nvim"));
+    std::fs::create_dir_all(dst_dir.parent().unwrap()).unwrap();
+    let staged =
+        paths::staged_path(&dst_dir, paths::StagedKind::Discard, "20260101_000000000").unwrap();
+    std::fs::create_dir_all(&staged).unwrap();
+    std::fs::write(staged.join("ghost.lua"), "G").unwrap();
+
+    let ctx = dir_ctx!(cfg, source, plan, backup_root);
+    link_dir_with_backup(&src_dir, &dst_dir, &ctx).unwrap();
+
+    assert!(!staged.exists(), "discard staging is swept");
+    assert!(
+        !src_dir.join("ghost.lua").exists(),
+        "discarded content must never reach source"
+    );
+    assert_eq!(
+        absorb::classify(&src_dir, &dst_dir).unwrap(),
+        absorb::AbsorbDecision::InSync
+    );
+}
+
+#[test]
+fn dry_run_recovery_leaves_staging_untouched() {
+    // `--dry-run` promises to write nothing. Recovery is a write, so
+    // it must only report.
+    let tmp = TempDir::new().unwrap();
+    let (cfg, source, backup_root, plan) = dir_absorb_fixture(&tmp);
+    let src_dir = source.join("nvim");
+    std::fs::create_dir_all(&src_dir).unwrap();
+
+    let dst_dir = utf8(tmp.path().join("target/nvim"));
+    std::fs::create_dir_all(dst_dir.parent().unwrap()).unwrap();
+    let staged =
+        paths::staged_path(&dst_dir, paths::StagedKind::Absorb, "20260101_000000000").unwrap();
+    std::fs::create_dir_all(&staged).unwrap();
+    std::fs::write(staged.join("kept.lua"), "K").unwrap();
+
+    let mut ctx = dir_ctx!(cfg, source, plan, backup_root);
+    ctx.dry_run = true;
+    link_dir_with_backup(&src_dir, &dst_dir, &ctx).unwrap();
+
+    assert!(staged.exists(), "dry-run must not sweep staging");
+    assert!(!src_dir.join("kept.lua").exists(), "dry-run must not merge");
+    assert!(!dst_dir.exists(), "dry-run must not link");
+}

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -3081,7 +3081,7 @@ fn absorb_dir_stages_target_aside_and_cleans_up() {
         "target must end up linked to source"
     );
     assert!(
-        paths::scan_staged(&dst_dir).unwrap().is_empty(),
+        paths::scan_staged(&dst_dir).is_empty(),
         "staging must be swept once the merge succeeded"
     );
 }

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -3178,3 +3178,50 @@ fn dry_run_recovery_leaves_staging_untouched() {
     assert!(!src_dir.join("kept.lua").exists(), "dry-run must not merge");
     assert!(!dst_dir.exists(), "dry-run must not link");
 }
+
+#[test]
+fn quit_during_dir_absorb_restores_the_target() {
+    // `[q]uit` mid-merge must not leave the user pointed at a
+    // half-merged source: `unstage` drops the link we already put up
+    // and renames the staged tree home, so the target is the real
+    // directory it was before apply touched it.
+    //
+    // Pre-setting `quit_requested` reproduces the state the prompt
+    // leaves behind — `merge_dir_target_into_source` bails at the top
+    // of its entry loop, exactly as it would after the user answered
+    // `q` on the first conflicting file. Calling
+    // `absorb_target_dir_into_source` directly is deliberate:
+    // `link_dir_with_backup` short-circuits on the same flag.
+    let tmp = TempDir::new().unwrap();
+    let (cfg, source, backup_root, plan) = dir_absorb_fixture(&tmp);
+    let src_dir = source.join("nvim");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(src_dir.join("init.lua"), "from source").unwrap();
+
+    let dst_dir = utf8(tmp.path().join("target/nvim"));
+    std::fs::create_dir_all(&dst_dir).unwrap();
+    std::fs::write(dst_dir.join("mine.lua"), "target-only").unwrap();
+
+    let mut ctx = dir_ctx!(cfg, source, plan, backup_root);
+    ctx.quit_requested = Cell::new(true);
+    absorb_target_dir_into_source(&src_dir, &dst_dir, &ctx).unwrap();
+
+    assert!(
+        paths::scan_staged(&dst_dir).is_empty(),
+        "the staged tree must be moved back, not abandoned"
+    );
+    let meta = std::fs::symlink_metadata(&dst_dir).unwrap();
+    assert!(
+        meta.file_type().is_dir() && !meta.file_type().is_symlink(),
+        "target must be a real directory again, not the link we had already put up"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dst_dir.join("mine.lua")).unwrap(),
+        "target-only",
+        "the user's target content comes back untouched"
+    );
+    assert!(
+        !src_dir.join("mine.lua").exists(),
+        "an aborted absorb must not have merged anything"
+    );
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -363,6 +363,103 @@ pub fn append_timestamp(path: &Utf8Path, ts: &str) -> Utf8PathBuf {
     parent.join(new_name)
 }
 
+/// What an interrupted run still owes a staged-aside directory.
+///
+/// A dir-level relink moves the live target out of the way with a
+/// single same-volume rename before it touches anything else. The kind
+/// is encoded *in the directory's name* on purpose: the rename is what
+/// establishes the invariant, so a leftover staging directory always
+/// carries its own recovery plan and yui needs no journal file to
+/// finish the job on the next run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StagedKind {
+    /// Content has not necessarily reached source yet — recovery MUST
+    /// merge it into source before deleting. Written by the absorb
+    /// path, where the staged tree may hold the only copy of a
+    /// target-side edit.
+    Absorb,
+    /// Content is already safe in `.yui/backup/` — recovery just
+    /// deletes. Written by the overwrite path, which takes its backup
+    /// *before* staging precisely so this holds by construction.
+    Discard,
+}
+
+impl StagedKind {
+    /// Infix separating the target's basename from the timestamp.
+    pub fn infix(self) -> &'static str {
+        match self {
+            Self::Absorb => ".yui-absorb.",
+            Self::Discard => ".yui-discard.",
+        }
+    }
+}
+
+/// Staging name for `dst`: a sibling, never a path under
+/// `.yui/backup/` or the system temp dir.
+///
+/// Sibling placement is load-bearing, not cosmetic — `rename` is only
+/// atomic and O(1) within one volume, and the whole point of staging
+/// is to replace an O(tree) `remove_dir_all` on the live path with one
+/// metadata operation.
+///
+/// `None` when `dst` has no basename or no parent (a root), in which
+/// case the caller keeps the in-place teardown.
+pub fn staged_path(dst: &Utf8Path, kind: StagedKind, ts: &str) -> Option<Utf8PathBuf> {
+    let name = dst.file_name()?;
+    let parent = dst.parent()?;
+    Some(parent.join(format!("{name}{}{ts}", kind.infix())))
+}
+
+/// Find every staging directory an interrupted run left next to `dst`,
+/// sorted by name (so same-target leftovers are recovered oldest
+/// first — the timestamp suffix makes name order time order).
+///
+/// A missing or unreadable parent yields an empty list rather than an
+/// error: recovery is a best-effort sweep in front of the real work,
+/// and a target whose parent we can't read has bigger problems that
+/// the link step itself will report.
+pub fn scan_staged(dst: &Utf8Path) -> crate::Result<Vec<(Utf8PathBuf, StagedKind)>> {
+    let (Some(parent), Some(name)) = (dst.parent(), dst.file_name()) else {
+        return Ok(Vec::new());
+    };
+    let entries = match std::fs::read_dir(parent) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e.into()),
+    };
+
+    let prefixes = [
+        (
+            format!("{name}{}", StagedKind::Absorb.infix()),
+            StagedKind::Absorb,
+        ),
+        (
+            format!("{name}{}", StagedKind::Discard.infix()),
+            StagedKind::Discard,
+        ),
+    ];
+
+    let mut found = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        let raw = entry.file_name();
+        let Some(entry_name) = raw.to_str() else {
+            continue;
+        };
+        for (prefix, kind) in &prefixes {
+            // `len() > prefix.len()` keeps a hand-made directory named
+            // exactly `<target>.yui-absorb.` (no timestamp) out of the
+            // sweep — we only claim names this code could have written.
+            if entry_name.starts_with(prefix.as_str()) && entry_name.len() > prefix.len() {
+                found.push((parent.join(entry_name), *kind));
+                break;
+            }
+        }
+    }
+    found.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(found)
+}
+
 /// Normalize a path by eliminating redundant `.` components without accessing
 /// the filesystem, preserving `..` to maintain symlink semantics.
 pub fn normalize(path: &Utf8Path) -> Utf8PathBuf {
@@ -665,5 +762,71 @@ mod tests {
         );
         assert_eq!(normalize(Utf8Path::new("./foo")), Utf8PathBuf::from("foo"));
         assert_eq!(normalize(Utf8Path::new(".")), Utf8PathBuf::from("."));
+    }
+
+    #[test]
+    fn staged_path_is_a_timestamped_sibling() {
+        // Sibling placement is the contract: same volume → the rename
+        // that creates it is atomic and O(1).
+        assert_eq!(
+            staged_path(
+                Utf8Path::new("/home/u/.config"),
+                StagedKind::Absorb,
+                "20260101_010203004"
+            ),
+            Some(Utf8PathBuf::from(
+                "/home/u/.config.yui-absorb.20260101_010203004"
+            ))
+        );
+        assert_eq!(
+            staged_path(
+                Utf8Path::new("/home/u/.config"),
+                StagedKind::Discard,
+                "20260101_010203004"
+            ),
+            Some(Utf8PathBuf::from(
+                "/home/u/.config.yui-discard.20260101_010203004"
+            ))
+        );
+    }
+
+    #[test]
+    fn scan_staged_claims_only_names_yui_could_have_written() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        let dst = root.join("nvim");
+        std::fs::create_dir_all(&dst).unwrap();
+
+        std::fs::create_dir_all(root.join("nvim.yui-absorb.20260101_000000000")).unwrap();
+        std::fs::create_dir_all(root.join("nvim.yui-discard.20260102_000000000")).unwrap();
+        // Near-misses: a bare infix with no timestamp, an unrelated
+        // name, and another target's staging. None may be swept — the
+        // sweep deletes trees, so over-matching is data loss.
+        std::fs::create_dir_all(root.join("nvim.yui-absorb.")).unwrap();
+        std::fs::create_dir_all(root.join("nvim-backup")).unwrap();
+        std::fs::create_dir_all(root.join("other.yui-absorb.20260101_000000000")).unwrap();
+
+        let got = scan_staged(&dst).unwrap();
+        assert_eq!(
+            got,
+            vec![
+                (
+                    root.join("nvim.yui-absorb.20260101_000000000"),
+                    StagedKind::Absorb
+                ),
+                (
+                    root.join("nvim.yui-discard.20260102_000000000"),
+                    StagedKind::Discard
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn scan_staged_on_missing_parent_is_empty() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        let dst = root.join("gone/nvim");
+        assert!(scan_staged(&dst).unwrap().is_empty());
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -2,6 +2,7 @@
 //! cross-platform tilde expansion.
 
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
+use tracing::warn;
 
 /// Expand a leading `~` or `~/...` to the user's home directory.
 ///
@@ -414,18 +415,25 @@ pub fn staged_path(dst: &Utf8Path, kind: StagedKind, ts: &str) -> Option<Utf8Pat
 /// sorted by name (so same-target leftovers are recovered oldest
 /// first — the timestamp suffix makes name order time order).
 ///
-/// A missing or unreadable parent yields an empty list rather than an
-/// error: recovery is a best-effort sweep in front of the real work,
-/// and a target whose parent we can't read has bigger problems that
-/// the link step itself will report.
-pub fn scan_staged(dst: &Utf8Path) -> crate::Result<Vec<(Utf8PathBuf, StagedKind)>> {
+/// Never fails. An unreadable parent — gone, permission denied, a
+/// directory entry that won't stat — yields whatever was readable
+/// instead of an error, because this is a best-effort sweep in front
+/// of the real work: aborting it would take down a `link_dir_with_backup`
+/// call that has every chance of succeeding, and a target whose parent
+/// we genuinely can't read fails again a few lines later with a much
+/// better message. Anything skipped is warned about, so a leftover
+/// that recovery could not see is still visible in the log.
+pub fn scan_staged(dst: &Utf8Path) -> Vec<(Utf8PathBuf, StagedKind)> {
     let (Some(parent), Some(name)) = (dst.parent(), dst.file_name()) else {
-        return Ok(Vec::new());
+        return Vec::new();
     };
     let entries = match std::fs::read_dir(parent) {
         Ok(e) => e,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(e) => return Err(e.into()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(e) => {
+            warn!("cannot scan {parent} for interrupted staging ({e}) — skipping recovery");
+            return Vec::new();
+        }
     };
 
     let prefixes = [
@@ -441,7 +449,13 @@ pub fn scan_staged(dst: &Utf8Path) -> crate::Result<Vec<(Utf8PathBuf, StagedKind
 
     let mut found = Vec::new();
     for entry in entries {
-        let entry = entry?;
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                warn!("skipping unreadable entry under {parent} while scanning staging ({e})");
+                continue;
+            }
+        };
         let raw = entry.file_name();
         let Some(entry_name) = raw.to_str() else {
             continue;
@@ -457,7 +471,7 @@ pub fn scan_staged(dst: &Utf8Path) -> crate::Result<Vec<(Utf8PathBuf, StagedKind
         }
     }
     found.sort_by(|a, b| a.0.cmp(&b.0));
-    Ok(found)
+    found
 }
 
 /// Normalize a path by eliminating redundant `.` components without accessing
@@ -806,7 +820,7 @@ mod tests {
         std::fs::create_dir_all(root.join("nvim-backup")).unwrap();
         std::fs::create_dir_all(root.join("other.yui-absorb.20260101_000000000")).unwrap();
 
-        let got = scan_staged(&dst).unwrap();
+        let got = scan_staged(&dst);
         assert_eq!(
             got,
             vec![
@@ -827,6 +841,6 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
         let dst = root.join("gone/nvim");
-        assert!(scan_staged(&dst).unwrap().is_empty());
+        assert!(scan_staged(&dst).is_empty());
     }
 }


### PR DESCRIPTION
## Problem

A whole-directory absorb (`absorb_target_dir_into_source`) ran in this order:

```
backup(source) → merge target → source → remove_dir_all(target) → link
```

On a real `~/.config`, `remove_dir_all` is O(tree) and non-atomic. The
target is carved out entry by entry, and the link only goes up after the
delete finishes. Interrupt that — power loss, Ctrl-C, OOM — and the user
is left with a half-deleted config directory and no link at all.
`overwrite_source_dir_into_target` had the same shape.

## Change

Reorder both dir-level paths around a same-volume rename:

```
backup(source) → rename target aside → link → merge → remove_dir_all(staged)
```

The two expensive steps now run while the live path already resolves to
source, so an interrupted run leaves a *working* target plus a leftover
sibling directory — never a half-deleted one.

Sibling placement is load-bearing, not cosmetic: `rename` is only atomic
and O(1) within a volume, which is also why the staging directory is not
under `.yui/backup/`.

`overwrite_source_dir_into_target` takes its backup *before* staging,
which is what makes the `Discard` invariant below true by construction.

## Retry: the staging name is the crash journal

No state file, no partial-state parsing. Each staging directory declares
what it still owes, and the rename that created it is what made that
true:

| leftover | meaning | recovery |
| --- | --- | --- |
| `<name>.yui-absorb.<ts>` | content may never have reached source | merge into source, then delete |
| `<name>.yui-discard.<ts>` | content is already in `.yui/backup/` | delete unread |

`recover_staged` runs at the top of `link_dir_with_backup`, **before
`absorb::classify`**. That ordering is the subtle part: once the link is
up, the target reads `InSync`, so classifying first would walk straight
past the leftover and strand target-side content that never made it into
source.

Recovery is idempotent — re-merging an already-merged tree is
content-classified per file, so it is a no-op rather than a second
overwrite. Source is not re-backed-up during recovery; the interrupted
run already took that snapshot before staging.

## Degradation and interruption

- **Rename refused** (a file held open inside the tree on Windows, a
  mount point in the way) → warn and fall back to the previous in-place
  teardown. No functional regression, just no crash-safety win.
- **`[q]uit` mid-merge** → drop the link and rename the staged tree home,
  so the target ends up as the real directory it was before apply touched
  it. Previously the target was left as-is mid-flight; this is strictly
  closer to "abort".
- **`--dry-run`** → reports leftovers, writes nothing.

## Verification

`cargo make check` green (238 tests, fmt + clippy + lock-check).

7 new unit tests: staging-name round-trip, `scan_staged` rejecting
near-miss names (over-matching would delete an unrelated tree), the three
recovery paths, and dry-run inertness.

End-to-end against the built binary on Windows, with a `[[link]]`-mounted
directory and real junctions:

| scenario | result |
| --- | --- |
| absorb a pre-existing real target dir | target-only files merged into source, junction created, zero staging litter |
| crash before the link (target missing + staging) | staging merged, junction restored |
| crash mid-merge (**link already up → `InSync`**) | `unmerged.lua` rescued — the path `classify` alone would miss |
| interrupted overwrite (discard staging) | `ghost.lua` never reaches source, staging removed |
| `--dry-run` over a leftover | staging untouched, nothing merged or linked |
| second `apply` | no-op |

## Notes

`doctor` / `status` deliberately do not report leftovers. Surfacing them
there needs mount resolution to enumerate target paths, and `apply`
already sweeps them automatically, so it would be duplicate logic for no
new signal. Easy to add later if wanted.

Docs updated: README "How it works" and the AGENTS.md design-decision
list, the latter with the rationale so nobody reverts to a bare
`remove_dir_all`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when linking or replacing whole directories, including safer handling during interruptions or failures.
  * Interrupted directory operations can now recover automatically on the next apply.
  * Failed staging attempts fall back to safe in-place cleanup.
  * Quit and dry-run operations better preserve existing files and filesystem state.

* **Documentation**
  * Added guidance on directory relinking, crash recovery, staging behavior, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->