### PR TITLE
feat(doctor): warn about directory links no [[link]] declares

### DIFF
--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -1,10 +1,15 @@
 use super::*;
-use crate::config::{self, IconsMode};
+use crate::config::{self, Config, IconsMode, MountStrategy};
 use crate::icons::Icons;
+use crate::link::{EffectiveDirMode, resolve_dir_mode};
+use crate::links::LinkPlan;
+use crate::mount;
 use crate::paths;
+use crate::template;
 use crate::vars::YuiVars;
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
+use std::collections::BTreeSet;
 
 pub fn doctor(
     source: Option<Utf8PathBuf>,
@@ -104,6 +109,15 @@ pub fn doctor(
     } else {
         probes.push(Probe::ok("default mode", "files=symlink, dirs=symlink"));
     }
+    if let (Ok(s), Some(c)) = (&resolved_source, cfg) {
+        // Resilience principle: a config yui can't fully resolve
+        // (unrenderable mount dst, bad `[[link]]` src) must not take
+        // the rest of doctor down — degrade this one probe instead.
+        match undeclared_dir_link_probes(s, c, &yui) {
+            Ok(found) => probes.extend(found),
+            Err(e) => probes.push(Probe::warn("dir links", format!("check skipped — {e}"))),
+        }
+    }
 
     // ── hooks ─────────────────────────────────────────────────
     if have_source {
@@ -185,8 +199,160 @@ pub fn doctor(
     Ok(())
 }
 
+/// Target-side directory links that no `[[link]]` declaration asks for.
+///
+/// A junction / symlink pointing back into the source tree is
+/// load-bearing: *everything* under the source directory — tracked or
+/// not — is visible from the target through it. When nothing declares
+/// it, nothing recreates it, and no other command notices: both sides
+/// resolve to the same inode *through* that very link, so
+/// [`crate::absorb::classify`] reports the files inside as `in-sync`
+/// forever. Remove the link (new machine, `yui unlink`, a manual
+/// cleanup) and `apply` faithfully rebuilds the target as a plain
+/// directory holding per-file links of only the tracked files; the
+/// rest of the source directory silently stops being visible from the
+/// target side.
+///
+/// Warn, never error: the link is not broken *now*, it is
+/// unreproducible — and doctor exists to say that before `apply` does
+/// something surprising.
+pub(crate) fn undeclared_dir_link_probes(
+    source: &Utf8Path,
+    config: &Config,
+    yui: &YuiVars,
+) -> Result<Vec<Probe>> {
+    let mut engine = template::Engine::new();
+    let tera_ctx = template::template_context(yui, &config.vars);
+    let mounts = mount::resolve(
+        source,
+        &config.mount.entry,
+        config.mount.default_strategy,
+        &mut engine,
+        &tera_ctx,
+    )?;
+    let plan = LinkPlan::from_config(source, &config.link)?;
+    let marker_filename = &config.mount.marker_filename;
+
+    // Declaration roots: `$DOTFILES` plus any mount `src` living
+    // outside it (an absolute `src` is how a separate private clone
+    // participates), so a `.yuilink` out there still counts as a
+    // declaration.
+    let mut roots: Vec<Utf8PathBuf> = vec![source.to_path_buf()];
+    for m in &mounts {
+        if !roots.iter().any(|r| m.src.starts_with(r)) {
+            roots.push(m.src.clone());
+        }
+    }
+
+    // Every target path some declaration names. Rendered and
+    // tilde-expanded exactly like the apply walk does it, so the
+    // comparison below is against the path apply would create.
+    let mut declared: BTreeSet<Utf8PathBuf> = BTreeSet::new();
+    for root in &roots {
+        for dir in plan.declared_dirs(root, marker_filename) {
+            // Markers only count where the mount honours them — same
+            // gate the apply walk applies.
+            let honor_markers = mounts
+                .iter()
+                .find(|m| dir.starts_with(&m.src))
+                .is_none_or(|m| m.strategy == MountStrategy::Marker);
+            let spec = plan.dir_spec(&dir, marker_filename, honor_markers)?;
+            if spec.passthrough {
+                for m in &mounts {
+                    if let Ok(rel) = dir.strip_prefix(&m.src) {
+                        declared.insert(paths::normalize(&m.dst.join(rel)));
+                    }
+                }
+            }
+            for link in &spec.links {
+                if let Some(when) = &link.when {
+                    if !template::eval_truthy(when, &mut engine, &tera_ctx)? {
+                        continue;
+                    }
+                }
+                let rendered = engine.render(&link.dst, &tera_ctx)?;
+                declared.insert(paths::normalize(&paths::expand_tilde(rendered.trim())));
+            }
+        }
+    }
+
+    // A target link only concerns yui when it resolves back into a
+    // tree yui manages; an unrelated symlink (`/home/u` → `/mnt/u`)
+    // is somebody else's business.
+    let canonical_roots: Vec<std::path::PathBuf> = roots
+        .iter()
+        .filter_map(|r| std::fs::canonicalize(r).ok())
+        .collect();
+
+    // Name the mechanism the *config* asks for, not the platform
+    // default: `[mount] dir_mode = "symlink"` is opt-in on Windows, and
+    // a warning that says "junction" about a symlink misdescribes both
+    // what is on disk and what apply would rebuild.
+    let kind = match resolve_dir_mode(config.mount.dir_mode) {
+        EffectiveDirMode::Junction => "junction",
+        EffectiveDirMode::Symlink => "symlink",
+    };
+    let mut probes = Vec::new();
+    for m in &mounts {
+        if !m.src.is_dir() {
+            continue;
+        }
+        for ent in paths::source_walker(&m.src).build() {
+            let Ok(ent) = ent else { continue };
+            if !ent.file_type().is_some_and(|t| t.is_dir()) {
+                continue;
+            }
+            let Ok(src_dir) = Utf8PathBuf::from_path_buf(ent.into_path()) else {
+                continue;
+            };
+            let Ok(rel) = src_dir.strip_prefix(&m.src) else {
+                continue;
+            };
+            let dst = paths::normalize(&m.dst.join(rel));
+            if declared.contains(&dst) {
+                continue;
+            }
+            let is_link =
+                std::fs::symlink_metadata(&dst).is_ok_and(|md| md.file_type().is_symlink());
+            if !is_link {
+                continue;
+            }
+            let Ok(canonical) = std::fs::canonicalize(&dst) else {
+                continue;
+            };
+            if !canonical_roots.iter().any(|r| canonical.starts_with(r)) {
+                continue;
+            }
+            // Gitignore is only layered in here, on the handful of
+            // candidates that got this far: `source_walker` honours
+            // `.yuiignore` itself, and rebuilding the gitignore
+            // matchers for every directory in the tree would cost far
+            // more than it can ever save.
+            if paths::is_ignored_at(source, &src_dir, true, config.mount.respect_gitignore)? {
+                continue;
+            }
+            probes.push(Probe::warn(
+                "undeclared dir link",
+                format!(
+                    "{dst} → {src_dir} — the target is a {kind} into the source tree \
+                     but no [[link]] declares it; apply would rebuild it as a plain \
+                     directory with per-file links"
+                ),
+            ));
+        }
+    }
+
+    if probes.is_empty() {
+        probes.push(Probe::ok(
+            "dir links",
+            "every target-side directory link is declared",
+        ));
+    }
+    Ok(probes)
+}
+
 #[derive(Debug)]
-enum Probe {
+pub(crate) enum Probe {
     /// Section divider (just a heading, no severity).
     Group(&'static str),
     Ok {

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -3225,3 +3225,89 @@ fn quit_during_dir_absorb_restores_the_target() {
         "an aborted absorb must not have merged anything"
     );
 }
+
+/// A directory link into the source tree that no `[[link]]` declares
+/// is invisible to every other command: both sides resolve to the
+/// same inode *through* that very link, so `absorb::classify` reports
+/// the files inside as in-sync forever. Doctor has to say it out
+/// loud, because the day the link goes away `apply` rebuilds the
+/// target as a plain directory holding per-file links of only the
+/// tracked files — and the rest of the source dir stops being visible
+/// from the target side.
+#[test]
+fn doctor_warns_about_undeclared_dir_link() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("target"));
+    let kimi_src = source.join("home/.kimi-code");
+    std::fs::create_dir_all(&kimi_src).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(kimi_src.join("settings.json"), "{}\n").unwrap();
+
+    let mount_cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+        toml_path(&target)
+    );
+    std::fs::write(source.join("config.toml"), &mount_cfg).unwrap();
+
+    // The dir link exists on disk, but nothing in the config asks for
+    // it — exactly the state a hand-made junction leaves behind.
+    let kimi_dst = target.join(".kimi-code");
+    crate::link::link_dir(
+        &kimi_src,
+        &kimi_dst,
+        resolve_dir_mode(Config::default().mount.dir_mode),
+    )
+    .unwrap();
+    assert!(
+        std::fs::symlink_metadata(&kimi_dst)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "test setup: {kimi_dst} should be a junction / symlink"
+    );
+
+    let yui = YuiVars::detect(&source);
+    let cfg = config::load(&source, &yui).unwrap();
+    let probes = undeclared_dir_link_probes(&source, &cfg, &yui).unwrap();
+    let warns: Vec<&str> = probes
+        .iter()
+        .filter_map(|p| match p {
+            Probe::Warn { detail, .. } => Some(detail.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(warns.len(), 1, "expected one warning, got {probes:?}");
+    let want_dst = paths::normalize(&kimi_dst);
+    let want_src = paths::normalize(&kimi_src);
+    assert!(
+        warns[0].contains(want_dst.as_str()) && warns[0].contains(want_src.as_str()),
+        "warning should name both sides ({want_dst} → {want_src}): {}",
+        warns[0]
+    );
+
+    // Declare it and the link becomes reproducible — nothing to warn
+    // about any more.
+    std::fs::write(
+        source.join("config.toml"),
+        format!(
+            "{mount_cfg}\n[[link]]\nsrc = \"home/.kimi-code\"\ndst = \"{}\"\n",
+            toml_path(&kimi_dst)
+        ),
+    )
+    .unwrap();
+    let cfg = config::load(&source, &yui).unwrap();
+    let probes = undeclared_dir_link_probes(&source, &cfg, &yui).unwrap();
+    assert!(
+        !probes.iter().any(|p| matches!(p, Probe::Warn { .. })),
+        "declared dir link must not warn: {probes:?}"
+    );
+    assert!(
+        probes.iter().any(|p| matches!(p, Probe::Ok { .. })),
+        "a clean check should still report something: {probes:?}"
+    );
+}


### PR DESCRIPTION
## What

`yui doctor` now warns about target-side directory links (junction /
symlink) that resolve back into a managed tree but which no `[[link]]`
declaration covers.

```
  links
    ✓  default mode    files=hardlink, dirs=junction (no admin needed)
    ⚠  undeclared dir link  C:\…\target\.kimi-code → C:\…\dotfiles\home\.kimi-code — the target is a junction into the source tree but no [[link]] declares it; apply would rebuild it as a plain directory with per-file links
```

## Why

A directory link nobody declared is invisible to every other command.
`absorb::classify` compares file identity, and with the junction in
place both sides resolve to the same inode *through that very link* —
so every file inside reports `in-sync`, forever.

The link is load-bearing but unreproducible. The day it goes away (new
machine, `yui unlink`, a manual cleanup) `apply` faithfully rebuilds
the target as a *plain directory* holding hardlinks of only the tracked
files; everything else in the source directory silently stops being
visible from the target side. Nothing warned, before or after. `doctor`
is the place that exists to surface exactly this class of surprise
before `apply` acts on it.

## How

`cmd::doctor::undeclared_dir_link_probes`:

1. Resolves mounts and builds the `LinkPlan`, then collects every
   *declared target path* — for each dir in `plan.declared_dirs` (over
   `$DOTFILES` plus any mount `src` outside it), each dir-scoped entry's
   `dst` is `when`-filtered, Tera-rendered and tilde-expanded exactly as
   the apply walk does it; a `passthrough` marker contributes the
   mount-natural dst. Markers only count where the mount strategy
   honours them, same gate apply applies.
2. Walks each mount's source tree with `paths::source_walker` and, for
   every source directory, checks whether its natural target exists, is
   a symlink / junction (`symlink_metadata(...).file_type().is_symlink()`,
   true for Windows junctions), resolves back into a managed root, and
   is absent from the declared set. Gitignore is layered in only on the
   handful of candidates that get that far, so the common path doesn't
   pay for matcher rebuilds.
3. Warns, naming both sides and what would happen. Never errors, never
   mutates — the link is not broken *now*, it is unreproducible
   (resilience principle).

A clean check reports `✓ dir links  every target-side directory link is
declared`, consistent with the other groups.

## Test

`doctor_warns_about_undeclared_dir_link` in `src/cmd/tests.rs`: temp
source tree + `[[mount.entry]]`, dir link created via
`crate::link::link_dir` (junction on Windows, symlink on Unix), no
declaration → exactly one warning naming both paths; add the matching
`[[link]]` → no warning, the ok probe instead.

Manually smoke-checked against a scratch repo with a hand-made
`mklink /J` junction (output above), and re-run after adding the
declaration to confirm the warning disappears.

`cargo make check` green.

Closes #238


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostics to detect directory links into managed source folders that are missing from link configuration.
  * Reports both the source and destination paths for undeclared links.
  * Displays an all-clear result when no undeclared links are found.

* **Bug Fixes**
  * Directory-link checks now warn gracefully when the probe cannot run instead of failing the diagnostic command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->