### PR TITLE
fix(apply): report off-TTY anomalies and snapshot the git-clean gate

### DIFF
--- a/src/cmd/absorb.rs
+++ b/src/cmd/absorb.rs
@@ -7,7 +7,7 @@ use crate::template;
 use crate::vars::YuiVars;
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use teravars::Context as TeraContext;
 use tracing::{info, warn};
 
@@ -79,7 +79,6 @@ pub fn absorb(
     let plan = LinkPlan::from_config(&source, &config.link)?;
     let ctx = ApplyCtx {
         config: &config,
-        source: &source,
         plan: &plan,
         file_mode: resolve_file_mode(config.mount.file_mode),
         dir_mode: resolve_dir_mode(config.mount.dir_mode),
@@ -87,6 +86,10 @@ pub fn absorb(
         dry_run: false,
         sticky_anomaly: Cell::new(None),
         quit_requested: Cell::new(false),
+        // Manual absorb bypasses the `require_clean_git` policy
+        // entirely (see below), so this only satisfies the shared type.
+        source_clean: true,
+        unresolved: RefCell::new(Vec::new()),
     };
 
     // Manual absorb is an explicit user request — bypass `auto`,

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -11,7 +11,7 @@ use crate::vars::YuiVars;
 use crate::{absorb, backup, paths};
 use anyhow::{Context as _, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use teravars::Context as TeraContext;
 use tracing::{info, warn};
 
@@ -22,6 +22,20 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
 
     let mut engine = template::Engine::new();
     let tera_ctx = template::template_context(&yui, &config.vars);
+
+    // Snapshot the git-clean state *before* this run writes anything.
+    // Two reasons it can't wait until the link pass:
+    //   - a whole-dir absorb copies target content into source, so the
+    //     second absorb in a run would see the dirt the first one made
+    //   - apply itself writes `.yui/state.json` (hook state) and
+    //     rendered files along the way
+    // The gate asks "was the user's work committed before yui started",
+    // and that question has exactly one answer per run.
+    let source_clean = if config.absorb.require_clean_git {
+        source_repo_is_clean(&source)
+    } else {
+        true
+    };
 
     // 0. Pre-apply hooks (before render / link). Bail on hook failure so
     //    apply doesn't proceed past a broken bootstrap.
@@ -98,7 +112,6 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
     plan.warn_unreachable(mounts.iter().map(|m| m.src.as_path()));
     let ctx = ApplyCtx {
         config: &config,
-        source: &source,
         plan: &plan,
         file_mode: resolve_file_mode(config.mount.file_mode),
         dir_mode: resolve_dir_mode(config.mount.dir_mode),
@@ -106,6 +119,8 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
         dry_run,
         sticky_anomaly: Cell::new(None),
         quit_requested: Cell::new(false),
+        source_clean,
+        unresolved: RefCell::new(Vec::new()),
     };
 
     info!("source: {source}");
@@ -139,6 +154,23 @@ pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
         HookPhase::Post,
         dry_run,
     )?;
+
+    // 4. Anything the run couldn't decide fails the run — silence here
+    //    used to make "linked everything" and "left a declared link
+    //    unmade" look identical from the outside. Each entry already
+    //    logged its path and reason when it was hit (`note_unresolved`),
+    //    so this only needs the count and the way out.
+    let unresolved = ctx.unresolved.borrow();
+    if !unresolved.is_empty() {
+        anyhow::bail!(
+            "apply: {} anomal{} left unresolved (see the warnings above) — no TTY \
+             to ask at with [absorb] on_anomaly = \"ask\"; set on_anomaly to \
+             \"force\" (target wins) or \"skip\" (leave them) to make this \
+             deterministic",
+            unresolved.len(),
+            if unresolved.len() == 1 { "y" } else { "ies" }
+        );
+    }
     Ok(())
 }
 
@@ -191,6 +223,11 @@ pub(crate) enum AnomalyChoice {
     Overwrite,
     /// Leave both as-is for now.
     Skip,
+    /// Nobody could be asked — `on_anomaly = "ask"` with no TTY. The
+    /// *action* is the same as `Skip` (do nothing, it's the safe one),
+    /// but it is not a decision, so callers record it and `apply`
+    /// reports it at the end instead of exiting as if all was well.
+    Unresolved,
     /// Skip this entry and stop walking remaining entries.
     Quit,
 }
@@ -214,8 +251,6 @@ enum RenderDriftChoice {
 
 pub(crate) struct ApplyCtx<'a> {
     pub(crate) config: &'a Config,
-    /// Source repo root — needed for git-clean checks during absorb.
-    pub(crate) source: &'a Utf8Path,
     /// Central `[[link]]` declarations from `config.toml`, keyed by the
     /// source dir the walk has to reach for them to fire.
     pub(crate) plan: &'a LinkPlan,
@@ -230,6 +265,17 @@ pub(crate) struct ApplyCtx<'a> {
     /// of every link op and short-circuits to a no-op so apply exits
     /// cleanly without further prompts.
     pub(crate) quit_requested: Cell<bool>,
+    /// Was the source repo clean when this run started?
+    ///
+    /// Snapshotted once on purpose: a whole-dir absorb copies target
+    /// content into source, so anything not gitignored makes the repo
+    /// dirty *mid-run* and would defer every later absorb. The
+    /// `require_clean_git` gate is about the user's uncommitted work,
+    /// not about what this run just produced.
+    pub(crate) source_clean: bool,
+    /// Anomalies left unresolved because there was no TTY to ask at.
+    /// Surfaced together when the walk is over.
+    pub(crate) unresolved: RefCell<Vec<Utf8PathBuf>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -439,7 +485,7 @@ pub(crate) fn link_file_with_backup(
                     "absorb.auto = false; treating divergence as anomaly",
                 );
             }
-            if ctx.config.absorb.require_clean_git && !source_repo_is_clean(ctx.source) {
+            if ctx.config.absorb.require_clean_git && !ctx.source_clean {
                 return handle_anomaly(
                     src,
                     dst,
@@ -491,11 +537,22 @@ pub(crate) fn overwrite_source_into_target(
     Ok(())
 }
 
+/// Log + record an anomaly nobody could be asked about.
+fn note_unresolved(ctx: &ApplyCtx<'_>, dst: &Utf8Path, reason: &str) {
+    warn!(
+        "anomaly unresolved: {dst} ({reason}) — no TTY to ask at, and \
+         [absorb] on_anomaly = \"ask\"; set it to \"force\" or \"skip\" \
+         to decide up front"
+    );
+    ctx.unresolved.borrow_mut().push(dst.to_path_buf());
+}
+
 /// Decide what to do for an anomaly (NeedsConfirm or AutoAbsorb that was
 /// escalated by `auto = false` / dirty git). Per `[absorb] on_anomaly`:
 ///   - `skip`  → log warning, leave target alone
 ///   - `force` → behave like AutoAbsorb (target wins)
-///   - `ask`   → on a TTY, show diff + prompt. Off-TTY, downgrade to skip.
+///   - `ask`   → on a TTY, show diff + prompt. Off-TTY, leave the target
+///     alone and record it as unresolved.
 fn handle_anomaly(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>, reason: &str) -> Result<()> {
     use crate::config::AnomalyAction::*;
     match ctx.config.absorb.on_anomaly {
@@ -512,6 +569,10 @@ fn handle_anomaly(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>, reason: &s
             AnomalyChoice::Overwrite => overwrite_source_into_target(src, dst, ctx),
             AnomalyChoice::Skip => {
                 warn!("anomaly skipped by user: {dst}");
+                Ok(())
+            }
+            AnomalyChoice::Unresolved => {
+                note_unresolved(ctx, dst, reason);
                 Ok(())
             }
             AnomalyChoice::Quit => {
@@ -535,9 +596,10 @@ fn handle_anomaly(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>, reason: &s
 /// `ctx.sticky_anomaly`. `[q]uit` flips `ctx.quit_requested` so the
 /// walker stops calling per-entry link ops.
 ///
-/// Off-TTY: returns `Skip` immediately (caller logs the downgrade) —
-/// matches the previous "non-TTY ask = skip" behaviour. Quit is not
-/// possible without a TTY because there is nothing to interact with.
+/// Off-TTY: returns `Unresolved` immediately. The target is left alone
+/// either way, but the caller records it so the run can report what it
+/// didn't do — nobody chose this, there was just nobody to ask. Quit is
+/// not possible without a TTY because there is nothing to interact with.
 pub(crate) fn prompt_anomaly(
     ctx: &ApplyCtx<'_>,
     src: &Utf8Path,
@@ -558,7 +620,7 @@ pub(crate) fn prompt_anomaly(
     use std::io::IsTerminal;
     use std::io::Write as _;
     if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
-        return Ok(AnomalyChoice::Skip);
+        return Ok(AnomalyChoice::Unresolved);
     }
 
     eprintln!();
@@ -906,7 +968,7 @@ pub(crate) fn link_dir_with_backup(
                     "absorb.auto = false; treating divergence as anomaly",
                 );
             }
-            if ctx.config.absorb.require_clean_git && !source_repo_is_clean(ctx.source) {
+            if ctx.config.absorb.require_clean_git && !ctx.source_clean {
                 return handle_anomaly_dir(
                     src,
                     dst,
@@ -1064,7 +1126,8 @@ fn merge_dir_target_into_source(
 ///     - `skip` → leave source alone, target's version is dropped
 ///       (after the outer junction, target ends up with source's content)
 ///     - `force` → copy target → source (target wins anyway)
-///     - `ask` → TTY prompt with diff; downgrade to skip off-TTY
+///     - `ask` → TTY prompt with diff; off-TTY it is recorded as
+///       unresolved (`note_unresolved`) and fails the run at the end
 fn merge_resolve_file_conflict(
     target_path: &Utf8Path,
     source_path: &Utf8Path,
@@ -1135,6 +1198,14 @@ fn merge_resolve_file_conflict(
                         }
                         AnomalyChoice::Skip => {
                             warn!("merge: kept source version by user choice: {source_path}");
+                            Ok(())
+                        }
+                        AnomalyChoice::Unresolved => {
+                            note_unresolved(
+                                ctx,
+                                target_path,
+                                "merge: file content differs and source is newer",
+                            );
                             Ok(())
                         }
                         AnomalyChoice::Quit => {
@@ -1345,7 +1416,8 @@ fn overwrite_source_dir_into_target(
 
 /// Dir-level counterpart to `handle_anomaly`. Same `[absorb] on_anomaly`
 /// dispatch — `skip` warns and walks away, `force` absorbs anyway,
-/// `ask` prompts on a TTY (downgraded to skip off-TTY).
+/// `ask` prompts on a TTY; off-TTY the entry is recorded as unresolved
+/// (`note_unresolved`) and `apply` fails at the end of the run.
 fn handle_anomaly_dir(
     src: &Utf8Path,
     dst: &Utf8Path,
@@ -1370,6 +1442,10 @@ fn handle_anomaly_dir(
             AnomalyChoice::Overwrite => overwrite_source_dir_into_target(src, dst, ctx),
             AnomalyChoice::Skip => {
                 warn!("anomaly skipped by user: {dst}");
+                Ok(())
+            }
+            AnomalyChoice::Unresolved => {
+                note_unresolved(ctx, dst, reason);
                 Ok(())
             }
             AnomalyChoice::Quit => {

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -7,7 +7,7 @@ use crate::secret;
 use crate::vars::YuiVars;
 use crate::{absorb, paths};
 use camino::{Utf8Path, Utf8PathBuf};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use tempfile::TempDir;
 
 fn utf8(p: std::path::PathBuf) -> Utf8PathBuf {
@@ -2611,6 +2611,174 @@ fn walkdir(root: &Utf8Path) -> Vec<Utf8PathBuf> {
 }
 
 // -----------------------------------------------------------------
+// anomaly visibility (off-TTY) + git-clean snapshot
+// -----------------------------------------------------------------
+
+/// Initialise a git repo at `dir` and commit everything in it, so
+/// `git status --porcelain` is empty. Returns false when git isn't
+/// available on the runner, so callers can skip.
+fn git_init_and_commit(dir: &Utf8Path) -> bool {
+    let run = |args: &[&str]| {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir.as_std_path())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    };
+    run(&["init", "-q"])
+        && run(&["add", "-A"])
+        && run(&[
+            "-c",
+            "user.email=t@example.com",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-qm",
+            "init",
+        ])
+}
+
+/// Off-TTY there is nobody to answer `on_anomaly = "ask"`, so the
+/// anomaly is left unresolved. That used to be logged as
+/// "anomaly skipped by user" and the run exited 0 — indistinguishable
+/// from a run that linked everything. It has to be reported.
+#[test]
+fn off_tty_anomaly_is_reported_instead_of_silently_skipped() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("home"));
+    std::fs::create_dir_all(source.join("home")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+
+    // Source newer + content differs → NeedsConfirm, which the default
+    // `on_anomaly = "ask"` sends to the prompt.
+    let now = std::time::SystemTime::now();
+    let past = now - std::time::Duration::from_secs(120);
+    write_with_mtime(&target.join(".bashrc"), "target side", past);
+    write_with_mtime(&source.join("home/.bashrc"), "source side", now);
+
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+        toml_path(&target)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    let err = apply(Some(source.clone()), false).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("unresolved"), "got {msg}");
+    assert!(msg.contains("on_anomaly"), "got {msg}");
+
+    // Non-destructive: both sides keep their content.
+    assert_eq!(
+        std::fs::read_to_string(target.join(".bashrc")).unwrap(),
+        "target side"
+    );
+    assert_eq!(
+        std::fs::read_to_string(source.join("home/.bashrc")).unwrap(),
+        "source side"
+    );
+}
+
+/// `on_anomaly = "skip"` is the explicit "leave them alone" answer, so
+/// it must stay silent and keep exiting 0 — only the `ask`-with-no-TTY
+/// degradation is reported.
+#[test]
+fn explicit_skip_policy_does_not_report_unresolved() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("home"));
+    std::fs::create_dir_all(source.join("home")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+
+    let now = std::time::SystemTime::now();
+    let past = now - std::time::Duration::from_secs(120);
+    write_with_mtime(&target.join(".bashrc"), "target side", past);
+    write_with_mtime(&source.join("home/.bashrc"), "source side", now);
+
+    let cfg = format!(
+        r#"
+[absorb]
+on_anomaly = "skip"
+
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+        toml_path(&target)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    apply(Some(source.clone()), false).unwrap();
+}
+
+/// A dir absorb copies target content into source, which makes the repo
+/// dirty mid-run. `require_clean_git` must judge the state apply started
+/// from, otherwise the first absorb defers every later one and each new
+/// dir link needs its own run (with a commit in between).
+#[test]
+fn dirty_from_own_absorb_does_not_defer_the_next_one() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("home"));
+    std::fs::create_dir_all(source.join("home/appa")).unwrap();
+    std::fs::create_dir_all(source.join("home/appb")).unwrap();
+    std::fs::create_dir_all(target.join("appa")).unwrap();
+    std::fs::create_dir_all(target.join("appb")).unwrap();
+    std::fs::write(source.join("home/appa/config.toml"), "a\n").unwrap();
+    std::fs::write(source.join("home/appb/config.toml"), "b\n").unwrap();
+    // Target-only files: the merge pulls them into source, and they are
+    // what makes the repo dirty for the *second* absorb.
+    std::fs::write(target.join("appa/state.json"), "{}").unwrap();
+    std::fs::write(target.join("appb/state.json"), "{}").unwrap();
+
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{0}"
+
+[[link]]
+src = "home/appa"
+dst = "{0}/appa"
+
+[[link]]
+src = "home/appb"
+dst = "{0}/appb"
+"#,
+        toml_path(&target)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    if !git_init_and_commit(&source) {
+        eprintln!("skipping: git not available");
+        return;
+    }
+
+    // One run has to absorb both. Before the snapshot fix the second
+    // one hit `source repo is dirty; deferring auto-absorb`.
+    apply(Some(source.clone()), false).unwrap();
+
+    for app in ["appa", "appb"] {
+        assert!(
+            source.join(format!("home/{app}/state.json")).exists(),
+            "{app}: target-only file should have been absorbed"
+        );
+        // The dir is now a link: a file written on the target side
+        // shows up in source without another apply.
+        std::fs::write(target.join(format!("{app}/fresh.txt")), "x").unwrap();
+        assert!(
+            source.join(format!("home/{app}/fresh.txt")).exists(),
+            "{app}: target should be linked to source"
+        );
+    }
+}
+
+// -----------------------------------------------------------------
 // gc-backup
 // -----------------------------------------------------------------
 
@@ -2862,7 +3030,6 @@ fn prompt_anomaly_short_circuits_on_quit_requested() {
 
     let ctx = ApplyCtx {
         config: &cfg,
-        source: &source,
         plan: &plan,
         file_mode: resolve_file_mode(cfg.mount.file_mode),
         dir_mode: resolve_dir_mode(cfg.mount.dir_mode),
@@ -2870,6 +3037,8 @@ fn prompt_anomaly_short_circuits_on_quit_requested() {
         dry_run: false,
         sticky_anomaly: Cell::new(None),
         quit_requested: Cell::new(true),
+        source_clean: true,
+        unresolved: RefCell::new(Vec::new()),
     };
 
     let got = prompt_anomaly(&ctx, &src_file, &dst_file, "test").unwrap();
@@ -2891,7 +3060,6 @@ fn prompt_anomaly_short_circuits_on_sticky_choice() {
 
     let ctx = ApplyCtx {
         config: &cfg,
-        source: &source,
         plan: &plan,
         file_mode: resolve_file_mode(cfg.mount.file_mode),
         dir_mode: resolve_dir_mode(cfg.mount.dir_mode),
@@ -2899,6 +3067,8 @@ fn prompt_anomaly_short_circuits_on_sticky_choice() {
         dry_run: false,
         sticky_anomaly: Cell::new(Some(AnomalyChoice::Overwrite)),
         quit_requested: Cell::new(false),
+        source_clean: true,
+        unresolved: RefCell::new(Vec::new()),
     };
 
     let got = prompt_anomaly(&ctx, &src_file, &dst_file, "test").unwrap();
@@ -2920,7 +3090,6 @@ fn overwrite_source_into_target_replaces_target_and_backs_up() {
 
     let ctx = ApplyCtx {
         config: &cfg,
-        source: &source,
         plan: &plan,
         file_mode: resolve_file_mode(cfg.mount.file_mode),
         dir_mode: resolve_dir_mode(cfg.mount.dir_mode),
@@ -2928,6 +3097,8 @@ fn overwrite_source_into_target_replaces_target_and_backs_up() {
         dry_run: false,
         sticky_anomaly: Cell::new(None),
         quit_requested: Cell::new(false),
+        source_clean: true,
+        unresolved: RefCell::new(Vec::new()),
     };
 
     overwrite_source_into_target(&src_file, &dst_file, &ctx).unwrap();
@@ -2974,7 +3145,6 @@ fn link_file_with_backup_short_circuits_when_quit_requested() {
 
     let ctx = ApplyCtx {
         config: &cfg,
-        source: &source,
         plan: &plan,
         file_mode: resolve_file_mode(cfg.mount.file_mode),
         dir_mode: resolve_dir_mode(cfg.mount.dir_mode),
@@ -2982,6 +3152,8 @@ fn link_file_with_backup_short_circuits_when_quit_requested() {
         dry_run: false,
         sticky_anomaly: Cell::new(None),
         quit_requested: Cell::new(true),
+        source_clean: true,
+        unresolved: RefCell::new(Vec::new()),
     };
 
     link_file_with_backup(&src_file, &dst_file, &ctx).unwrap();
@@ -3037,10 +3209,9 @@ fn dir_absorb_fixture(tmp: &TempDir) -> (Config, Utf8PathBuf, Utf8PathBuf, LinkP
 }
 
 macro_rules! dir_ctx {
-    ($cfg:expr, $source:expr, $plan:expr, $backup_root:expr) => {
+    ($cfg:expr, $plan:expr, $backup_root:expr) => {
         ApplyCtx {
             config: &$cfg,
-            source: &$source,
             plan: &$plan,
             file_mode: resolve_file_mode($cfg.mount.file_mode),
             dir_mode: resolve_dir_mode($cfg.mount.dir_mode),
@@ -3048,6 +3219,8 @@ macro_rules! dir_ctx {
             dry_run: false,
             sticky_anomaly: Cell::new(None),
             quit_requested: Cell::new(false),
+            source_clean: true,
+            unresolved: RefCell::new(Vec::new()),
         }
     };
 }
@@ -3067,7 +3240,7 @@ fn absorb_dir_stages_target_aside_and_cleans_up() {
     std::fs::create_dir_all(dst_dir.join("lua")).unwrap();
     std::fs::write(dst_dir.join("lua/only-in-target.lua"), "T").unwrap();
 
-    let ctx = dir_ctx!(cfg, source, plan, backup_root);
+    let ctx = dir_ctx!(cfg, plan, backup_root);
     absorb_target_dir_into_source(&src_dir, &dst_dir, &ctx).unwrap();
 
     assert_eq!(
@@ -3106,7 +3279,7 @@ fn interrupted_absorb_staging_is_resumed_before_classify() {
     std::fs::create_dir_all(staged.join("lua")).unwrap();
     std::fs::write(staged.join("lua/rescued.lua"), "R").unwrap();
 
-    let ctx = dir_ctx!(cfg, source, plan, backup_root);
+    let ctx = dir_ctx!(cfg, plan, backup_root);
     link_dir_with_backup(&src_dir, &dst_dir, &ctx).unwrap();
 
     assert_eq!(
@@ -3140,7 +3313,7 @@ fn interrupted_overwrite_staging_is_discarded_not_merged() {
     std::fs::create_dir_all(&staged).unwrap();
     std::fs::write(staged.join("ghost.lua"), "G").unwrap();
 
-    let ctx = dir_ctx!(cfg, source, plan, backup_root);
+    let ctx = dir_ctx!(cfg, plan, backup_root);
     link_dir_with_backup(&src_dir, &dst_dir, &ctx).unwrap();
 
     assert!(!staged.exists(), "discard staging is swept");
@@ -3170,7 +3343,7 @@ fn dry_run_recovery_leaves_staging_untouched() {
     std::fs::create_dir_all(&staged).unwrap();
     std::fs::write(staged.join("kept.lua"), "K").unwrap();
 
-    let mut ctx = dir_ctx!(cfg, source, plan, backup_root);
+    let mut ctx = dir_ctx!(cfg, plan, backup_root);
     ctx.dry_run = true;
     link_dir_with_backup(&src_dir, &dst_dir, &ctx).unwrap();
 
@@ -3202,7 +3375,7 @@ fn quit_during_dir_absorb_restores_the_target() {
     std::fs::create_dir_all(&dst_dir).unwrap();
     std::fs::write(dst_dir.join("mine.lua"), "target-only").unwrap();
 
-    let mut ctx = dir_ctx!(cfg, source, plan, backup_root);
+    let mut ctx = dir_ctx!(cfg, plan, backup_root);
     ctx.quit_requested = Cell::new(true);
     absorb_target_dir_into_source(&src_dir, &dst_dir, &ctx).unwrap();
 


### PR DESCRIPTION
Two ways `apply` could quietly not do what the config declares. Both were hit while migrating a real dotfiles repo onto the v0.11.0 `[[link]]` table.

Closes #236, closes #237.

## Off-TTY anomalies were logged as a user decision

`prompt_anomaly` returned `Skip` when there was no terminal, and the callers logged `anomaly skipped by user` — nobody chose anything. `apply` exited 0 with a declared link not created:

```
WARN anomaly skipped by user: C:\Users\yukimemi\.vscode
$ echo $?
0
```

`AnomalyChoice::Unresolved` now separates "the user said skip" from "there was nobody to ask". The action is identical (leave both sides alone — still the safe default), but the entry is recorded and surfaced when the walk is over:

```
WARN anomaly unresolved: …\target\appa (source repo is dirty; deferring auto-absorb)
     — no TTY to ask at, and [absorb] on_anomaly = "ask"; set it to "force" or "skip"
Error: apply: 2 anomalies left unresolved — no TTY to ask at with [absorb]
       on_anomaly = "ask"; set on_anomaly to "force" (target wins) or "skip"
       (leave them) to make this deterministic
```

Reporting happens after post-hooks, so the rest of the run still completes (resilience principle: warn, continue, surface the full set at the end). `on_anomaly = "skip"` is an explicit answer and stays quiet with exit 0 — covered by a test so it can't regress into noise.

## `require_clean_git` saw dirt from earlier absorbs in the same run

The gate was re-evaluated per absorb. A whole-dir absorb copies target content into source, so anything not gitignored made the repo dirty and deferred every *later* absorb:

```
INFO absorb dir: …\.gemini → …\home\.gemini      # merged, brought in 13 untracked files
WARN anomaly skipped by user: …\.vscode          # deferred: repo now dirty
```

N new dir links needed N runs with a commit between each. The state is snapshotted once now — and at the *top* of `apply`, not just before the walk: apply itself writes `.yui/state.json` (hook state) and rendered files, which would poison a later snapshot in a repo that doesn't gitignore them. The knob asks whether the user's work was committed before yui started; that question has one answer per run.

`ApplyCtx.source` existed only for the per-call git check and is dropped.

## Verification

`cargo make check` green (fmt + clippy `-D warnings` + 234 tests + lock-check).

Three new tests:
- `off_tty_anomaly_is_reported_instead_of_silently_skipped` — source-newer conflict under default `ask`, no TTY → `apply` errors, both sides keep their content.
- `explicit_skip_policy_does_not_report_unresolved` — same setup with `on_anomaly = "skip"` → Ok.
- `dirty_from_own_absorb_does_not_defer_the_next_one` — real git repo, clean at start, two dir-level `[[link]]`s whose targets both diverge → one `apply` absorbs both, and a file written on the target side afterwards appears in source (i.e. the dirs really are links). Skips itself when `git` is missing, like the other git-dependent tests.

Manual smoke on the same two-dir scratch repo:

```
# repo clean at start
INFO absorb dir: …\target\appa → …\src\home\appa
INFO absorb dir: …\target\appb → …\src\home\appb     # was: deferred + silently skipped
```

## Note for review

Making unresolved anomalies fail the command is a behaviour change: a script running `yui apply` off-TTY with the default `on_anomaly = "ask"` and a diverged target used to exit 0 and now exits non-zero. That is the point of #236 — the alternative (warn only) leaves CI green while the declared state isn't reached — but it is worth a second opinion. `on_anomaly = "skip"` remains the way to say "leave them, quietly".
