### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,9 +1,9 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-08-15T03:29:39.604355468Z"
+applied_at = "2026-08-16T03:33:30.558923361Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "b5f394660d08ef671e6c29204c366b3e7984868c"
+rev = "00be9d5dc530de2a6bbde59c1867d58f58b1bdfc"
 version = "0.14.0"
 
 [[templates]]


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->