### PR TITLE
chore: release v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."


### PR DESCRIPTION
Everything on main since v0.11.0.

- #235 — dir absorb stages the target aside instead of deleting it in place
- #240 — `apply` reports off-TTY anomalies instead of logging them as a user decision, and snapshots the `require_clean_git` gate once per run (fixes #236, #237)
- #239 — `doctor` warns about directory links no `[[link]]` declares (fixes #238)

Behaviour note for the changelog: off-TTY `apply` with the default `[absorb] on_anomaly = "ask"` and a diverged target now exits non-zero instead of 0. `on_anomaly = "skip"` is the explicit way to keep the old quiet-and-succeed behaviour.

Version-bump-only PR (`package.version` + `Cargo.lock`), so it skips the bot-review gate per AGENTS.md.