### PR TITLE
feat(link): let a [[link]] entry override the link mechanism

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,15 @@ before reverting any of them.
 - **Link modes live in `[mount]`** (`file_mode` / `dir_mode`). They used
   to be a `[link]` table; that key is now the `[[link]]` array, and
   `config::load` intercepts the old table shape with a migration error
-  rather than letting serde emit a type error about a sequence.
+  rather than letting serde emit a type error about a sequence. A single
+  `[[link]]` entry may override the mechanism with `mode` — legal values
+  depend on what it links (dirs: `auto`/`symlink`/`junction`, files:
+  `auto`/`symlink`/`hardlink`), validated where the entry is declared.
+  The override exists because flipping `dir_mode` globally on Windows
+  costs every link its privilege-free default just to accommodate one
+  junction-hostile app. The effective mode is passed down the link /
+  absorb call chain as an argument — no ambient state, so a nested
+  per-file conflict inside a dir merge can't pick up the dir's override.
 - **Templates are `*.tera` files; rendered output goes to the *same
   directory* as the template.** `home/.gitconfig.tera` →
   `home/.gitconfig`. Rendered files are listed in a managed section

--- a/README.md
+++ b/README.md
@@ -259,6 +259,34 @@ File scope doesn't claim the directory, so the rest of it still falls
 through to whatever placement an ancestor (or the parent mount)
 provides.
 
+### Per-entry `mode`
+
+`[mount] file_mode` / `dir_mode` set the mechanism for the whole repo.
+One entry can opt out with `mode`:
+
+```toml
+[[link]]
+src = "home/.config/someapp"
+dst = "~/.config/someapp"
+mode = "symlink"        # this dir only; everything else stays junction
+```
+
+That matters on Windows, where flipping `dir_mode` globally means every
+directory link needs Developer Mode or admin — a single app that refuses
+to work through a junction shouldn't cost the other twenty links their
+privilege-free default.
+
+Legal values depend on what the entry links, and a mismatch is a config
+error at declaration time rather than a surprise at link time:
+
+| entry links | `mode` | default (`auto`) |
+|---|---|---|
+| a directory | `auto` \| `symlink` \| `junction` | symlink on Unix, junction on Windows |
+| a file | `auto` \| `symlink` \| `hardlink` | symlink on Unix, hardlink on Windows |
+
+`yui list` grows a `MODE` column as soon as any entry overrides, so the
+odd one out is visible without reading the config.
+
 ### Rules for `src`
 
 - Relative, and it has to stay inside its base: `..`, absolute paths and

--- a/src/cmd/absorb.rs
+++ b/src/cmd/absorb.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::config::{self, Config};
 use crate::link::{resolve_dir_mode, resolve_file_mode};
-use crate::links::LinkPlan;
+use crate::links::{LinkMode, LinkPlan};
 use crate::paths;
 use crate::template;
 use crate::vars::YuiVars;
@@ -39,9 +39,11 @@ pub fn absorb(
     let mut engine = template::Engine::new();
     let tera_ctx = template::template_context(&yui, &config.vars);
 
-    let src_path = match find_source_for_target(&source, &config, &target, &mut engine, &tera_ctx)?
-    {
-        Some(s) => s,
+    let TargetMatch {
+        src: src_path,
+        mode,
+    } = match find_source_for_target(&source, &config, &target, &mut engine, &tera_ctx)? {
+        Some(m) => m,
         None => anyhow::bail!(
             "no mount entry / .yuilink override claims target {target}; \
                  pass a path inside a known dst"
@@ -93,11 +95,16 @@ pub fn absorb(
     };
 
     // Manual absorb is an explicit user request — bypass `auto`,
-    // `require_clean_git`, and `on_anomaly` policy entirely.
+    // `require_clean_git`, and `on_anomaly` policy entirely. The
+    // mechanism still follows the declaration that claims this target:
+    // relinking with the global mode would quietly undo a per-entry
+    // `mode`, and `classify` compares by identity rather than
+    // mechanism, so a later `apply` would see InSync and never put it
+    // back.
     if target.is_dir() {
-        absorb_target_dir_into_source(&src_path, &target, &ctx)
+        absorb_target_dir_into_source(&src_path, &target, &ctx, ctx.dir_mode_for(mode))
     } else {
-        absorb_target_into_source(&src_path, &target, &ctx)
+        absorb_target_into_source(&src_path, &target, &ctx, ctx.file_mode_for(mode))
     }
 }
 
@@ -204,6 +211,14 @@ fn prompt_yes_no(question: &str) -> Result<bool> {
     Ok(answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes"))
 }
 
+/// What claims a target: the source path it maps back to, plus the
+/// mechanism the claiming declaration asked for (`None` = whatever
+/// `[mount]` says).
+pub(crate) struct TargetMatch {
+    pub(crate) src: Utf8PathBuf,
+    pub(crate) mode: Option<LinkMode>,
+}
+
 /// Walk mount entries + every `[[link]]` declaration (central table and
 /// `.yuilink` markers) to find the source file/dir that the given target
 /// maps back to. Returns `None` when nothing claims the path.
@@ -213,7 +228,7 @@ fn find_source_for_target(
     target: &Utf8Path,
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
-) -> Result<Option<Utf8PathBuf>> {
+) -> Result<Option<TargetMatch>> {
     // 1. Mount entries — render dst, see if target is inside it.
     for entry in &config.mount.entry {
         if let Some(when) = &entry.when {
@@ -246,7 +261,11 @@ fn find_source_for_target(
             )? {
                 continue;
             }
-            return Ok(Some(candidate));
+            // A mount entry carries no mechanism of its own.
+            return Ok(Some(TargetMatch {
+                src: candidate,
+                mode: None,
+            }));
         }
     }
 
@@ -282,13 +301,25 @@ fn find_source_for_target(
                 if !file_src.is_file() {
                     anyhow::bail!("{} not found", link.describe(&dir));
                 }
-                return Ok(Some(file_src));
+                return Ok(Some(TargetMatch {
+                    src: file_src,
+                    mode: link.mode,
+                }));
             }
             if target == dst {
-                return Ok(Some(dir));
+                return Ok(Some(TargetMatch {
+                    src: dir,
+                    mode: link.mode,
+                }));
             }
             if let Ok(rel) = target.strip_prefix(&dst) {
-                return Ok(Some(dir.join(rel)));
+                // A path *inside* a dir-scoped link: what gets relinked
+                // is that file, so the directory's mechanism doesn't
+                // apply to it. Fall back to the file default.
+                return Ok(Some(TargetMatch {
+                    src: dir.join(rel),
+                    mode: None,
+                }));
             }
         }
     }

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::config::{self, Config, HookPhase, MountStrategy};
 use crate::hook;
 use crate::link::{self, EffectiveDirMode, EffectiveFileMode, resolve_dir_mode, resolve_file_mode};
-use crate::links::{self, LinkPlan};
+use crate::links::{self, LinkMode, LinkPlan};
 use crate::mount::{self, ResolvedMount};
 use crate::render::{self, RenderReport};
 use crate::secret;
@@ -278,6 +278,25 @@ pub(crate) struct ApplyCtx<'a> {
     pub(crate) unresolved: RefCell<Vec<Utf8PathBuf>>,
 }
 
+impl ApplyCtx<'_> {
+    /// Effective file mode for one `[[link]]` entry: its own `mode`
+    /// when it declares one, the `[mount]` default otherwise. The
+    /// entry's value was validated against its kind at declaration
+    /// time, so a `junction` can't reach here.
+    pub(crate) fn file_mode_for(&self, mode: Option<LinkMode>) -> EffectiveFileMode {
+        mode.and_then(|m| m.as_file())
+            .map(resolve_file_mode)
+            .unwrap_or(self.file_mode)
+    }
+
+    /// Directory counterpart of [`Self::file_mode_for`].
+    pub(crate) fn dir_mode_for(&self, mode: Option<LinkMode>) -> EffectiveDirMode {
+        mode.and_then(|m| m.as_dir())
+            .map(resolve_dir_mode)
+            .unwrap_or(self.dir_mode)
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn process_mount(
     m: &ResolvedMount,
@@ -356,7 +375,7 @@ fn walk_and_link_body(
         // Empty marker = junction this dir at the natural mount-derived
         // dst. Subsequent recursion keeps going so descendant markers
         // can layer on extra dsts.
-        link_dir_with_backup(src_dir, dst_dir, ctx)?;
+        link_dir_with_backup(src_dir, dst_dir, ctx, ctx.dir_mode)?;
         covered = true;
     }
     if !spec.links.is_empty() {
@@ -378,10 +397,10 @@ fn walk_and_link_body(
                     if !file_src.is_file() {
                         anyhow::bail!("{} not found", link.describe(src_dir));
                     }
-                    link_file_with_backup(&file_src, &dst, ctx)?;
+                    link_file_with_backup(&file_src, &dst, ctx, ctx.file_mode_for(link.mode))?;
                 }
                 None => {
-                    link_dir_with_backup(src_dir, &dst, ctx)?;
+                    link_dir_with_backup(src_dir, &dst, ctx, ctx.dir_mode_for(link.mode))?;
                     emitted_dir_link = true;
                 }
             }
@@ -431,7 +450,7 @@ fn walk_and_link_body(
             // (and on Windows might land at a path that's already
             // hard-linked through the parent).
             if !covered {
-                link_file_with_backup(&src_path, &dst_path, ctx)?;
+                link_file_with_backup(&src_path, &dst_path, ctx, ctx.file_mode)?;
             }
         }
     }
@@ -442,6 +461,7 @@ pub(crate) fn link_file_with_backup(
     src: &Utf8Path,
     dst: &Utf8Path,
     ctx: &ApplyCtx<'_>,
+    mode: EffectiveFileMode,
 ) -> Result<()> {
     use absorb::AbsorbDecision::*;
 
@@ -463,7 +483,7 @@ pub(crate) fn link_file_with_backup(
         }
         Restore => {
             info!("link: {src} → {dst}");
-            link::link_file(src, dst, ctx.file_mode)?;
+            link::link_file(src, dst, mode)?;
             Ok(())
         }
         RelinkOnly => {
@@ -471,7 +491,7 @@ pub(crate) fn link_file_with_backup(
             // editor's atomic save). Re-link without touching source.
             info!("relink: {src} → {dst}");
             link::unlink(dst)?;
-            link::link_file(src, dst, ctx.file_mode)?;
+            link::link_file(src, dst, mode)?;
             Ok(())
         }
         AutoAbsorb => {
@@ -482,6 +502,7 @@ pub(crate) fn link_file_with_backup(
                     src,
                     dst,
                     ctx,
+                    mode,
                     "absorb.auto = false; treating divergence as anomaly",
                 );
             }
@@ -490,15 +511,17 @@ pub(crate) fn link_file_with_backup(
                     src,
                     dst,
                     ctx,
+                    mode,
                     "source repo is dirty; deferring auto-absorb",
                 );
             }
-            absorb_target_into_source(src, dst, ctx)
+            absorb_target_into_source(src, dst, ctx, mode)
         }
         NeedsConfirm => handle_anomaly(
             src,
             dst,
             ctx,
+            mode,
             "anomaly: source equals/newer than target but content differs",
         ),
     }
@@ -511,12 +534,13 @@ pub(crate) fn absorb_target_into_source(
     src: &Utf8Path,
     dst: &Utf8Path,
     ctx: &ApplyCtx<'_>,
+    mode: EffectiveFileMode,
 ) -> Result<()> {
     info!("absorb: {dst} → {src}");
     backup_existing(src, ctx.backup_root, /* is_dir */ false)?;
     std::fs::copy(dst, src)?;
     link::unlink(dst)?;
-    link::link_file(src, dst, ctx.file_mode)?;
+    link::link_file(src, dst, mode)?;
     Ok(())
 }
 
@@ -529,11 +553,12 @@ pub(crate) fn overwrite_source_into_target(
     src: &Utf8Path,
     dst: &Utf8Path,
     ctx: &ApplyCtx<'_>,
+    mode: EffectiveFileMode,
 ) -> Result<()> {
     info!("overwrite: {src} → {dst}");
     backup_existing(dst, ctx.backup_root, /* is_dir */ false)?;
     link::unlink(dst)?;
-    link::link_file(src, dst, ctx.file_mode)?;
+    link::link_file(src, dst, mode)?;
     Ok(())
 }
 
@@ -553,7 +578,13 @@ fn note_unresolved(ctx: &ApplyCtx<'_>, dst: &Utf8Path, reason: &str) {
 ///   - `force` → behave like AutoAbsorb (target wins)
 ///   - `ask`   → on a TTY, show diff + prompt. Off-TTY, leave the target
 ///     alone and record it as unresolved.
-fn handle_anomaly(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>, reason: &str) -> Result<()> {
+fn handle_anomaly(
+    src: &Utf8Path,
+    dst: &Utf8Path,
+    ctx: &ApplyCtx<'_>,
+    mode: EffectiveFileMode,
+    reason: &str,
+) -> Result<()> {
     use crate::config::AnomalyAction::*;
     match ctx.config.absorb.on_anomaly {
         Skip => {
@@ -562,11 +593,11 @@ fn handle_anomaly(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>, reason: &s
         }
         Force => {
             warn!("anomaly force: {dst} ({reason}) — absorbing target into source");
-            absorb_target_into_source(src, dst, ctx)
+            absorb_target_into_source(src, dst, ctx, mode)
         }
         Ask => match prompt_anomaly(ctx, src, dst, reason)? {
-            AnomalyChoice::Absorb => absorb_target_into_source(src, dst, ctx),
-            AnomalyChoice::Overwrite => overwrite_source_into_target(src, dst, ctx),
+            AnomalyChoice::Absorb => absorb_target_into_source(src, dst, ctx, mode),
+            AnomalyChoice::Overwrite => overwrite_source_into_target(src, dst, ctx, mode),
             AnomalyChoice::Skip => {
                 warn!("anomaly skipped by user: {dst}");
                 Ok(())
@@ -899,6 +930,7 @@ pub(crate) fn link_dir_with_backup(
     src: &Utf8Path,
     dst: &Utf8Path,
     ctx: &ApplyCtx<'_>,
+    mode: EffectiveDirMode,
 ) -> Result<()> {
     use absorb::AbsorbDecision::*;
 
@@ -926,7 +958,7 @@ pub(crate) fn link_dir_with_backup(
         InSync => Ok(()),
         Restore => {
             info!("link dir: {src} → {dst}");
-            link::link_dir(src, dst, ctx.dir_mode)?;
+            link::link_dir(src, dst, mode)?;
             Ok(())
         }
         RelinkOnly => {
@@ -936,7 +968,7 @@ pub(crate) fn link_dir_with_backup(
             // so just swap the target for a junction to source.
             info!("relink dir: {src} → {dst}");
             remove_dir_link_or_real(dst)?;
-            link::link_dir(src, dst, ctx.dir_mode)?;
+            link::link_dir(src, dst, mode)?;
             Ok(())
         }
         AutoAbsorb | NeedsConfirm => {
@@ -965,6 +997,7 @@ pub(crate) fn link_dir_with_backup(
                     src,
                     dst,
                     ctx,
+                    mode,
                     "absorb.auto = false; treating divergence as anomaly",
                 );
             }
@@ -973,10 +1006,11 @@ pub(crate) fn link_dir_with_backup(
                     src,
                     dst,
                     ctx,
+                    mode,
                     "source repo is dirty; deferring auto-absorb",
                 );
             }
-            absorb_target_dir_into_source(src, dst, ctx)
+            absorb_target_dir_into_source(src, dst, ctx, mode)
         }
     }
 }
@@ -1338,6 +1372,7 @@ pub(crate) fn absorb_target_dir_into_source(
     src: &Utf8Path,
     dst: &Utf8Path,
     ctx: &ApplyCtx<'_>,
+    mode: EffectiveDirMode,
 ) -> Result<()> {
     info!("absorb dir: {dst} → {src}");
     backup_existing(src, ctx.backup_root, /* is_dir */ true)?;
@@ -1346,7 +1381,7 @@ pub(crate) fn absorb_target_dir_into_source(
         Ok(Some(staged)) => staged,
         // Target vanished under us between classify and now — there is
         // nothing left to absorb, so just expose source.
-        Ok(None) => return link::link_dir(src, dst, ctx.dir_mode).map_err(Into::into),
+        Ok(None) => return link::link_dir(src, dst, mode).map_err(Into::into),
         Err(e) => {
             warn!("cannot stage {dst} aside ({e:#}) — falling back to in-place teardown");
             merge_dir_target_into_source(dst, src, ctx)?;
@@ -1359,12 +1394,12 @@ pub(crate) fn absorb_target_dir_into_source(
                 return Ok(());
             }
             remove_dir_link_or_real(dst)?;
-            link::link_dir(src, dst, ctx.dir_mode)?;
+            link::link_dir(src, dst, mode)?;
             return Ok(());
         }
     };
 
-    link::link_dir(src, dst, ctx.dir_mode)?;
+    link::link_dir(src, dst, mode)?;
     merge_dir_target_into_source(&staged, src, ctx)?;
 
     // If the user picked `[q]uit` at a prompt during the merge, put the
@@ -1396,19 +1431,20 @@ fn overwrite_source_dir_into_target(
     src: &Utf8Path,
     dst: &Utf8Path,
     ctx: &ApplyCtx<'_>,
+    mode: EffectiveDirMode,
 ) -> Result<()> {
     info!("overwrite dir: {src} → {dst}");
     backup_existing(dst, ctx.backup_root, /* is_dir */ true)?;
     match stage_aside(dst, paths::StagedKind::Discard) {
         Ok(Some(staged)) => {
-            link::link_dir(src, dst, ctx.dir_mode)?;
+            link::link_dir(src, dst, mode)?;
             remove_staged(&staged);
         }
-        Ok(None) => link::link_dir(src, dst, ctx.dir_mode)?,
+        Ok(None) => link::link_dir(src, dst, mode)?,
         Err(e) => {
             warn!("cannot stage {dst} aside ({e:#}) — falling back to in-place teardown");
             remove_dir_link_or_real(dst)?;
-            link::link_dir(src, dst, ctx.dir_mode)?;
+            link::link_dir(src, dst, mode)?;
         }
     }
     Ok(())
@@ -1422,6 +1458,7 @@ fn handle_anomaly_dir(
     src: &Utf8Path,
     dst: &Utf8Path,
     ctx: &ApplyCtx<'_>,
+    mode: EffectiveDirMode,
     reason: &str,
 ) -> Result<()> {
     use crate::config::AnomalyAction::*;
@@ -1435,11 +1472,11 @@ fn handle_anomaly_dir(
                 "anomaly force dir: {dst} ({reason}) \
                  — absorbing target into source"
             );
-            absorb_target_dir_into_source(src, dst, ctx)
+            absorb_target_dir_into_source(src, dst, ctx, mode)
         }
         Ask => match prompt_anomaly(ctx, src, dst, reason)? {
-            AnomalyChoice::Absorb => absorb_target_dir_into_source(src, dst, ctx),
-            AnomalyChoice::Overwrite => overwrite_source_dir_into_target(src, dst, ctx),
+            AnomalyChoice::Absorb => absorb_target_dir_into_source(src, dst, ctx, mode),
+            AnomalyChoice::Overwrite => overwrite_source_dir_into_target(src, dst, ctx, mode),
             AnomalyChoice::Skip => {
                 warn!("anomaly skipped by user: {dst}");
                 Ok(())

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -194,11 +194,14 @@ dst = "~"
 
 # Explicit links, declared centrally instead of with a `.yuilink`
 # marker file in the tree. `src` is relative to $DOTFILES and may name
-# a directory (linked as one unit) or a single file.
+# a directory (linked as one unit) or a single file. `mode` overrides
+# the [mount] mechanism for that entry alone — dirs take
+# auto|symlink|junction, files auto|symlink|hardlink.
 # [[link]]
 # src = "home/.config/nvim"
 # dst = "{{ env(name='LOCALAPPDATA') }}/nvim"
 # when = "yui.os == 'windows'"
+# mode = "symlink"
 "#;
 
 const SKELETON_GITIGNORE: &str = r#"# yui per-machine state and backups (regenerable, do not commit).

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::config::{self, Config, IconsMode};
 use crate::icons::Icons;
-use crate::links::LinkPlan;
+use crate::links::{LinkMode, LinkPlan};
 use crate::paths;
 use crate::template;
 use crate::vars::YuiVars;
@@ -58,6 +58,10 @@ struct ListItem {
     dst: String,
     when: Option<String>,
     active: bool,
+    /// Per-entry `mode` override, if the entry declares one. `None`
+    /// means "whatever `[mount]` says", which is the common case — the
+    /// column only appears when something actually overrides.
+    mode: Option<&'static str>,
 }
 
 fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Result<Vec<ListItem>> {
@@ -80,6 +84,7 @@ fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Resu
             dst,
             when: entry.when.clone(),
             active,
+            mode: None,
         });
     }
 
@@ -120,6 +125,7 @@ fn collect_list_items(source: &Utf8Path, config: &Config, yui: &YuiVars) -> Resu
                 dst,
                 when: link.when.clone(),
                 active,
+                mode: link.mode.map(LinkMode::as_str),
             });
         }
     }
@@ -141,15 +147,23 @@ fn print_list_table(items: &[&ListItem], icons: Icons, color: bool) {
         .max()
         .unwrap_or(0)
         .max("DST".len());
+    // The MODE column only exists when something overrides `[mount]`.
+    // Most repos never do, and an always-empty column is just noise.
+    let mode_w = items
+        .iter()
+        .filter_map(|i| i.mode)
+        .map(|m| m.chars().count())
+        .max()
+        .map(|w| w.max("MODE".len()));
 
     let status_w = "STATUS".len();
     let arrow_w = icons.arrow.chars().count();
 
     // Header
-    print_header(status_w, src_w, arrow_w, dst_w, color);
+    print_header(status_w, src_w, arrow_w, dst_w, mode_w, color);
 
     // Separator
-    let sep = render_separator(icons.sep, status_w, src_w, arrow_w, dst_w);
+    let sep = render_separator(icons.sep, status_w, src_w, arrow_w, dst_w, mode_w);
     if color {
         use owo_colors::OwoColorize as _;
         println!("{}", sep.dimmed());
@@ -159,18 +173,29 @@ fn print_list_table(items: &[&ListItem], icons: Icons, color: bool) {
 
     // Rows
     for item in items {
-        print_row(item, icons, status_w, src_w, arrow_w, dst_w, color);
+        print_row(item, icons, status_w, src_w, arrow_w, dst_w, mode_w, color);
     }
 }
 
-fn print_header(status_w: usize, src_w: usize, arrow_w: usize, dst_w: usize, color: bool) {
+fn print_header(
+    status_w: usize,
+    src_w: usize,
+    arrow_w: usize,
+    dst_w: usize,
+    mode_w: Option<usize>,
+    color: bool,
+) {
     use owo_colors::OwoColorize as _;
     let mut line = String::new();
     let _ = write!(
         &mut line,
-        "  {:<status_w$}  {:<src_w$}  {:<arrow_w$}  {:<dst_w$}  WHEN",
+        "  {:<status_w$}  {:<src_w$}  {:<arrow_w$}  {:<dst_w$}",
         "STATUS", "SRC", "", "DST"
     );
+    if let Some(w) = mode_w {
+        let _ = write!(&mut line, "  {:<w$}", "MODE");
+    }
+    let _ = write!(&mut line, "  WHEN");
     if color {
         println!("{}", line.bold());
     } else {
@@ -184,18 +209,24 @@ fn render_separator(
     src_w: usize,
     arrow_w: usize,
     dst_w: usize,
+    mode_w: Option<usize>,
 ) -> String {
     let bar = |n: usize| sep_ch.to_string().repeat(n);
-    format!(
-        "  {}  {}  {}  {}  {}",
+    let mut out = format!(
+        "  {}  {}  {}  {}",
         bar(status_w),
         bar(src_w),
         bar(arrow_w),
         bar(dst_w),
-        bar("WHEN".len())
-    )
+    );
+    if let Some(w) = mode_w {
+        let _ = write!(&mut out, "  {}", bar(w));
+    }
+    let _ = write!(&mut out, "  {}", bar("WHEN".len()));
+    out
 }
 
+#[allow(clippy::too_many_arguments)]
 fn print_row(
     item: &ListItem,
     icons: Icons,
@@ -203,6 +234,7 @@ fn print_row(
     src_w: usize,
     arrow_w: usize,
     dst_w: usize,
+    mode_w: Option<usize>,
     color: bool,
 ) {
     use owo_colors::OwoColorize as _;
@@ -231,29 +263,41 @@ fn print_row(
     let cell_src = format!("{:<src_w$}", src);
     let cell_arrow = format!("{:<arrow_w$}", arrow);
     let cell_dst = format!("{:<dst_w$}", dst);
+    // Entries without an override show `-`: the column exists because
+    // *some* entry overrides, and a blank cell would read as missing
+    // data rather than "the default applies".
+    let cell_mode = mode_w.map(|w| format!("{:<w$}", item.mode.unwrap_or("-")));
 
     if !color {
-        println!("  {cell_status}  {cell_src}  {cell_arrow}  {cell_dst}  {when_str}");
+        let mut line = format!("  {cell_status}  {cell_src}  {cell_arrow}  {cell_dst}");
+        if let Some(cell) = &cell_mode {
+            let _ = write!(&mut line, "  {cell}");
+        }
+        let _ = write!(&mut line, "  {when_str}");
+        println!("{line}");
         return;
     }
 
-    if item.active {
-        println!(
-            "  {}  {}  {}  {}  {}",
+    let mut line = if item.active {
+        format!(
+            "  {}  {}  {}  {}",
             cell_status.green(),
             cell_src.cyan(),
             cell_arrow.dimmed(),
             cell_dst.green(),
-            when_str.dimmed()
-        );
+        )
     } else {
-        println!(
-            "  {}  {}  {}  {}  {}",
+        format!(
+            "  {}  {}  {}  {}",
             cell_status.red().dimmed(),
             cell_src.dimmed(),
             cell_arrow.dimmed(),
             cell_dst.dimmed(),
-            when_str.dimmed()
-        );
+        )
+    };
+    if let Some(cell) = &cell_mode {
+        let _ = write!(&mut line, "  {}", cell.yellow());
     }
+    let _ = write!(&mut line, "  {}", when_str.dimmed());
+    println!("{line}");
 }

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -2192,6 +2192,195 @@ dst = "{0}/.gitconfig-alt"
     assert!(target.join(".gitconfig-alt").exists());
 }
 
+/// A file entry can pick its mechanism without dragging the rest of the
+/// repo along. `hardlink` is the cross-platform choice to assert on:
+/// forcing a *symlink* on Windows would need Developer Mode, which is
+/// exactly the global-flip cost this feature exists to avoid.
+#[test]
+fn per_entry_mode_overrides_the_global_file_mode() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("home"));
+    let alt = utf8(tmp.path().join("alt"));
+    std::fs::create_dir_all(source.join("home/app")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::create_dir_all(&alt).unwrap();
+    std::fs::write(source.join("home/app/keep.conf"), "body\n").unwrap();
+
+    let cfg = format!(
+        r#"
+[mount]
+file_mode = "symlink"
+
+[[mount.entry]]
+src = "home"
+dst = "{}"
+
+[[link]]
+src = "home/app/keep.conf"
+dst = "{}/keep.conf"
+mode = "hardlink"
+"#,
+        toml_path(&target),
+        toml_path(&alt)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    apply(Some(source.clone()), false).unwrap();
+
+    // The overriding entry is a hardlink: same inode, and NOT a symlink.
+    let linked = alt.join("keep.conf");
+    let meta = std::fs::symlink_metadata(&linked).unwrap();
+    assert!(
+        !meta.file_type().is_symlink(),
+        "entry asked for hardlink, got a symlink"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&linked).unwrap(),
+        "body\n",
+        "hardlink should expose the source content"
+    );
+    // Writing through the link reaches source — that's what makes it a
+    // link rather than a copy.
+    std::fs::write(&linked, "edited\n").unwrap();
+    assert_eq!(
+        std::fs::read_to_string(source.join("home/app/keep.conf")).unwrap(),
+        "edited\n"
+    );
+}
+
+/// `yui absorb <target>` re-links after copying, so it has to use the
+/// mechanism the claiming declaration asked for. Relinking with the
+/// global mode would quietly undo the override — and `classify`
+/// compares by identity, not mechanism, so a later `apply` would read
+/// InSync and never put it back.
+#[test]
+fn manual_absorb_honours_the_entry_mode() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("home"));
+    let alt = utf8(tmp.path().join("alt"));
+    std::fs::create_dir_all(source.join("home/app")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::create_dir_all(&alt).unwrap();
+    std::fs::write(source.join("home/app/keep.conf"), "from source\n").unwrap();
+
+    let cfg = format!(
+        r#"
+[mount]
+file_mode = "symlink"
+
+[[mount.entry]]
+src = "home"
+dst = "{}"
+
+[[link]]
+src = "home/app/keep.conf"
+dst = "{}/keep.conf"
+mode = "hardlink"
+"#,
+        toml_path(&target),
+        toml_path(&alt)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    // Target-side content that diverged from source — the thing manual
+    // absorb exists to pull back in.
+    let dst_file = alt.join("keep.conf");
+    std::fs::write(&dst_file, "edited on the target side\n").unwrap();
+
+    absorb(
+        Some(source.clone()),
+        dst_file.clone(),
+        /* dry_run */ false,
+        /* yes */ true,
+    )
+    .unwrap();
+
+    // Content came back…
+    assert_eq!(
+        std::fs::read_to_string(source.join("home/app/keep.conf")).unwrap(),
+        "edited on the target side\n"
+    );
+    // …and the relink used the entry's hardlink, not `[mount]`'s symlink.
+    let meta = std::fs::symlink_metadata(&dst_file).unwrap();
+    assert!(
+        !meta.file_type().is_symlink(),
+        "absorb relinked with the global symlink mode, dropping the entry's mode = \"hardlink\""
+    );
+    std::fs::write(&dst_file, "written through the link\n").unwrap();
+    assert_eq!(
+        std::fs::read_to_string(source.join("home/app/keep.conf")).unwrap(),
+        "written through the link\n",
+        "target and source should share an inode after the relink"
+    );
+}
+
+/// The mode is rejected where it is declared, so a bad combination
+/// never reaches the link call.
+#[test]
+fn per_entry_mode_rejects_impossible_combination() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("home"));
+    std::fs::create_dir_all(source.join("home/app")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{0}"
+
+[[link]]
+src = "home/app"
+dst = "{0}/app"
+mode = "hardlink"
+"#,
+        toml_path(&target)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    let err = apply(Some(source.clone()), false).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("cannot link a directory"), "got {msg}");
+}
+
+/// A `.yuilink` entry carries `mode` with the same rules — the schema
+/// is shared, so a marker gets the feature for free.
+#[test]
+fn marker_entry_mode_is_validated_too() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    let target = utf8(tmp.path().join("home"));
+    std::fs::create_dir_all(source.join("home/app")).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(
+        source.join("home/app/.yuilink"),
+        format!(
+            "[[link]]\ndst = \"{}/app\"\nmode = \"hardlink\"\n",
+            toml_path(&target)
+        ),
+    )
+    .unwrap();
+
+    let cfg = format!(
+        r#"
+[[mount.entry]]
+src = "home"
+dst = "{}"
+"#,
+        toml_path(&target)
+    );
+    std::fs::write(source.join("config.toml"), cfg).unwrap();
+
+    let err = apply(Some(source.clone()), false).unwrap_err();
+    assert!(
+        format!("{err:#}").contains("cannot link a directory"),
+        "got {err:#}"
+    );
+}
+
 /// The pre-0.11 `[link] file_mode / dir_mode` table now collides with
 /// the `[[link]]` array. Serde's own type error says nothing about
 /// where the keys went, so `load` intercepts the old shape.
@@ -3101,7 +3290,7 @@ fn overwrite_source_into_target_replaces_target_and_backs_up() {
         unresolved: RefCell::new(Vec::new()),
     };
 
-    overwrite_source_into_target(&src_file, &dst_file, &ctx).unwrap();
+    overwrite_source_into_target(&src_file, &dst_file, &ctx, ctx.file_mode).unwrap();
 
     // Target now matches source.
     assert_eq!(std::fs::read_to_string(&dst_file).unwrap(), "from source");
@@ -3156,7 +3345,7 @@ fn link_file_with_backup_short_circuits_when_quit_requested() {
         unresolved: RefCell::new(Vec::new()),
     };
 
-    link_file_with_backup(&src_file, &dst_file, &ctx).unwrap();
+    link_file_with_backup(&src_file, &dst_file, &ctx, ctx.file_mode).unwrap();
 
     assert_eq!(std::fs::read_to_string(&dst_file).unwrap(), dst_before);
     assert_eq!(std::fs::read_to_string(&src_file).unwrap(), src_before);
@@ -3241,7 +3430,7 @@ fn absorb_dir_stages_target_aside_and_cleans_up() {
     std::fs::write(dst_dir.join("lua/only-in-target.lua"), "T").unwrap();
 
     let ctx = dir_ctx!(cfg, plan, backup_root);
-    absorb_target_dir_into_source(&src_dir, &dst_dir, &ctx).unwrap();
+    absorb_target_dir_into_source(&src_dir, &dst_dir, &ctx, ctx.dir_mode).unwrap();
 
     assert_eq!(
         std::fs::read_to_string(src_dir.join("lua/only-in-target.lua")).unwrap(),
@@ -3280,7 +3469,7 @@ fn interrupted_absorb_staging_is_resumed_before_classify() {
     std::fs::write(staged.join("lua/rescued.lua"), "R").unwrap();
 
     let ctx = dir_ctx!(cfg, plan, backup_root);
-    link_dir_with_backup(&src_dir, &dst_dir, &ctx).unwrap();
+    link_dir_with_backup(&src_dir, &dst_dir, &ctx, ctx.dir_mode).unwrap();
 
     assert_eq!(
         std::fs::read_to_string(src_dir.join("lua/rescued.lua")).unwrap(),
@@ -3314,7 +3503,7 @@ fn interrupted_overwrite_staging_is_discarded_not_merged() {
     std::fs::write(staged.join("ghost.lua"), "G").unwrap();
 
     let ctx = dir_ctx!(cfg, plan, backup_root);
-    link_dir_with_backup(&src_dir, &dst_dir, &ctx).unwrap();
+    link_dir_with_backup(&src_dir, &dst_dir, &ctx, ctx.dir_mode).unwrap();
 
     assert!(!staged.exists(), "discard staging is swept");
     assert!(
@@ -3345,7 +3534,7 @@ fn dry_run_recovery_leaves_staging_untouched() {
 
     let mut ctx = dir_ctx!(cfg, plan, backup_root);
     ctx.dry_run = true;
-    link_dir_with_backup(&src_dir, &dst_dir, &ctx).unwrap();
+    link_dir_with_backup(&src_dir, &dst_dir, &ctx, ctx.dir_mode).unwrap();
 
     assert!(staged.exists(), "dry-run must not sweep staging");
     assert!(!src_dir.join("kept.lua").exists(), "dry-run must not merge");
@@ -3377,7 +3566,7 @@ fn quit_during_dir_absorb_restores_the_target() {
 
     let mut ctx = dir_ctx!(cfg, plan, backup_root);
     ctx.quit_requested = Cell::new(true);
-    absorb_target_dir_into_source(&src_dir, &dst_dir, &ctx).unwrap();
+    absorb_target_dir_into_source(&src_dir, &dst_dir, &ctx, ctx.dir_mode).unwrap();
 
     assert!(
         paths::scan_staged(&dst_dir).is_empty(),

--- a/src/links.rs
+++ b/src/links.rs
@@ -32,6 +32,7 @@ use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 use serde::Deserialize;
 use tracing::warn;
 
+use crate::config::{DirLinkMode, FileLinkMode};
 use crate::marker::{self, MarkerSpec};
 use crate::paths;
 use crate::{Error, Result};
@@ -49,6 +50,80 @@ pub struct LinkEntry {
     /// Tera expression gating the entry.
     #[serde(default)]
     pub when: Option<String>,
+    /// Link mechanism for this entry only, overriding `[mount]
+    /// file_mode` / `dir_mode`. One awkward app (a watcher that
+    /// resolves reparse points, an installer that rewrites in place)
+    /// shouldn't force the whole repo onto a different mechanism —
+    /// especially on Windows, where symlinks need Developer Mode or
+    /// admin and the `auto` default exists to avoid exactly that.
+    #[serde(default)]
+    pub mode: Option<LinkMode>,
+}
+
+/// Per-entry `mode` as written. Which values are legal depends on what
+/// the entry links: a directory can't be hardlinked, a file can't be a
+/// junction. Resolution to an effective mode goes through
+/// [`LinkMode::as_dir`] / [`LinkMode::as_file`], which return `None`
+/// for the combination that doesn't exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LinkMode {
+    Auto,
+    Symlink,
+    Hardlink,
+    Junction,
+}
+
+impl LinkMode {
+    pub fn as_dir(self) -> Option<DirLinkMode> {
+        match self {
+            Self::Auto => Some(DirLinkMode::Auto),
+            Self::Symlink => Some(DirLinkMode::Symlink),
+            Self::Junction => Some(DirLinkMode::Junction),
+            Self::Hardlink => None,
+        }
+    }
+
+    pub fn as_file(self) -> Option<FileLinkMode> {
+        match self {
+            Self::Auto => Some(FileLinkMode::Auto),
+            Self::Symlink => Some(FileLinkMode::Symlink),
+            Self::Hardlink => Some(FileLinkMode::Hardlink),
+            Self::Junction => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Symlink => "symlink",
+            Self::Hardlink => "hardlink",
+            Self::Junction => "junction",
+        }
+    }
+}
+
+/// Reject `mode = "hardlink"` on a directory and `mode = "junction"` on
+/// a file at declaration time — both are config bugs with no sensible
+/// runtime interpretation.
+pub fn validate_mode(mode: LinkMode, dir_scoped: bool, label: &str) -> Result<()> {
+    let ok = if dir_scoped {
+        mode.as_dir().is_some()
+    } else {
+        mode.as_file().is_some()
+    };
+    if ok {
+        return Ok(());
+    }
+    let (kind, allowed) = if dir_scoped {
+        ("a directory", "auto | symlink | junction")
+    } else {
+        ("a file", "auto | symlink | hardlink")
+    };
+    Err(Error::Config(format!(
+        "{label}: mode = {:?} cannot link {kind} ({allowed})",
+        mode.as_str()
+    )))
 }
 
 /// Diagnostic prefix for the central table. Every `config.toml`-sourced
@@ -86,6 +161,9 @@ pub struct DirLink {
     pub dst: String,
     pub when: Option<String>,
     pub origin: Origin,
+    /// Per-entry mechanism override, already validated against the
+    /// entry's kind.
+    pub mode: Option<LinkMode>,
 }
 
 impl DirLink {
@@ -107,6 +185,15 @@ pub struct DirSpec {
     pub passthrough: bool,
     pub links: Vec<DirLink>,
 }
+
+/// What makes two `[[link]]` declarations "the same": target-relative
+/// path, dst template, `when` guard and mechanism.
+type DedupeKey = (
+    Option<Utf8PathBuf>,
+    String,
+    Option<String>,
+    Option<LinkMode>,
+);
 
 /// Central `[[link]]` entries, keyed by the source directory the walk
 /// has to be standing in for them to fire.
@@ -153,12 +240,16 @@ impl LinkPlan {
                 })?;
                 (parent, Some(Utf8PathBuf::from(name)))
             };
+            if let Some(mode) = entry.mode {
+                validate_mode(mode, rel.is_none(), &format!("{CONFIG_LABEL} src={src}"))?;
+            }
             by_dir.entry(dir).or_default().push(DirLink {
                 rel,
                 declared: Some(src.clone()),
                 dst: entry.dst.clone(),
                 when: entry.when.clone(),
                 origin: Origin::Config,
+                mode: entry.mode,
             });
         }
         Ok(Self { by_dir })
@@ -188,6 +279,7 @@ impl LinkPlan {
                         dst: e.dst,
                         when: e.when,
                         origin: Origin::Marker,
+                        mode: e.mode,
                     }));
                 }
             }
@@ -195,9 +287,12 @@ impl LinkPlan {
         if let Some(central) = self.by_dir.get(dir) {
             spec.links.extend(central.iter().cloned());
         }
-        let mut seen: BTreeSet<(Option<Utf8PathBuf>, String, Option<String>)> = BTreeSet::new();
+        // Dedupe on everything that decides what gets linked and how:
+        // the same dst reached with two different mechanisms is a
+        // genuine (if odd) pair of declarations, not a duplicate.
+        let mut seen: BTreeSet<DedupeKey> = BTreeSet::new();
         spec.links
-            .retain(|l| seen.insert((l.rel.clone(), l.dst.clone(), l.when.clone())));
+            .retain(|l| seen.insert((l.rel.clone(), l.dst.clone(), l.when.clone(), l.mode)));
         Ok(spec)
     }
 
@@ -297,6 +392,14 @@ mod tests {
             src: Some(Utf8PathBuf::from(src)),
             dst: dst.to_string(),
             when: None,
+            mode: None,
+        }
+    }
+
+    fn entry_with_mode(src: &str, dst: &str, mode: LinkMode) -> LinkEntry {
+        LinkEntry {
+            mode: Some(mode),
+            ..entry(src, dst)
         }
     }
 
@@ -352,6 +455,7 @@ mod tests {
                 src: None,
                 dst: "/t".to_string(),
                 when: None,
+                mode: None,
             }],
         )
         .unwrap_err();
@@ -441,6 +545,67 @@ mod tests {
             .dir_spec(&source.join("home/.config/nvim"), ".yuilink", true)
             .unwrap();
         assert_eq!(spec.links.len(), 2);
+    }
+
+    /// A directory can't be hardlinked and a file can't be a junction;
+    /// both are caught where the entry is declared, not at link time.
+    #[test]
+    fn mode_is_validated_against_the_entry_kind() {
+        let tmp = TempDir::new().unwrap();
+        let source = root(&tmp);
+        std::fs::create_dir_all(source.join("home/dir")).unwrap();
+        std::fs::write(source.join("home/file.txt"), "x").unwrap();
+
+        let err = LinkPlan::from_config(
+            &source,
+            &[entry_with_mode("home/dir", "/t/dir", LinkMode::Hardlink)],
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err}").contains("cannot link a directory"),
+            "{err}"
+        );
+
+        let err = LinkPlan::from_config(
+            &source,
+            &[entry_with_mode("home/file.txt", "/t/f", LinkMode::Junction)],
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("cannot link a file"), "{err}");
+
+        // The legal combinations survive.
+        LinkPlan::from_config(
+            &source,
+            &[
+                entry_with_mode("home/dir", "/t/dir", LinkMode::Symlink),
+                entry_with_mode("home/file.txt", "/t/f", LinkMode::Hardlink),
+            ],
+        )
+        .unwrap();
+    }
+
+    /// `mode` rides along to the walk, and two entries that differ only
+    /// by mechanism are two declarations, not a duplicate.
+    #[test]
+    fn mode_reaches_the_dir_spec_and_survives_dedupe() {
+        let tmp = TempDir::new().unwrap();
+        let source = root(&tmp);
+        std::fs::create_dir_all(source.join("home/app")).unwrap();
+        let plan = LinkPlan::from_config(
+            &source,
+            &[
+                entry("home/app", "/t/app"),
+                entry_with_mode("home/app", "/t/app", LinkMode::Symlink),
+            ],
+        )
+        .unwrap();
+
+        let spec = plan
+            .dir_spec(&source.join("home/app"), ".yuilink", true)
+            .unwrap();
+        assert_eq!(spec.links.len(), 2);
+        assert_eq!(spec.links[0].mode, None);
+        assert_eq!(spec.links[1].mode, Some(LinkMode::Symlink));
     }
 
     /// `per-file` mounts ignore markers; a central entry is an explicit

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -113,6 +113,10 @@ pub fn read_spec(dir: &Utf8Path, marker_filename: &str) -> Result<Option<MarkerS
                 )));
             }
         }
+        if let Some(mode) = link.mode {
+            // `src` present = file scope, absent = this directory.
+            links::validate_mode(mode, link.src.is_none(), &format!("parse {path}: [[link]]"))?;
+        }
     }
     Ok(Some(MarkerSpec::Explicit { links: parsed.link }))
 }


### PR DESCRIPTION
Closes #232.

## Why

`[mount] file_mode` / `dir_mode` are repo-wide. One app that refuses to work through a junction forced `dir_mode = "symlink"` on everything — and on Windows that means every directory link needs Developer Mode or admin, which is exactly what the `auto` (hardlink + junction) default exists to avoid. The inverse exists too: an installer that rewrites in place chokes on a hardlinked file, with no way to exempt that single file.

## What

```toml
[[link]]
src = "home/.config/someapp"
dst = "~/.config/someapp"
mode = "symlink"        # this dir only; everything else stays junction
```

- Legal values follow what the entry links: dirs take `auto` / `symlink` / `junction`, files `auto` / `symlink` / `hardlink`.
- A mismatch fails where the entry is declared, with the alternatives in the message:
  `config.toml: [[link]] src=home/app: mode = "hardlink" cannot link a directory (auto | symlink | junction)`
- Same schema in `.yuilink`, so markers get the key with the same validation.
- `yui list` grows a `MODE` column **only when some entry overrides** — an always-empty column would be noise, and entries on the default show `-` rather than a blank cell.

## Implementation note

The effective mode is passed down the link / absorb call chain as an argument instead of being stashed on `ApplyCtx`. That costs a parameter on eight functions but keeps the property that matters: a per-file conflict resolved *inside* a directory merge resolves with the file default, not the enclosing directory's override. Ambient state would have silently coupled the two.

`absorb::classify` is untouched — it compares file identity via the `same-file` crate, which resolves symlinks, hardlinks and junctions transparently, so `status` reads the same regardless of mechanism.

## Verification

`cargo make check` green (fmt + clippy `-D warnings` + 248 tests + lock-check).

Five new tests: mode validated against entry kind (both directions), mode reaching `dir_spec` and surviving dedupe (two entries differing only by mechanism are two declarations), a file entry overriding the global `file_mode`, and the rejection paths from both `config.toml` and a marker.

Smoke test on a scratch repo, `[mount] dir_mode = "symlink"` globally with `mode = "junction"` on one entry:

```
INFO modes: file=Hardlink dir=Symlink
INFO link dir: …\src\home\app → …/target/app

# what actually landed on disk:
tag: 0xa0000003 → IO_REPARSE_TAG_MOUNT_POINT (junction)
```

The global setting says symlink, the entry says junction, and the reparse tag confirms the entry won.

`yui list` on the same repo:

```
  STATUS  SRC                     DST                       MODE      WHEN
  ------  ------------------  --  ------------------------  --------  ----
  [+]     home                ->  …/yui-mode/target         -         (always)
  [+]     home/app            ->  …/yui-mode/target/app     -         (always)
  [+]     home/app/keep.conf  ->  …/yui-mode/alt/keep.conf  hardlink  (always)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Link entries can now override the repository’s default mechanism with `auto`, symlink, hardlink, or junction modes.
  - Mode settings are validated for compatibility with file and directory targets.
  - `yui list` displays a `MODE` column when link-specific overrides are configured.

- **Bug Fixes**
  - Invalid mode combinations now produce configuration errors.
  - Link and absorb operations consistently honor each entry’s resolved mode.

- **Documentation**
  - Added guidance and configuration examples for per-entry link modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->