### PR TITLE
feat(gc-backup): prune by generation count with --keep-last

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ Need to absorb a single file regardless of policy? `yui absorb
 | `yui update [--dry-run]` | `git pull --ff-only` source repo, then re-apply |
 | `yui unmanaged [--icons MODE] [--no-color]` | list source files no `[[mount.entry]]` claims |
 | `yui doctor` | environment sanity check |
-| `yui gc-backup [--older-than DUR] [--dry-run]` | survey or prune `.yui/backup/` snapshots by suffix age |
+| `yui gc-backup [--older-than DUR] [--keep-last N] [--dry-run]` | survey or prune `.yui/backup/` snapshots |
 | `yui hooks list` | show configured `[[hook]]` entries + last-run state |
 | `yui hooks run [<name>] [--force]` | run hooks on demand (bypassing `when_run` with `--force`) |
 | `yui secret <init\|encrypt\|store\|unlock>` | manage `*.age` secrets + the X25519 identity — see [Secrets](#secrets-age--opt-in) |
@@ -577,6 +577,16 @@ Need to absorb a single file regardless of policy? `yui absorb
 `--icons` accepts `unicode` (default), `nerd` (Nerd-Font glyphs),
 `ascii` (CI-log-safe). The `[ui] icons = "..."` config key sets it
 globally.
+
+`gc-backup` with no rule surveys; `--older-than DUR` (`30d`, `2w`,
+`12h`, `6mo`, `1y` — bare `m` is *minutes*, months are `mo`) and
+`--keep-last N` are a retention policy, so **an
+entry survives if either rule protects it** — `--older-than 30d
+--keep-last 3` prunes anything over a month old except the three newest
+snapshots of each target. Generation count is the axis age can't reach:
+the snapshot that fills a disk is usually the freshest one, taken the
+moment a large directory was first absorbed. `--keep-last 0` protects
+nothing, which is the honest spelling for "purge".
 
 ### Background auto-update (`[ui] auto_update`)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -139,8 +139,14 @@ pub enum Command {
         /// Omit to run a non-destructive survey instead.
         #[arg(long, value_name = "DUR")]
         older_than: Option<String>,
+        /// Keep the newest N snapshots of each target and delete the
+        /// older generations regardless of age. `0` keeps none.
+        /// Composes with `--older-than`: an entry survives if either
+        /// rule protects it.
+        #[arg(long, value_name = "N")]
+        keep_last: Option<usize>,
         /// Preview the deletion (no files removed). Only meaningful
-        /// when `--older-than` is also given.
+        /// alongside `--older-than` / `--keep-last`.
         #[arg(long)]
         dry_run: bool,
         /// Override [ui] icons mode for this invocation
@@ -337,10 +343,11 @@ impl Cli {
             Command::Doctor { icons, no_color } => cmd::doctor(source, icons, no_color),
             Command::GcBackup {
                 older_than,
+                keep_last,
                 dry_run,
                 icons,
                 no_color,
-            } => cmd::gc_backup(source, older_than, dry_run, icons, no_color),
+            } => cmd::gc_backup(source, older_than, keep_last, dry_run, icons, no_color),
             Command::Hooks { action } => match action {
                 HookAction::List { icons, no_color } => cmd::hooks_list(source, icons, no_color),
                 HookAction::Run { name, force } => cmd::hooks_run(source, name, force),

--- a/src/cmd/gc_backup.rs
+++ b/src/cmd/gc_backup.rs
@@ -5,16 +5,29 @@ use crate::vars::YuiVars;
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 
-/// `yui gc-backup [--older-than DUR] [--dry-run]` — prune snapshots
-/// under `$DOTFILES/.yui/backup/`.
+/// `yui gc-backup [--older-than DUR] [--keep-last N] [--dry-run]` —
+/// prune snapshots under `$DOTFILES/.yui/backup/`.
 ///
-/// With no `--older-than` we run a non-destructive *survey*: walk the
-/// backup tree, list every entry whose name carries yui's
+/// With no rule we run a non-destructive *survey*: walk the backup
+/// tree, list every entry whose name carries yui's
 /// `_<YYYYMMDD_HHMMSSfff>[.<ext>]` suffix, and print AGE / SIZE / PATH
-/// sorted oldest-first plus a hint to pass `--older-than DUR` to
-/// actually delete. With `--older-than DUR` (e.g. `30d`, `2w`, `12h`,
-/// `6m`, `1y`) we delete every entry strictly older than the cutoff.
-/// `--dry-run` previews the same set without writing.
+/// sorted oldest-first plus a hint about the flags that delete.
+///
+/// Two rules, and they compose as a *retention policy* rather than a
+/// filter chain — **an entry survives if either rule protects it**:
+///   - `--older-than DUR` (e.g. `30d`, `2w`, `12h`, `6mo`, `1y` —
+///     note bare `m` is *minutes*, months need `mo`) keeps
+///     anything newer than the cutoff.
+///   - `--keep-last N` keeps the N newest snapshots of each target,
+///     however old they are. `N = 0` protects nothing, which is the
+///     honest spelling for "purge".
+///
+/// So `--older-than 30d --keep-last 3` prunes what's older than a
+/// month while never dropping the three newest of anything. Age alone
+/// can't help with the case that actually fills a disk: one fresh
+/// snapshot of a large junctioned tree.
+///
+/// `--dry-run` previews whichever policy was given.
 ///
 /// Two design points worth flagging:
 /// 1. *Suffix, not mtime.* `std::fs::copy` preserves source mtime on
@@ -27,6 +40,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 pub fn gc_backup(
     source: Option<Utf8PathBuf>,
     older_than: Option<String>,
+    keep_last: Option<usize>,
     dry_run: bool,
     icons_override: Option<IconsMode>,
     no_color: bool,
@@ -53,71 +67,131 @@ pub fn gc_backup(
     entries.sort_by_key(|e| e.ts);
     let now = jiff::Zoned::now();
 
-    match older_than {
-        None => {
-            let refs: Vec<&BackupEntry> = entries.iter().collect();
-            print_gc_table(&refs, &backup_root, &now, icons, color);
-            println!();
-            println!(
-                "  {} entries · {} total — pass --older-than DUR (e.g. 30d) to delete",
-                entries.len(),
-                format_bytes(entries.iter().map(|e| e.size_bytes).sum())
-            );
-            Ok(())
-        }
+    if older_than.is_none() && keep_last.is_none() {
+        let refs: Vec<&BackupEntry> = entries.iter().collect();
+        print_gc_table(&refs, &backup_root, &now, icons, color);
+        println!();
+        println!(
+            "  {} entries · {} total — pass --older-than DUR (e.g. 30d) \
+             or --keep-last N to delete",
+            entries.len(),
+            format_bytes(entries.iter().map(|e| e.size_bytes).sum())
+        );
+        return Ok(());
+    }
+
+    let cutoff = match &older_than {
         Some(dur_str) => {
-            let span = parse_human_duration(&dur_str)?;
-            let cutoff = now
-                .checked_sub(span)
-                .map_err(|e| anyhow::anyhow!("invalid duration {dur_str:?}: {e}"))?;
-            let cutoff_dt = cutoff.datetime();
-
-            let total_before: u64 = entries.iter().map(|e| e.size_bytes).sum();
-            let to_delete: Vec<&BackupEntry> =
-                entries.iter().filter(|e| e.ts < cutoff_dt).collect();
-
-            if to_delete.is_empty() {
-                println!(
-                    "  no backups older than {dur_str} (oldest: {})",
-                    format_age(entries[0].ts, &now)
-                );
-                return Ok(());
-            }
-
-            print_gc_table(&to_delete, &backup_root, &now, icons, color);
-            println!();
-            let total_freed: u64 = to_delete.iter().map(|e| e.size_bytes).sum();
-
-            if dry_run {
-                println!(
-                    "  [dry-run] would remove {} of {} entries · would free {} of {}",
-                    to_delete.len(),
-                    entries.len(),
-                    format_bytes(total_freed),
-                    format_bytes(total_before),
-                );
-                return Ok(());
-            }
-
-            for entry in &to_delete {
-                match entry.kind {
-                    BackupKind::File => std::fs::remove_file(&entry.path)?,
-                    BackupKind::Dir => std::fs::remove_dir_all(&entry.path)?,
-                }
-                if let Some(parent) = entry.path.parent() {
-                    cleanup_empty_parents(parent, &backup_root);
-                }
-            }
-            println!(
-                "  removed {} of {} entries · freed {} (was {}, now {})",
-                to_delete.len(),
-                entries.len(),
-                format_bytes(total_freed),
-                format_bytes(total_before),
-                format_bytes(total_before - total_freed),
-            );
-            Ok(())
+            let span = parse_human_duration(dur_str)?;
+            Some(
+                now.checked_sub(span)
+                    .map_err(|e| anyhow::anyhow!("invalid duration {dur_str:?}: {e}"))?
+                    .datetime(),
+            )
         }
+        None => None,
+    };
+    let protected = keep_last.map(|n| protected_by_generation(&entries, n));
+
+    let total_before: u64 = entries.iter().map(|e| e.size_bytes).sum();
+    let to_delete: Vec<&BackupEntry> = entries
+        .iter()
+        .enumerate()
+        .filter(|(idx, entry)| {
+            // Retention, not filtering: an entry survives if *any*
+            // active rule protects it. With only one rule given, the
+            // other simply has no opinion.
+            let age_protects = cutoff.is_some_and(|c| entry.ts >= c);
+            let generation_protects = protected.as_ref().is_some_and(|p| p.contains(idx));
+            !(age_protects || generation_protects)
+        })
+        .map(|(_, entry)| entry)
+        .collect();
+
+    if to_delete.is_empty() {
+        println!(
+            "  nothing to prune under this policy ({}; oldest: {})",
+            describe_policy(&older_than, keep_last),
+            format_age(entries[0].ts, &now)
+        );
+        return Ok(());
+    }
+
+    print_gc_table(&to_delete, &backup_root, &now, icons, color);
+    println!();
+    let total_freed: u64 = to_delete.iter().map(|e| e.size_bytes).sum();
+
+    if dry_run {
+        println!(
+            "  [dry-run] would remove {} of {} entries · would free {} of {} ({})",
+            to_delete.len(),
+            entries.len(),
+            format_bytes(total_freed),
+            format_bytes(total_before),
+            describe_policy(&older_than, keep_last),
+        );
+        return Ok(());
+    }
+
+    for entry in &to_delete {
+        match entry.kind {
+            BackupKind::File => std::fs::remove_file(&entry.path)?,
+            BackupKind::Dir => std::fs::remove_dir_all(&entry.path)?,
+        }
+        if let Some(parent) = entry.path.parent() {
+            cleanup_empty_parents(parent, &backup_root);
+        }
+    }
+    println!(
+        "  removed {} of {} entries · freed {} (was {}, now {})",
+        to_delete.len(),
+        entries.len(),
+        format_bytes(total_freed),
+        format_bytes(total_before),
+        format_bytes(total_before - total_freed),
+    );
+    Ok(())
+}
+
+/// Indices of the `n` newest snapshots of every target.
+///
+/// The target is the entry's path with yui's timestamp suffix stripped,
+/// so `home/.claude_<ts>/` and `home/.claude_<older ts>/` share a
+/// bucket while two apps' `settings.json` don't (the parent path is
+/// part of the key).
+fn protected_by_generation(entries: &[BackupEntry], n: usize) -> std::collections::HashSet<usize> {
+    use std::collections::HashMap;
+    let mut by_target: HashMap<Utf8PathBuf, Vec<usize>> = HashMap::new();
+    for (idx, entry) in entries.iter().enumerate() {
+        let Some(name) = entry.path.file_name() else {
+            continue;
+        };
+        let Some(target) = backup_target_name(name) else {
+            continue;
+        };
+        let key = entry
+            .path
+            .parent()
+            .map(|p| p.join(&target))
+            .unwrap_or_else(|| Utf8PathBuf::from(target));
+        by_target.entry(key).or_default().push(idx);
+    }
+    let mut protected = std::collections::HashSet::new();
+    for idxs in by_target.values() {
+        // `entries` is sorted oldest-first, so the tail is the newest.
+        for idx in idxs.iter().rev().take(n) {
+            protected.insert(*idx);
+        }
+    }
+    protected
+}
+
+fn describe_policy(older_than: &Option<String>, keep_last: Option<usize>) -> String {
+    match (older_than, keep_last) {
+        (Some(d), Some(n)) => format!("older than {d}, keeping the newest {n} per target"),
+        (Some(d), None) => format!("older than {d}"),
+        (None, Some(n)) => format!("keeping the newest {n} per target"),
+        (None, None) => "survey".to_string(),
     }
 }
 
@@ -238,6 +312,35 @@ pub(crate) fn parse_backup_suffix(name: &str) -> Option<jiff::civil::DateTime> {
         }
     }
     None
+}
+
+/// Strip yui's `_<YYYYMMDD_HHMMSSfff>` suffix back off, recovering the
+/// name the snapshot was taken of: `config_20260815_020729950.yml` →
+/// `config.yml`, `.claude_20260816_111625675` → `.claude`.
+///
+/// This is the inverse of [`crate::paths::append_timestamp`] and is
+/// what groups snapshots of the same target together. Returns `None`
+/// for anything that isn't yui-stamped, mirroring
+/// [`parse_backup_suffix`]'s defensive stance.
+pub(crate) fn backup_target_name(name: &str) -> Option<String> {
+    if strip_ts_at_end(name).is_some() {
+        return strip_ts_at_end(name).map(str::to_string);
+    }
+    // Nested ifs (not let-chains) so the crate's MSRV
+    // (rust-version = "1.85") stays buildable.
+    if let Some((before, ext)) = name.rsplit_once('.') {
+        if let Some(stem) = strip_ts_at_end(before) {
+            return Some(format!("{stem}.{ext}"));
+        }
+    }
+    None
+}
+
+/// `<stem>_<18-char timestamp>` → `<stem>`, when the tail really is a
+/// timestamp.
+fn strip_ts_at_end(s: &str) -> Option<&str> {
+    parse_ts_at_end(s)?;
+    Some(&s[..s.len() - 19])
 }
 
 fn parse_ts_at_end(s: &str) -> Option<jiff::civil::DateTime> {

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -3112,7 +3112,7 @@ fn gc_backup_survey_keeps_all_entries() {
     std::fs::write(backup.join("a_20260101_000000000.txt"), "old").unwrap();
     std::fs::write(backup.join("b_20260415_120000000.txt"), "fresh").unwrap();
 
-    gc_backup(Some(source.clone()), None, false, None, true).unwrap();
+    gc_backup(Some(source.clone()), None, None, false, None, true).unwrap();
 
     // Both still present.
     assert!(backup.join("a_20260101_000000000.txt").exists());
@@ -3141,7 +3141,15 @@ fn gc_backup_prune_removes_old_files_only() {
     // User-dropped file — not in yui shape.
     std::fs::write(backup.join("notes.md"), "mine").unwrap();
 
-    gc_backup(Some(source.clone()), Some("30d".into()), false, None, true).unwrap();
+    gc_backup(
+        Some(source.clone()),
+        Some("30d".into()),
+        None,
+        false,
+        None,
+        true,
+    )
+    .unwrap();
 
     assert!(!backup.join("sub/old_20200101_000000000.txt").exists());
     // Empty parent dir got cleaned up too.
@@ -3162,7 +3170,15 @@ fn gc_backup_dry_run_does_not_delete() {
     let backup = source.join(".yui/backup");
     std::fs::write(backup.join("old_20200101_000000000.txt"), "old").unwrap();
 
-    gc_backup(Some(source.clone()), Some("30d".into()), true, None, true).unwrap();
+    gc_backup(
+        Some(source.clone()),
+        Some("30d".into()),
+        None,
+        true,
+        None,
+        true,
+    )
+    .unwrap();
 
     assert!(
         backup.join("old_20200101_000000000.txt").exists(),
@@ -3185,11 +3201,120 @@ fn gc_backup_prune_handles_directory_snapshot() {
     std::fs::write(snap.join("init.lua"), "x").unwrap();
     std::fs::write(snap.join("lua/y.lua"), "y").unwrap();
 
-    gc_backup(Some(source.clone()), Some("30d".into()), false, None, true).unwrap();
+    gc_backup(
+        Some(source.clone()),
+        Some("30d".into()),
+        None,
+        false,
+        None,
+        true,
+    )
+    .unwrap();
 
     assert!(!snap.exists(), "dir snapshot removed wholesale");
     assert!(!backup.join("mirror").exists(), "empty mirror chain pruned");
     assert!(backup.exists(), "backup root preserved");
+}
+
+/// `--keep-last N` prunes by generation, which is the axis age can't
+/// reach: the snapshot that fills the disk is usually the freshest one.
+/// Buckets are per target, so a busy file losing generations must not
+/// drag another target's only snapshot with it.
+#[test]
+fn gc_backup_keep_last_prunes_per_target() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    std::fs::create_dir_all(source.join(".yui/backup/app")).unwrap();
+    std::fs::write(source.join("config.toml"), "").unwrap();
+    let backup = source.join(".yui/backup");
+
+    // Three generations of one target, all fresh (dated in the future
+    // so no age rule could be what removed them).
+    for ts in [
+        "20260101_000000000",
+        "20260102_000000000",
+        "20260103_000000000",
+    ] {
+        std::fs::write(backup.join(format!("app/config_{ts}.yml")), ts).unwrap();
+    }
+    // A different target in the same directory, single generation.
+    std::fs::write(backup.join("app/other_20260101_000000000.yml"), "other").unwrap();
+    // A directory snapshot of a third target.
+    let snap = backup.join("app/tree_20260101_000000000");
+    std::fs::create_dir_all(&snap).unwrap();
+    std::fs::write(snap.join("f.txt"), "x").unwrap();
+
+    gc_backup(Some(source.clone()), None, Some(1), false, None, true).unwrap();
+
+    // Newest generation of the busy target survives, older ones don't.
+    assert!(backup.join("app/config_20260103_000000000.yml").exists());
+    assert!(!backup.join("app/config_20260102_000000000.yml").exists());
+    assert!(!backup.join("app/config_20260101_000000000.yml").exists());
+    // Other targets each keep their only snapshot.
+    assert!(backup.join("app/other_20260101_000000000.yml").exists());
+    assert!(snap.exists(), "single dir snapshot of its own target kept");
+}
+
+/// The two rules are a retention policy: an entry survives if *either*
+/// protects it. A fresh entry beyond the generation limit stays because
+/// it is newer than the cutoff.
+#[test]
+fn gc_backup_age_and_generation_rules_compose() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    std::fs::create_dir_all(source.join(".yui/backup")).unwrap();
+    std::fs::write(source.join("config.toml"), "").unwrap();
+    let backup = source.join(".yui/backup");
+
+    // Two ancient generations…
+    std::fs::write(backup.join("c_20200101_000000000.yml"), "old1").unwrap();
+    std::fs::write(backup.join("c_20200102_000000000.yml"), "old2").unwrap();
+    // …and two fresh ones (tomorrow, so they can't age out).
+    let tomorrow = jiff::Zoned::now()
+        .checked_add(jiff::Span::new().days(1))
+        .unwrap();
+    let bdt = jiff::fmt::strtime::BrokenDownTime::from(&tomorrow);
+    let future_ts = bdt.to_string("%Y%m%d_%H%M%S%3f").unwrap();
+    std::fs::write(backup.join(format!("c_{future_ts}.yml")), "fresh").unwrap();
+
+    gc_backup(
+        Some(source.clone()),
+        Some("30d".into()),
+        Some(1),
+        false,
+        None,
+        true,
+    )
+    .unwrap();
+
+    // Fresh: protected by age even though it is the only kept generation.
+    assert!(backup.join(format!("c_{future_ts}.yml")).exists());
+    // Ancient + beyond the generation limit → gone.
+    assert!(!backup.join("c_20200101_000000000.yml").exists());
+    assert!(!backup.join("c_20200102_000000000.yml").exists());
+}
+
+/// `--keep-last 0` protects nothing — the honest spelling for "purge".
+/// `--dry-run` still writes nothing.
+#[test]
+fn gc_backup_keep_last_zero_purges_and_dry_run_is_safe() {
+    let tmp = TempDir::new().unwrap();
+    let source = utf8(tmp.path().join("dotfiles"));
+    std::fs::create_dir_all(source.join(".yui/backup")).unwrap();
+    std::fs::write(source.join("config.toml"), "").unwrap();
+    let backup = source.join(".yui/backup");
+    std::fs::write(backup.join("a_20260101_000000000.txt"), "a").unwrap();
+    std::fs::write(backup.join("notes.md"), "mine").unwrap();
+
+    gc_backup(Some(source.clone()), None, Some(0), true, None, true).unwrap();
+    assert!(
+        backup.join("a_20260101_000000000.txt").exists(),
+        "dry-run must not delete"
+    );
+
+    gc_backup(Some(source.clone()), None, Some(0), false, None, true).unwrap();
+    assert!(!backup.join("a_20260101_000000000.txt").exists());
+    assert!(backup.join("notes.md").exists(), "user file untouched");
 }
 
 /// Build a no-op `ApplyCtx` over a `TempDir`. The returned tuple


### PR DESCRIPTION
Closes #244.

## Why

`gc-backup` could only prune by age, and age is the wrong axis for the case that actually fills a disk. An hour after migrating a few directories to `[[link]]`, a real repo:

```
  36 entries · 651.0 MiB total — pass --older-than DUR (e.g. 30d) to delete
  …
  4h   619.4 MiB  C\Users\yukimemi\dotfiles\home\.claude_20260816_111625675/
  3h     1.8 KiB  C\Users\yukimemi\dotfiles\home\.gemini_20260816_120006097/
  1d       533 B  C\Users\yukimemi\dotfiles\home\.omp\agent\config_20260815_115104994.yml
```

95 % of the tree is one four-hour-old snapshot. And the same target keeps stacking up: `home/.omp/agent/config.yml` had four snapshots in a single day, because it's a file an app rewrites constantly. #46 filed exactly this as the follow-up ("keep last 3 backups of `~/.config`").

## What

`--keep-last N` keeps the N newest snapshots **per target** and drops older generations regardless of age.

The target is the entry's path with yui's `_<YYYYMMDD_HHMMSSfff>` suffix stripped — `backup_target_name`, the inverse of `paths::append_timestamp`, so `config_<ts>.yml` → `config.yml` and `.claude_<ts>/` → `.claude`. The bucket key includes the parent path, so two apps' `settings.json` don't collide.

The two flags are a **retention policy, not a filter chain: an entry survives if either rule protects it.**

| invocation | effect |
|---|---|
| (no flags) | survey, unchanged |
| `--older-than 30d` | prune older than a month |
| `--keep-last 3` | keep three newest per target, whatever their age |
| `--older-than 30d --keep-last 3` | prune over a month old, but never drop the three newest of anything |
| `--keep-last 0` | protects nothing — the honest spelling for "purge", no extra flag needed |

The summary line names the active policy so a destructive run says what it applied.

## Verification

`cargo make check` green (fmt + clippy `-D warnings` + 252 tests + lock-check). Three new tests: per-target bucketing (a busy target losing generations must not take another target's only snapshot with it), the compose rule (a fresh entry beyond the generation limit survives on age), and `--keep-last 0` + `--dry-run` safety.

Exercised against the 651 MiB tree above:

```
$ yui gc-backup --keep-last 1 --dry-run
  [dry-run] would remove 21 of 36 entries · would free 21.1 MiB of 651.0 MiB (keeping the newest 1 per target)

$ yui gc-backup --older-than 30d --keep-last 2 --dry-run
  [dry-run] would remove 11 of 36 entries · would free 10.5 MiB of 651.0 MiB (older than 30d, keeping the newest 2 per target)

$ yui gc-backup --keep-last 0 --dry-run
  [dry-run] would remove 36 of 36 entries · would free 651.0 MiB of 651.0 MiB (keeping the newest 0 per target)
```

Note the first one: the 619 MiB snapshot is *protected* by `--keep-last 1` because it is the newest of its target. That is the policy working as specified — reclaiming it is a deliberate `--keep-last 0`, not something a generation rule should do behind your back.
