### PR TITLE
chore: release v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."


### PR DESCRIPTION
Everything on main since v0.12.0.

- #243 — a `[[link]]` entry can override the link mechanism with `mode` (fixes #232). Dirs take `auto`/`symlink`/`junction`, files `auto`/`symlink`/`hardlink`; a mismatch is a config error where the entry is declared. `yui list` grows a MODE column when something overrides. Manual `yui absorb` honours the matched entry's mode too — relinking with the global one would have been invisible afterwards, since `classify` compares by identity rather than mechanism.
- #245 — `gc-backup --keep-last N` prunes by generation per target (fixes #244). Composes with `--older-than` as a retention policy: an entry survives if either rule protects it. `--keep-last 0` purges.

Version-bump-only PR (`package.version` + `Cargo.lock`), so it skips the bot-review gate per AGENTS.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 0.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->