### PR TITLE
chore(apply): demote inactive [[link]] log to debug

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -13,7 +13,7 @@ use anyhow::{Context as _, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use std::cell::{Cell, RefCell};
 use teravars::Context as TeraContext;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 pub fn apply(source: Option<Utf8PathBuf>, dry_run: bool) -> Result<()> {
     let source = resolve_source(source)?;
@@ -411,7 +411,11 @@ fn walk_and_link_body(
             // still descends and per-file defaults still apply.
             // Phrase it so users don't read "skipping" as
             // "subtree blocked" (the v0.5 behaviour).
-            info!("no active [[link]] for {src_dir} — falling back to defaults");
+            //
+            // debug, not info: OS-gated `when` conditions mean every
+            // run has a whole platform's worth of inactive links, and
+            // that's the design working, not something to report.
+            debug!("no active [[link]] for {src_dir} — falling back to defaults");
         }
         if emitted_dir_link {
             covered = true;


### PR DESCRIPTION
## Background

On Linux, every `yui apply` printed 14 INFO lines:

```
INFO no active [[link]] for .../home/.config/nvim — falling back to defaults
INFO no active [[link]] for .../home/.config/yazi — falling back to defaults
... (12 more)
```

On Windows the same thing happens in reverse — there only the
Linux/macOS-gated `.yuilink` (gogcli/keyring) reports.

## Cause

The branch in `src/cmd/apply.rs` fires when a directory *has* `[[link]]`
entries but every one of them was filtered out by its `when` condition:

```rust
if !emitted_any {
    info!("no active [[link]] for {src_dir} — falling back to defaults");
}
```

Since `.yuilink` markers gate on OS, whichever platform you run on has
the other platform's links entirely inactive. The message is therefore
guaranteed on every run, and its presence means the design is working —
not something the user needs to act on.

## Change

`info!` → `debug!`. No behaviour change; still visible under
`RUST_LOG=debug`.

The wording explaining the v0.6+ "keeps descending" semantics is kept as
a comment, with a note on why this is debug rather than info.

## Verification

- `cargo make check` — green (fmt, clippy, 257 tests, lockfile in sync)
- `cargo install --path .`, then a real `yui apply` on my dotfiles:
  the 14 lines are gone and all 16 entries remain in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zv1zAvsNvzgunuhNzCBPQ