### PR TITLE
chore: release v0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."


### PR DESCRIPTION
Version bump only: `0.13.0` → `0.13.1` plus the matching `Cargo.lock` entry.

Contents of this release:

- #257 — `chore(apply): demote inactive [[link]] log to debug`

On merge, `auto-tag.yml` pushes `v0.13.1`, which fires `release.yml`
(three-target binaries + `cargo publish`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zv1zAvsNvzgunuhNzCBPQ