### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/apm-bump.yml
+++ b/.github/workflows/apm-bump.yml
@@ -68,7 +68,7 @@ jobs:
       # uses it: PRs pushed via GITHUB_TOKEN don't trigger CI,
       # which would block the auto-merge gate. PAT-owned identity
       # restores the trigger chain.
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@v7.0.1
         with:
           token: ${{ secrets.KATA_APPLY_TOKEN }}
           persist-credentials: false

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -47,7 +47,7 @@ jobs:
       # use. Without this the tag push goes out under the default
       # `GITHUB_TOKEN` and downstream workflows stay silent.
       - name: Checkout
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 2
           token: ${{ secrets.KATA_APPLY_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@v7.0.1
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.9.2
         with:
@@ -51,7 +51,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@v7.0.1
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.9.2
         with:
@@ -74,7 +74,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@v7.0.1
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -93,7 +93,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@v7.0.1
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -113,7 +113,7 @@ jobs:
     name: cargo lockfile in sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@v7.0.1
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.9.2
         with:
@@ -134,7 +134,7 @@ jobs:
     name: coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@v7.0.1
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -131,7 +131,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 1
           # persist-credentials stays ON (the default) on purpose: the

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -109,7 +109,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 1
           # persist-credentials stays ON (the default) on purpose: the

--- a/.github/workflows/kata-apply.yml
+++ b/.github/workflows/kata-apply.yml
@@ -17,7 +17,10 @@ name: kata-apply
 #
 # Output: a PR (single rolling branch `kata-apply/auto`) with the
 # rendered-file diff. Auto-merged when CI passes — if CI fails,
-# the PR stays open for human review.
+# the PR stays open for human review. Auto-merge can also fail to
+# arm at all (see the last step), whether because the repo has no
+# required checks or because none had registered yet; the PR then
+# stays open, which is the safe default.
 #
 # Source: yukimemi/pj-base. Filename carries `.tera` so kata
 # Tera-renders the file at apply time (substituting
@@ -55,7 +58,7 @@ jobs:
       # CI from running on the auto-PR — making auto-merge wait for
       # checks that never fire. A PAT acts as a user-identity push
       # and triggers CI normally.
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@v7.0.1
         with:
           token: ${{ secrets.KATA_APPLY_TOKEN }}
 
@@ -90,15 +93,56 @@ jobs:
           body: |
             Automated `kata update + apply` (daily schedule + manual dispatch).
 
-            Auto-merged when CI passes; left open if CI fails.
+            Auto-merged when CI passes; left open if CI fails — or if
+            auto-merge couldn't be armed (no required checks, or none
+            had registered yet when this PR was opened).
 
             <!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
 
+      # Arm auto-merge so the PR lands by itself once the consumer's
+      # required checks go green.
+      #
+      # Deliberately tolerant of failure. GitHub rejects the
+      # `enablePullRequestAutoMerge` mutation when the PR is ALREADY
+      # mergeable — nothing left to wait on — and `gh pr merge
+      # --auto` exits 1 with
+      #   GraphQL: Pull request Pull request is in clean status
+      #   (enablePullRequestAutoMerge)
+      # Two situations produce that state: a default branch with no
+      # required status checks, permanently; or, transiently, this
+      # step firing a second or two after `create-pull-request`
+      # opens the PR, before the first check has registered. The
+      # second is a race, so the same repo can fail one run and
+      # succeed the next — yukimemi/hakari did exactly that within
+      # the hour (run 32610568604 failed, run 32612382813 armed
+      # fine) with its branch protection unchanged (absent)
+      # throughout. Either way, a red scheduled job that means
+      # nothing trains people to ignore the one that does.
+      #
+      # No fallback to an unconditional `gh pr merge --squash`: a repo
+      # with no required checks has no automated confidence to merge
+      # on. The very hakari PR that surfaced this carried three silent
+      # reverts of consumer-owned config; a human caught them. Leaving
+      # the PR open IS the correct outcome here, not a degraded one.
+      #
+      # Nor is the cause worth discriminating: gh reports every
+      # failure as a bare exit 1 with no machine-readable cause, so
+      # telling the two apart would mean matching on the error text
+      # — brittle against gh/API wording drift — and against a race
+      # the verdict would be about timing, not configuration. The
+      # step tolerates any arming failure and annotates it instead;
+      # gh's own stderr stays in the log, and the PR is visible on
+      # the repo either way.
       - name: Enable auto-merge
         if: steps.cpr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ secrets.KATA_APPLY_TOKEN }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
-          gh pr merge --auto --squash ${{ steps.cpr.outputs.pull-request-number }}
+          if gh pr merge --auto --squash "$PR"; then
+            echo "Auto-merge armed for PR #${PR}; it will land once required checks pass."
+            exit 0
+          fi
+          echo "::notice::Auto-merge could not be armed for PR #${PR} (see the gh error above; GitHub refuses to arm auto-merge on an already-mergeable PR — either the repo has no required status checks, or none had registered yet in the seconds since the PR was opened). Leaving the PR open for human review."

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,10 +1,10 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-08-22T03:30:12.008589265Z"
+applied_at = "2026-08-23T03:35:15.469319717Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "8217f1a99c55240c7337f40b8afb35d9e9232499"
-version = "0.14.0"
+rev = "0424dfa03771babdeca3c22f08fe003f2811f820"
+version = "0.16.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust"
@@ -33,22 +33,22 @@ content_hash = "486c974de88903113ed99b4e643432b7050e88f1031276f5263e8da7b43fe11e
 content_hash = "6d380d1ecc2f882c2011429d548a6f3c774b74f0c757d884453e4667172acc2a"
 
 [files.".github/workflows/apm-bump.yml"]
-content_hash = "e7140a937a36ec588351ab68be92345bdcc4c020e57060802a9e3709bd105b07"
+content_hash = "f1cf3615e0f5ff443860722da8d7f74530eaa37e755e65f4392a0c25cd83917e"
 
 [files.".github/workflows/auto-tag.yml"]
-content_hash = "406943795e69542d92d37a0d70051f22a899956dc0cbd1d70ebc16aea13d655a"
+content_hash = "4e2735f40c2ae61014810159a2458da2edc1646589f5f65d9f2f3d099366c9a8"
 
 [files.".github/workflows/ci.yml"]
-content_hash = "521b8e878a7b463a74b3006a8774ace3009d24abc62f2cba0a9dc0166384ec3b"
+content_hash = "db97d026a267859e3b93bcac29f69e7ae65be5ad760cf739b2f7622c77d27f6f"
 
 [files.".github/workflows/claude-review.yml"]
-content_hash = "9c07be16af6dc6f1e86b8a845a64a5c54b0d9092b8b34a9c4eefe31e84269509"
+content_hash = "4589425f4f2dd857f64116c2a8e0ae8746df423dd4cdf1de6c7e582b13fe245f"
 
 [files.".github/workflows/claude.yml"]
-content_hash = "2db473008ec9528565097a8e543c7a5586a6dd383d8f3e32e094ca78e8e9c2f5"
+content_hash = "e018b9c422cac8cb57d832c4100697a56bbd4b5f5a9a2abd6c803149665525a7"
 
 [files.".github/workflows/kata-apply.yml"]
-content_hash = "45e8fc324f046621343be84f99ed8f3a338fa6d0ea007e87f5ce0c81b0ae2335"
+content_hash = "c70c39b08f0e914a44c1dc6c558b3ce2439933fbd64c51674fe64dbc640f02bc"
 
 [files.".github/workflows/release.yml"]
 content_hash = "ef4db54ac86c63962de0e95bcdca4fe7d6ca8f6b28c358a65c98686aa984b5f0"
@@ -58,7 +58,7 @@ once_applied = true
 content_hash = "4bebd1c3417c33f9d1c51f011694f6d82b098bbb1a5a102ba56e97ab01a866ef"
 
 [files.".kata/vars.toml"]
-content_hash = "393b2b94540e792790ef9357e46e5bc259eb3064605794ca2373ae458999cb23"
+content_hash = "8e573305bc9b45b40e4c4c24c0da7728771a12d81c4c1631d6e35f25a189cf84"
 once_applied = true
 
 [files."AGENTS.md"]

--- a/.kata/vars.toml
+++ b/.kata/vars.toml
@@ -19,4 +19,4 @@ checkout = "v7.0.1"
 create_pull_request = "v8.1.1"
 # renovate: datasource=github-tags depName=Swatinem/rust-cache
 swatinem_rust_cache = "v2.9.2"
-claude_code_action = "v1"
+claude_code_action = "v1.0.195"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,13 +308,19 @@ here so each tool's auto-load behaviour still finds something.
   - Exception: trivial typo / whitespace / docs wording fixes.
 - Branch names: `feat/...`, `fix/...`, `chore/...`.
 - **PR titles + bodies in English. Commit messages in English.**
-- **Releases are PR-driven, tagging is automatic.** Bump
-  `[workspace.package].version` (workspace) or `[package].version`
-  (single crate) in a `chore/release-vX.Y.Z` PR. On merge to `main`,
-  `.github/workflows/auto-tag.yml` (kata-managed) detects the bump,
-  pushes the `vX.Y.Z` tag, and that tag fires `release.yml` for
-  binary builds + crates.io publish. **Do not run `git tag` by
-  hand** — the bot tag will collide and the manual push fails.
+- **Releases are PR-driven and tagging is automatic** — in repos that
+  ship a release pipeline. Bump the version in the project's own
+  manifest in a `chore/release-vX.Y.Z` PR; on merge to `main` the
+  language layer's `auto-tag.yml` detects the bump, pushes the
+  `vX.Y.Z` tag, and that tag is what fires `release.yml`. **Do not run
+  `git tag` by hand** — the bot tag will collide and the manual push
+  fails. The specifics belong to the layers shipping those two
+  workflows, which are not the same layer: `kata:agents:rust:*` for
+  which file holds the version and for `auto-tag.yml`,
+  `kata:agents:rust-{cli,lib}:*` for what `release.yml` builds and
+  publishes. A repo with no `auto-tag.yml` has no release pipeline at
+  all: nothing tags, and the version field in its manifest may well
+  be decoration.
 
 ### PR review cycle
 
@@ -502,11 +508,52 @@ templates — the bytes between `<!-- kata:*:begin -->` and
 listed in `.kata/applied.toml`. **Editing those bytes locally
 won't survive the next `kata apply`** — push the change to the
 upstream template repo (`yukimemi/pj-base` / `yukimemi/pj-rust` /
-…) instead. The marker scopes are layered:
+…) instead.
 
-- `kata:agents:base:*` — language-agnostic conventions (this section).
-- `kata:agents:rust:*` — added when `pj-rust` applies.
-- `kata:agents:rust-cli:*` — added when `pj-rust-cli` applies.
+The marker scopes are layered, one per applied layer:
+`kata:agents:base:*` is this section, and each layer adds its own
+(`kata:agents:rust:*`, `kata:agents:rust-cli:*`,
+`kata:agents:pnpm:*`, `kata:agents:firebase:*`, …). Which ones apply
+*here* is a grep away: `<!-- kata:` in this file.
+
+### This project's own conventions
+
+Everything a layer ships is generic by construction: it describes the
+stack the template assumed, not what this repo grew into. **Bytes
+outside every marker pair are yours and survive `kata apply`** — so
+project-specific conventions belong in a section of their own, outside
+the markers (conventionally at the end of the file; if a later layer
+appends its block below yours, no matter — kata only ever rewrites
+between its own markers). Same mechanism as the `.gitignore` /
+`.gitattributes` blocks.
+
+Write those conventions down there rather than leaving them in one
+agent's head, in commit archaeology, or in a README the agent will not
+read. What earns a line:
+
+- **Any layer default that does not hold here.** A layer states its
+  assumption flatly ("Hosting is the primary target", "these rules are
+  a placeholder to replace"). When the project has diverged, say so and
+  say why — the layer's text keeps asserting the opposite on every
+  apply, and an agent that only reads the blocks will act on it.
+- **Facts duplicated across files with no compiler in between** — an
+  address or a path that appears in code *and* in a rules/config file
+  that cannot import it, a timeout that has to stay inside another
+  timeout. List every copy, so the next edit finds them all.
+- **kata-shipped files this project deleted on purpose**, together with
+  the `once_applied = true` line in `.kata/applied.toml` that keeps
+  them deleted. Otherwise someone helpfully restores one.
+- **Shapes the runtime forces but no tool checks** — an export form a
+  platform requires, import specifiers that must (or must not) carry a
+  file extension, a directory whose contents are reachable by URL.
+- **Invariants that money or access rest on**, naming the file and line
+  that actually enforces them.
+- **Which language the code speaks versus what a user reads**, when the
+  two differ.
+
+A repo whose `AGENTS.md` is nothing but kata blocks is a repo where
+every agent re-derives all of that from scratch — and gets the layer
+defaults wrong the same way each time.
 <!-- kata:agents:base:end -->
 <!-- kata:agents:rust:begin -->
 ### Rust workflow


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Auto-merge failures no longer fail the workflow; generated pull requests remain open for follow-up.
  - Pull request descriptions now explain auto-merge failure conditions.

- **Documentation**
  - Clarified release automation behavior and project convention guidance.
  - Added guidance for repositories without automated release workflows.

- **Chores**
  - Updated workflow tooling and action versions for improved maintenance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->