### PR TITLE
fix: pass crate_name to kaishin so cargo install fallback targets yui-cli

### DIFF
--- a/src/updater.rs
+++ b/src/updater.rs
@@ -12,6 +12,9 @@
 //! `yui` is taken by an unrelated abandoned crate), but the repo
 //! and binary are both `yui`, so going through `env!("CARGO_PKG_NAME")`
 //! the way renri does would produce the wrong GitHub Release URL.
+//! `kaishin_opts` additionally passes `.crate_name("yui-cli")` so
+//! kaishin's `cargo install` fallback reaches the right package
+//! instead of the unrelated `yui` crate.
 //!
 //! The module exposes two layers:
 //!
@@ -41,6 +44,12 @@ use crate::vars::YuiVars;
 const OWNER: &str = "yukimemi";
 const REPO: &str = "yui";
 const BIN: &str = "yui";
+/// Published package name, for kaishin's `cargo install` fallback.
+/// crates.io's `yui` is taken by an unrelated abandoned crate, so this
+/// repo publishes as `yui-cli` (see `Cargo.toml`'s `[package] name`).
+/// Without this, kaishin would derive `cargo install yui` and reach
+/// the wrong package.
+const CRATE: &str = "yui-cli";
 
 /// How long [`finalize_auto_update_check`] waits for an in-flight
 /// background install before giving up (silently). Keeps fast commands
@@ -79,7 +88,7 @@ fn auto_update_disabled_by_env() -> bool {
 }
 
 fn kaishin_opts() -> kaishin::KaishinOptions {
-    kaishin::KaishinOptions::new(OWNER, REPO, BIN, env!("CARGO_PKG_VERSION"))
+    kaishin::KaishinOptions::new(OWNER, REPO, BIN, env!("CARGO_PKG_VERSION")).crate_name(CRATE)
 }
 
 fn make_runtime() -> Result<tokio::runtime::Runtime> {


### PR DESCRIPTION
yui's \`kaishin_opts()\` constructed \`KaishinOptions\` from \`(owner, repo, bin)\` but never called \`.crate_name("yui-cli")\`, so kaishin's \`cargo install\` fallback would try to install crates.io's \`yui\` — an unrelated abandoned crate — instead of the published \`yui-cli\` package.

\`magi\`'s \`src/updater.rs\` already documents this as a live bug in yui (see its module doc + AGENTS.md); this mirrors magi's fix (\`.crate_name(CRATE)\`).

Verified with \`cargo make check\` (fmt/clippy/test/lock-check all green, 252 tests pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the self-update fallback so it installs the correct `yui-cli` package instead of an unrelated package.
  * Improved update behavior when using the package installation fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->