### PR TITLE
chore: release v0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."


### PR DESCRIPTION
Version bump only. Includes #270 (kaishin crate_name fix). Auto-merges on CI green per repo release convention; auto-tag.yml pushes v0.13.2 on merge, firing release.yml.