### PR TITLE
fix(absorb): honor declared links before generic mount fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,17 @@ on_anomaly        = "ask"    # "ask" | "skip" | "force"
 
 Need to absorb a single file regardless of policy? `yui absorb
 <target-path>` does that — bypasses `auto`, `require_clean_git`, and
-`on_anomaly` for an explicit user-initiated pull.
+`on_anomaly` for an explicit user-initiated pull. If no `[[link]]`/
+`.yuilink` declaration claims the target yet — or only the generic
+`[[mount.entry]]` fallback does — pass `--to <SRC>` (a path relative
+to `$DOTFILES`, e.g. `home/.config/magi`): yui creates that
+directory, writes a `.yuilink` marker back to the target
+(substituting a known env var like `%APPDATA%` / `$XDG_CONFIG_HOME`
+for portability when the target falls under one), and absorbs into
+it. `--to` only creates a *new* declaration — it refuses to run if a
+*different*, more specific `[[link]]`/`.yuilink` declaration already
+claims the target, so it can't silently redirect an existing
+mapping.
 
 ## Commands
 
@@ -562,7 +572,7 @@ Need to absorb a single file regardless of policy? `yui absorb
 | `yui list [--all] [--icons MODE] [--no-color]` | every src→dst mapping |
 | `yui status [--icons MODE] [--no-color]` | drift overview, exits non-zero on any divergence |
 | `yui diff [--icons MODE] [--no-color]` | unified diff of every drifted entry (link or render) |
-| `yui absorb <target> [--dry-run] [--yes]` | pull one target into source — prints diff, confirms (`--yes` to skip) |
+| `yui absorb <target> [--to SRC] [--dry-run] [--yes]` | pull one target into source — prints diff, confirms (`--yes` to skip); `--to` declares a new `.yuilink` unless a more specific declaration already claims the target |
 | `yui unlink <path>...` | tear down a specific link |
 | `yui update [--dry-run]` | `git pull --ff-only` source repo, then re-apply |
 | `yui unmanaged [--icons MODE] [--no-color]` | list source files no `[[mount.entry]]` claims |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,8 +106,24 @@ pub enum Command {
     /// `--yes`, prompts on a TTY before writing; off a TTY refuses
     /// to act unless `--yes` is given. `--dry-run` only shows the
     /// diff and exits.
+    ///
+    /// If no `[[mount.entry]]` / `[[link]]` already claims `target`
+    /// — or only the generic `[[mount.entry]]` fallback does — pass
+    /// `--to` to declare where it should live in source: yui creates
+    /// that directory, writes a `.yuilink` marker mapping it back to
+    /// `target` (substituting a known env var like `%APPDATA%` /
+    /// `$XDG_CONFIG_HOME` for portability when the target falls under
+    /// one), and proceeds with the absorb. Refuses to run if a
+    /// *different*, more specific `[[link]]`/`.yuilink` declaration
+    /// already claims `target`.
     Absorb {
         target: Utf8PathBuf,
+        /// Where `target` should live in source (relative to
+        /// $DOTFILES), e.g. `home/.config/magi`. Only used when no
+        /// specific declaration already claims `target`; writes a new
+        /// `.yuilink` marker there.
+        #[arg(long, value_name = "SRC")]
+        to: Option<Utf8PathBuf>,
         #[arg(long)]
         dry_run: bool,
         /// Skip the y/N prompt (still prints the diff).
@@ -337,9 +353,10 @@ impl Cli {
             } => cmd::list(source, all, icons, no_color),
             Command::Absorb {
                 target,
+                to,
                 dry_run,
                 yes,
-            } => cmd::absorb(source, target, dry_run, yes),
+            } => cmd::absorb(source, target, to, dry_run, yes),
             Command::Doctor { icons, no_color } => cmd::doctor(source, icons, no_color),
             Command::GcBackup {
                 older_than,

--- a/src/cmd/absorb.rs
+++ b/src/cmd/absorb.rs
@@ -23,10 +23,13 @@ use tracing::{info, warn};
 /// rewrite source). `--dry-run` shows the diff and exits.
 ///
 /// Walks `[[mount.entry]]` and `.yuilink` overrides to find which source
-/// path "owns" the given target. Errors loudly if no mount claims it.
+/// path "owns" the given target. Errors loudly if no mount claims it,
+/// unless `to` names a source-relative directory to declare on the fly
+/// (see [`create_marker_for`]).
 pub fn absorb(
     source: Option<Utf8PathBuf>,
     target: Utf8PathBuf,
+    to: Option<Utf8PathBuf>,
     dry_run: bool,
     yes: bool,
 ) -> Result<()> {
@@ -39,16 +42,51 @@ pub fn absorb(
     let mut engine = template::Engine::new();
     let tera_ctx = template::template_context(&yui, &config.vars);
 
+    let found = find_source_for_target(&source, &config, &target, &mut engine, &tera_ctx)?;
+
+    let (target_match, pending_marker) = match (found, to) {
+        (Some(m), None) => (m, None),
+        (Some(m), Some(rel)) if !m.specific => {
+            // Only the generic mount-derived fallback claims this
+            // target — no explicit `[[link]]`/`.yuilink` declaration
+            // does. That's exactly what `--to` exists to override with
+            // a new, more specific declaration.
+            let (tm, pending) =
+                plan_marker_for(&source, &rel, &target, &config.mount.marker_filename)?;
+            (tm, Some(pending))
+        }
+        (Some(m), Some(rel)) => {
+            // A *specific* declaration already claims this target.
+            // `--to` only creates a new declaration, it never rewrites
+            // an existing one — silently ignoring a mismatch would
+            // absorb into a directory the user didn't ask for; bail
+            // instead so they can drop `--to` or fix the conflicting
+            // declaration by hand.
+            let declared = paths::normalize(&source.join(&rel));
+            if paths::normalize(&m.src) != declared {
+                anyhow::bail!(
+                    "target {target} is already claimed by a declaration pointing at \
+                     {}; --to {rel} disagrees — drop --to or fix the existing declaration",
+                    m.src
+                );
+            }
+            (m, None)
+        }
+        (None, None) => anyhow::bail!(
+            "no mount entry / .yuilink override claims target {target}; \
+                 pass a path inside a known dst, or --to SRC to declare one"
+        ),
+        (None, Some(rel)) => {
+            let (tm, pending) =
+                plan_marker_for(&source, &rel, &target, &config.mount.marker_filename)?;
+            (tm, Some(pending))
+        }
+    };
     let TargetMatch {
         src: src_path,
         mode,
-    } = match find_source_for_target(&source, &config, &target, &mut engine, &tera_ctx)? {
-        Some(m) => m,
-        None => anyhow::bail!(
-            "no mount entry / .yuilink override claims target {target}; \
-                 pass a path inside a known dst"
-        ),
-    };
+        specific: _,
+    } = target_match;
 
     info!("source for {target}: {src_path}");
 
@@ -59,6 +97,9 @@ pub fn absorb(
     print_absorb_diff(&src_path, &target);
 
     if dry_run {
+        if let Some(pending) = &pending_marker {
+            info!("[dry-run] would create {}", pending.marker_path);
+        }
         info!("[dry-run] would absorb {target} → {src_path}");
         return Ok(());
     }
@@ -75,6 +116,13 @@ pub fn absorb(
             warn!("manual absorb cancelled by user: {target}");
             return Ok(());
         }
+    }
+
+    // Only now — past both the dry-run short-circuit and the
+    // confirmation gate — does `--to` actually touch the source repo.
+    // Answering "no" (or `--dry-run`) must leave no trace.
+    if let Some(pending) = &pending_marker {
+        write_marker(pending)?;
     }
 
     let backup_root = source.join(&config.backup.dir);
@@ -106,6 +154,175 @@ pub fn absorb(
     } else {
         absorb_target_into_source(&src_path, &target, &ctx, ctx.file_mode_for(mode))
     }
+}
+
+/// A `[[link]]` marker computed for `target` but not yet written —
+/// [`plan_marker_for`] validates and renders everything that can fail
+/// or that's worth logging before any confirmation gate; [`write_marker`]
+/// performs the actual filesystem mutation once `absorb` has confirmed
+/// it's really proceeding (past `--dry-run` and the y/N prompt).
+struct PendingMarker {
+    marker_dir: Utf8PathBuf,
+    marker_path: Utf8PathBuf,
+    content: String,
+}
+
+/// Plan a brand-new `[[link]]` marker for `target` at
+/// `<source>/<rel>/.yuilink`: validate, render its content, and hand
+/// back both the [`TargetMatch`] `absorb` should use and the
+/// [`PendingMarker`] to write once it's safe to mutate the source
+/// repo. Performs no filesystem writes itself — `dry-run` and a
+/// declined confirmation must leave no trace.
+///
+/// Only supports directory targets — the realistic case is a whole
+/// `%APPDATA%`/`$XDG_CONFIG_HOME`-style app-data directory that isn't
+/// under source yet. A single-file target would need a `rel` inside
+/// the declaration that names the file, which is ambiguous to invent
+/// on the fly; write that `[[link]]` by hand instead.
+///
+/// `dst` is templatized against known env-var roots (`%APPDATA%`,
+/// `$XDG_CONFIG_HOME`, `$HOME`, …) via [`templatize_dst`] so the
+/// marker stays portable across machines/users, same as the
+/// hand-written markers elsewhere in this tree (e.g.
+/// `home/.config/shoka/.yuilink`). Falls back to the literal absolute
+/// path — with a loud warning — when nothing matches.
+fn plan_marker_for(
+    source: &Utf8Path,
+    rel: &Utf8Path,
+    target: &Utf8Path,
+    marker_filename: &str,
+) -> Result<(TargetMatch, PendingMarker)> {
+    if !target.is_dir() {
+        anyhow::bail!(
+            "--to only supports directory targets ({target} is a file); \
+             write a `[[link]]` entry by hand for a single file"
+        );
+    }
+    crate::links::validate_src(rel, "--to")?;
+
+    let marker_dir = paths::normalize(&source.join(rel));
+    let marker_path = marker_dir.join(marker_filename);
+    if marker_path.is_file() {
+        anyhow::bail!(
+            "{marker_path} already exists but doesn't claim {target}; \
+             fix it by hand instead of overwriting it"
+        );
+    }
+
+    let (dst, matched_var) = templatize_dst(target);
+    match matched_var {
+        Some(name) => info!("--to {rel}: templatizing {target} via env(name='{name}')"),
+        None => warn!(
+            "--to {rel}: {target} doesn't fall under a known env-var root \
+             (APPDATA/LOCALAPPDATA/USERPROFILE/XDG_*/HOME) — writing it as a \
+             literal path, which won't portable across machines/users. \
+             Edit {marker_path} by hand to templatize it."
+        ),
+    }
+
+    // Serialize `dst` through `toml::Value` rather than a hand-rolled
+    // `"{dst}"` interpolation — a directory name containing `"` or a
+    // backslash would otherwise write a marker that fails to parse (or
+    // parses into the wrong path) the moment `apply`/`absorb` reads it
+    // back.
+    let dst_toml = toml::Value::String(dst).to_string();
+    let content = format!(
+        "[[link]]\ndst = {dst_toml}\nwhen = \"yui.os == '{}'\"\n",
+        std::env::consts::OS
+    );
+
+    Ok((
+        TargetMatch {
+            src: marker_dir.clone(),
+            mode: None,
+            specific: true,
+        },
+        PendingMarker {
+            marker_dir,
+            marker_path,
+            content,
+        },
+    ))
+}
+
+/// Actually create `pending`'s directory and write its `.yuilink`
+/// marker. Split out of [`plan_marker_for`] so `absorb` can call it
+/// only after `--dry-run` and the confirmation prompt have both
+/// cleared.
+fn write_marker(pending: &PendingMarker) -> Result<()> {
+    std::fs::create_dir_all(&pending.marker_dir)?;
+    std::fs::write(&pending.marker_path, &pending.content)?;
+    info!("created {}", pending.marker_path);
+    Ok(())
+}
+
+/// Rewrite `target`'s absolute path as a Tera `env(...)` call rooted at
+/// whichever known env var it falls under, longest/most-specific match
+/// first. Returns the matched var name too, purely for the info/warn
+/// log in [`plan_marker_for`].
+fn templatize_dst(target: &Utf8Path) -> (String, Option<&'static str>) {
+    templatize_dst_with(target, |name| std::env::var(name).ok())
+}
+
+/// Core of [`templatize_dst`], taking the env lookup as a parameter so
+/// unit tests can exercise the path-matching logic against fake roots
+/// instead of mutating process-wide `HOME`/`USERPROFILE`/`APPDATA` —
+/// vars several other tests (`resolve_source`, `expand_tilde`, …) also
+/// depend on for real, so contending over them would be flaky.
+///
+/// Requires a path-separator boundary right after the matched root —
+/// a bare string-prefix test would let `HOME=/home/alice` swallow
+/// `/home/alice2/app` as `{{ env(name='HOME') }}/2/app`, silently
+/// rewriting the marker to point somewhere `apply` would later manage
+/// a directory the absorb never touched. `target == root` (no
+/// trailing component at all) also counts as a boundary match.
+fn templatize_dst_with(
+    target: &Utf8Path,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> (String, Option<&'static str>) {
+    let windows = std::env::consts::OS == "windows";
+    let candidates: &[&str] = if windows {
+        &["LOCALAPPDATA", "APPDATA", "USERPROFILE"]
+    } else {
+        &["XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME", "HOME"]
+    };
+
+    let target_str = target.as_str();
+    for name in candidates {
+        let Some(val) = lookup(name) else {
+            continue;
+        };
+        let val = val.trim_end_matches(['/', '\\']);
+        if val.is_empty() {
+            continue;
+        }
+        let prefix_matches = if windows {
+            target_str.len() >= val.len() && target_str[..val.len()].eq_ignore_ascii_case(val)
+        } else {
+            target_str.len() >= val.len() && target_str.starts_with(val)
+        };
+        // `target_str.len() >= val.len()` above guarantees this index
+        // is in bounds when lengths differ; byte indexing (not `&str`
+        // slicing) needs no char-boundary alignment. An exact-length
+        // match (`target == root`) has no trailing byte to check —
+        // the root itself is a valid boundary.
+        let boundary = prefix_matches
+            && (target_str.len() == val.len()
+                || matches!(target_str.as_bytes()[val.len()], b'/' | b'\\'));
+        if !boundary {
+            continue;
+        }
+        let rest = target_str[val.len()..]
+            .trim_start_matches(['/', '\\'])
+            .replace('\\', "/");
+        let dst = if rest.is_empty() {
+            format!("{{{{ env(name='{name}') }}}}")
+        } else {
+            format!("{{{{ env(name='{name}') }}}}/{rest}")
+        };
+        return (dst, Some(name));
+    }
+    (target_str.replace('\\', "/"), None)
 }
 
 /// Stderr-print a unified diff between `src` (file or dir) and `dst`
@@ -211,12 +428,17 @@ fn prompt_yes_no(question: &str) -> Result<bool> {
     Ok(answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes"))
 }
 
-/// What claims a target: the source path it maps back to, plus the
+/// What claims a target: the source path it maps back to, the
 /// mechanism the claiming declaration asked for (`None` = whatever
-/// `[mount]` says).
+/// `[mount]` says), and whether the match came from an explicit
+/// `[[link]]`/`.yuilink` declaration (`specific`) rather than the
+/// generic mount-derived fallback. `--to` only needs to agree with a
+/// `specific` match — a generic-mount match is exactly what `--to` is
+/// meant to override with a new, more specific declaration.
 pub(crate) struct TargetMatch {
     pub(crate) src: Utf8PathBuf,
     pub(crate) mode: Option<LinkMode>,
+    pub(crate) specific: bool,
 }
 
 /// Walk mount entries + every `[[link]]` declaration (central table and
@@ -229,7 +451,74 @@ fn find_source_for_target(
     engine: &mut template::Engine,
     tera_ctx: &TeraContext,
 ) -> Result<Option<TargetMatch>> {
-    // 1. Mount entries — render dst, see if target is inside it.
+    // 1. `[[link]]` declarations — render each `dst`, see if target is
+    //    that dst (or nested inside a junction'd dir). Marker discovery
+    //    goes through `source_walker`, which skips `.yui/` and honours
+    //    nested `.yuiignore` files, so declarations under ignored
+    //    subtrees stay invisible here too.
+    //
+    //    Checked before generic mount entries: a declared override is
+    //    more specific than the mount-derived default, and the forward
+    //    `apply` walk (`walk_and_link_body`) gives it the same priority
+    //    — it keeps recursing past a dir-scoped ancestor link so a
+    //    nested marker's override still fires. Reverse lookup has to
+    //    agree, or `absorb` proposes a different source than `apply`
+    //    would actually populate.
+    let plan = LinkPlan::from_config(source, &config.link)?;
+    let marker_filename = &config.mount.marker_filename;
+    for dir in plan.declared_dirs(source, marker_filename) {
+        let spec = plan.dir_spec(&dir, marker_filename, true)?;
+        for link in &spec.links {
+            if let Some(when) = &link.when {
+                if !template::eval_truthy(when, engine, tera_ctx)? {
+                    continue;
+                }
+            }
+            let dst_str = engine.render(&link.dst, tera_ctx)?;
+            let dst = paths::expand_tilde(dst_str.trim());
+            // File-scoped entry: dst points at a single file, so a match
+            // resolves directly to `<dir>/<rel>`. Test the target first —
+            // this is a *search* over every declaration, so a stale entry
+            // elsewhere in the config must not abort the lookup for the
+            // path the user actually asked about. Once it matches, mirror
+            // the existence check apply / status do so the message shape
+            // is the same from every entry point.
+            if let Some(rel) = &link.rel {
+                if target != dst {
+                    continue;
+                }
+                let file_src = dir.join(rel);
+                if !file_src.is_file() {
+                    anyhow::bail!("{} not found", link.describe(&dir));
+                }
+                return Ok(Some(TargetMatch {
+                    src: file_src,
+                    mode: link.mode,
+                    specific: true,
+                }));
+            }
+            if target == dst {
+                return Ok(Some(TargetMatch {
+                    src: dir,
+                    mode: link.mode,
+                    specific: true,
+                }));
+            }
+            if let Ok(rel) = target.strip_prefix(&dst) {
+                // A path *inside* a dir-scoped link: what gets relinked
+                // is that file, so the directory's mechanism doesn't
+                // apply to it. Fall back to the file default.
+                return Ok(Some(TargetMatch {
+                    src: dir.join(rel),
+                    mode: None,
+                    specific: true,
+                }));
+            }
+        }
+    }
+
+    // 2. Mount entries — render dst, see if target is inside it. Falls
+    //    back here only when no declared `[[link]]` claimed the target.
     for entry in &config.mount.entry {
         if let Some(when) = &entry.when {
             if !template::eval_truthy(when, engine, tera_ctx)? {
@@ -265,64 +554,66 @@ fn find_source_for_target(
             return Ok(Some(TargetMatch {
                 src: candidate,
                 mode: None,
+                specific: false,
             }));
         }
     }
 
-    // 2. `[[link]]` declarations — render each `dst`, see if target is
-    //    that dst (or nested inside a junction'd dir). Marker discovery
-    //    goes through `source_walker`, which skips `.yui/` and honours
-    //    nested `.yuiignore` files, so declarations under ignored
-    //    subtrees stay invisible here too.
-    let plan = LinkPlan::from_config(source, &config.link)?;
-    let marker_filename = &config.mount.marker_filename;
-    for dir in plan.declared_dirs(source, marker_filename) {
-        let spec = plan.dir_spec(&dir, marker_filename, true)?;
-        for link in &spec.links {
-            if let Some(when) = &link.when {
-                if !template::eval_truthy(when, engine, tera_ctx)? {
-                    continue;
-                }
-            }
-            let dst_str = engine.render(&link.dst, tera_ctx)?;
-            let dst = paths::expand_tilde(dst_str.trim());
-            // File-scoped entry: dst points at a single file, so a match
-            // resolves directly to `<dir>/<rel>`. Test the target first —
-            // this is a *search* over every declaration, so a stale entry
-            // elsewhere in the config must not abort the lookup for the
-            // path the user actually asked about. Once it matches, mirror
-            // the existence check apply / status do so the message shape
-            // is the same from every entry point.
-            if let Some(rel) = &link.rel {
-                if target != dst {
-                    continue;
-                }
-                let file_src = dir.join(rel);
-                if !file_src.is_file() {
-                    anyhow::bail!("{} not found", link.describe(&dir));
-                }
-                return Ok(Some(TargetMatch {
-                    src: file_src,
-                    mode: link.mode,
-                }));
-            }
-            if target == dst {
-                return Ok(Some(TargetMatch {
-                    src: dir,
-                    mode: link.mode,
-                }));
-            }
-            if let Ok(rel) = target.strip_prefix(&dst) {
-                // A path *inside* a dir-scoped link: what gets relinked
-                // is that file, so the directory's mechanism doesn't
-                // apply to it. Fall back to the file default.
-                return Ok(Some(TargetMatch {
-                    src: dir.join(rel),
-                    mode: None,
-                }));
-            }
-        }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod templatize_dst_tests {
+    use super::templatize_dst_with;
+    use camino::Utf8Path;
+
+    // `templatize_dst_with`'s candidate list differs by OS
+    // (LOCALAPPDATA/APPDATA/USERPROFILE on Windows, XDG_*/HOME
+    // elsewhere). Target whichever one it consults last so these
+    // tests exercise the real candidate loop on every CI platform
+    // instead of hardcoding a var name that's only in one list.
+    fn root_var_name() -> &'static str {
+        if cfg!(windows) { "USERPROFILE" } else { "HOME" }
     }
 
-    Ok(None)
+    /// The bug CodeRabbit flagged in PR #276: a bare string-prefix
+    /// test lets a shorter root swallow a sibling directory that only
+    /// shares a name prefix, not a real path-component boundary.
+    #[test]
+    fn does_not_swallow_a_sibling_with_shared_name_prefix() {
+        let root = "/home/alice";
+        let target = Utf8Path::new("/home/alice2/app");
+        let name = root_var_name();
+        let (dst, matched) = templatize_dst_with(target, |n| (n == name).then(|| root.into()));
+        assert_eq!(matched, None, "must not match past a non-boundary prefix");
+        assert_eq!(dst, "/home/alice2/app");
+    }
+
+    #[test]
+    fn matches_at_a_real_path_boundary() {
+        let root = "/home/alice";
+        let target = Utf8Path::new("/home/alice/app/data");
+        let name = root_var_name();
+        let (dst, matched) = templatize_dst_with(target, |n| (n == name).then(|| root.into()));
+        assert_eq!(matched, Some(name));
+        assert_eq!(dst, format!("{{{{ env(name='{name}') }}}}/app/data"));
+    }
+
+    #[test]
+    fn matches_when_target_is_exactly_the_root() {
+        let root = "/home/alice";
+        let target = Utf8Path::new("/home/alice");
+        let name = root_var_name();
+        let (dst, matched) = templatize_dst_with(target, |n| (n == name).then(|| root.into()));
+        assert_eq!(matched, Some(name));
+        assert_eq!(dst, format!("{{{{ env(name='{name}') }}}}"));
+    }
+
+    #[test]
+    fn falls_back_to_literal_path_when_nothing_matches() {
+        let target = Utf8Path::new("/opt/elsewhere/app");
+        let (dst, matched) = templatize_dst_with(target, |_| None);
+        assert_eq!(matched, None);
+        assert_eq!(dst, "/opt/elsewhere/app");
+    }
 }

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -1099,6 +1099,7 @@ dst = "{}"
     absorb(
         Some(source.clone()),
         target.join(".bashrc"),
+        /* to */ None,
         /* dry_run */ false,
         /* yes */ true,
     )
@@ -1138,6 +1139,7 @@ dst = "{}"
     absorb(
         Some(source.clone()),
         target.join("kimi-code"),
+        /* to */ None,
         /* dry_run */ false,
         /* yes */ true,
     )
@@ -1170,6 +1172,7 @@ fn manual_absorb_honors_dir_only_gitignore_for_target_only_dir() {
     let err = absorb(
         Some(source.clone()),
         target.join("sessions"),
+        /* to */ None,
         /* dry_run */ false,
         /* yes */ true,
     )
@@ -1193,7 +1196,7 @@ fn manual_absorb_errors_when_target_outside_known_mounts() {
     let stranger = utf8(tmp.path().join("not-managed/foo"));
     std::fs::create_dir_all(stranger.parent().unwrap()).unwrap();
     std::fs::write(&stranger, "not yui's").unwrap();
-    let err = absorb(Some(source), stranger, false, /* yes */ true).unwrap_err();
+    let err = absorb(Some(source), stranger, None, false, /* yes */ true).unwrap_err();
     assert!(format!("{err}").contains("no mount entry"));
 }
 
@@ -2292,6 +2295,7 @@ mode = "hardlink"
     absorb(
         Some(source.clone()),
         dst_file.clone(),
+        /* to */ None,
         /* dry_run */ false,
         /* yes */ true,
     )


### PR DESCRIPTION
## Problem

`yui absorb <target>`'s reverse lookup (`find_source_for_target`) checked
generic `[[mount.entry]]` entries **before** `[[link]]`/`.yuilink`
declarations. The forward `apply` walk (`walk_and_link_body`) does the
opposite: it keeps recursing past a dir-scoped ancestor link so a nested
marker's override still fires. Result: `absorb` could propose a different
source path than `apply` would actually populate for the same target.

Concretely: with `home/.config` dir-junctioned to `~/.config`, and a nested
`home/.config/<app>/.yuilink` overriding `dst` to `%APPDATA%/<app>`,
`yui absorb` resolved the target back through the generic `home` -> `~`
mount instead of the more specific marker.

## Fix

- Swap the two search passes in `find_source_for_target` so declared
  `[[link]]`/`.yuilink` entries are checked first, generic mount entries
  are the fallback — matching `apply`'s precedence.
- Add `TargetMatch.specific: bool` to distinguish a declared-link match
  from a generic-mount-fallback match (needed by the feature below).

## New: `yui absorb --to <SRC>`

Filing an absorb for a target nothing claims yet used to require
hand-authoring a `.yuilink` marker first. `--to <SRC>` (a path relative to
`$DOTFILES`) now creates that marker on the fly:

- Templatizes the target's absolute path against known env-var roots
  (`LOCALAPPDATA`/`APPDATA`/`USERPROFILE` on Windows,
  `XDG_CONFIG_HOME`/`XDG_CACHE_HOME`/`XDG_DATA_HOME`/`HOME` elsewhere) for
  portability across machines — same convention as hand-written markers
  like `home/.config/shoka/.yuilink`.
- Only fires when nothing *specific* claims the target yet — a generic
  mount-fallback match is exactly what `--to` is meant to override. If a
  *different* specific declaration already claims the target, it bails
  instead of silently redirecting.
- Directory targets only (the realistic app-data-directory case); a file
  target errors with a hint to write the `[[link]]` by hand.

## Verification

- `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets`: clean.
- `cargo test`: 252 passed, 0 failed (4 existing `absorb()` test callsites
  updated for the new `to` parameter).
- Manual smoke test against a throwaway fixture: `--to` creates the marker,
  templatizes via `LOCALAPPDATA`, absorbs directory content, and a
  subsequent `absorb --dry-run` (no `--to`) resolves through the new
  declaration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--to <SRC>` option to `yui absorb <target>`.
  - When the target has no existing source declaration, `absorb` can create the source directory and add a portable `.yuilink` marker automatically.
  - The command refuses to proceed when another declaration already claims the target.

- **Documentation**
  - Updated the `yui absorb` command reference and anomaly-handling guidance with the new option and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->