### PR TITLE
chore: release v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.13.2"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."


### PR DESCRIPTION
Bump version for release: v0.14.0

Includes #276 (yui absorb reverse-lookup precedence fix + new `--to <SRC>` flag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package version from 0.13.2 to 0.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->