### PR TITLE
fix: preserve live directories when relink staging fails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,8 +195,13 @@ before reverting any of them.
   half-deleted target and no link if it was interrupted. Sibling
   placement is mandatory — `rename` is only atomic within one volume,
   which is also why the staging dir is not under `.yui/backup/`.
-  A refused rename (open handles on Windows) warns and falls back to
-  the in-place teardown.
+  A refused rename (open handles on Windows) aborts that operation
+  without merging or deleting the live target. Never fall back to
+  in-place teardown. If link creation fails after staging, restore the
+  original target when its path is still absent; otherwise retain the
+  staged tree and report its recovery path without deleting the new
+  occupant. Rollback uses an atomic no-replace rename; a metadata
+  existence check followed by ordinary rename is not sufficient.
 - **The staging name is the crash journal.** `Absorb` means "content
   may not have reached source yet → merge, then delete"; `Discard`
   means "already in `.yui/backup/` → delete unread". Each invariant is
@@ -205,7 +210,10 @@ before reverting any of them.
   state file. `recover_staged` runs at the top of
   `link_dir_with_backup`, **before `absorb::classify`** — a recovered
   target reads `InSync`, so classifying first would strand the
-  leftover. Recovery is idempotent: re-merging an already-merged tree
+  leftover. Recovery must first prove the target resolves to source
+  (installing the link if the target is absent); an unrelated target
+  blocks recovery without merging or deleting staging. Recovery is
+  idempotent: re-merging an already-merged tree
   is per-file content-classified, hence a no-op.
 - **backup path scheme**: mirror absolute target into
   `$DOTFILES/.yui/backup/<abs-path>` with the drive colon stripped on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3901,6 +3901,7 @@ dependencies = [
  "kaishin",
  "owo-colors",
  "predicates",
+ "rustix 1.1.4",
  "same-file",
  "serde",
  "serde_json",
@@ -3915,6 +3916,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "whoami",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,10 @@ whoami = "2.1.3"
 
 [target.'cfg(windows)'.dependencies]
 junction = "2.0.0"
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+rustix = { version = "1.1.4", features = ["fs"] }
 
 [dev-dependencies]
 assert_cmd = "2.2.2"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,15 @@ reached `$DOTFILES/.yui/backup/` before the rename). Recovery runs
 ahead of the classifier on purpose — a relinked target reads `InSync`,
 so classification alone would walk right past the leftover. If the
 rename itself is refused — a file held open inside the tree on
-Windows, say — `yui` warns and falls back to deleting in place.
+Windows, say — `yui` stops that operation and leaves the live target
+unchanged. Close the applications using it and retry. There is no
+in-place deletion fallback. If link creation fails after staging,
+`yui` restores the original target when its path is still absent.
+If restoration is blocked, it keeps the staged tree and reports its
+path for recovery. Restoration uses an atomic no-replace rename, so a
+concurrent destination is never overwritten. On retry, staging is
+consumed only after the live target resolves to source; an unrelated
+target blocks recovery without changing source or the staged tree.
 
 ## Install
 

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -946,7 +946,7 @@ pub(crate) fn link_dir_with_backup(
     // Order matters: a recovered target reads `InSync`, so classify
     // would walk away and strand target-side content that never made
     // it into source.
-    recover_staged(src, dst, ctx)?;
+    recover_staged(src, dst, ctx, mode)?;
     if ctx.quit_requested.get() {
         return Ok(());
     }
@@ -971,9 +971,7 @@ pub(crate) fn link_dir_with_backup(
             // for symmetry with the file path: contents already match,
             // so just swap the target for a junction to source.
             info!("relink dir: {src} → {dst}");
-            remove_dir_link_or_real(dst)?;
-            link::link_dir(src, dst, mode)?;
-            Ok(())
+            overwrite_source_dir_into_target(src, dst, ctx, mode)
         }
         AutoAbsorb | NeedsConfirm => {
             // Reaching `link_dir_with_backup` means we're acting on a
@@ -1272,12 +1270,10 @@ fn merge_resolve_file_conflict(
 /// `Ok(None)` means `dst` was genuinely absent; the caller just links.
 /// `Err` means we could not stage: the rename was refused (open
 /// handles inside the tree on Windows, a mount point in the way,
-/// permissions), or `dst` could not even be stat'd. Neither is fatal
-/// — callers warn and fall back to the in-place teardown, which is
-/// exactly what yui did before staging existed. What we must not do
-/// is treat an unreadable-but-present `dst` as absent: that skips the
-/// backup and the merge, and hands the caller a `link_dir` that fails
-/// with "already exists" instead of the real cause.
+/// permissions), or `dst` could not even be stat'd. Callers must stop
+/// this operation and leave the live target unchanged. Falling back
+/// to recursive deletion could partially destroy it before a link
+/// exists. An unreadable-but-present target must not count as absent.
 fn stage_aside(dst: &Utf8Path, kind: paths::StagedKind) -> Result<Option<Utf8PathBuf>> {
     match std::fs::symlink_metadata(dst) {
         Ok(_) => {}
@@ -1289,6 +1285,38 @@ fn stage_aside(dst: &Utf8Path, kind: paths::StagedKind) -> Result<Option<Utf8Pat
         .with_context(|| format!("cannot derive a staging name for {dst}"))?;
     std::fs::rename(dst, &staged).with_context(|| format!("stage aside {dst} → {staged}"))?;
     Ok(Some(staged))
+}
+
+fn staging_failure_message(dst: &Utf8Path) -> String {
+    format!(
+        "cannot safely relink {dst}: target left unchanged; \
+         Close applications using this directory, check permissions, and retry"
+    )
+}
+
+/// A failed link must not strand the original target under the staging name.
+/// Never remove a destination that appeared in the meantime: it may belong to
+/// another process, or be a partial result of a failed link operation.
+fn link_staged_dir(
+    src: &Utf8Path,
+    dst: &Utf8Path,
+    staged: &Utf8Path,
+    mode: EffectiveDirMode,
+) -> Result<()> {
+    if let Err(error) = link::link_dir(src, dst, mode) {
+        let restored = link::rename_dir_noreplace(staged, dst)
+            .with_context(|| format!("restore {staged} → {dst}"));
+        return match restored {
+            Ok(()) => Err(anyhow::Error::new(error).context(format!(
+                "cannot link {src} → {dst}; original target restored"
+            ))),
+            Err(restore_error) => Err(anyhow::Error::new(error).context(format!(
+                "cannot link {src} → {dst}; original target retained at {staged}; \
+                 restoration failed: {restore_error:#}"
+            ))),
+        };
+    }
+    Ok(())
 }
 
 /// Delete a staged tree.
@@ -1328,11 +1356,42 @@ fn unstage(staged: &Utf8Path, dst: &Utf8Path) -> Result<()> {
 /// its snapshot before staging, and the merge below is
 /// content-classified per file, so re-running it over an
 /// already-merged tree is a no-op rather than a second overwrite.
-fn recover_staged(src: &Utf8Path, dst: &Utf8Path, ctx: &ApplyCtx<'_>) -> Result<()> {
+fn recover_staged(
+    src: &Utf8Path,
+    dst: &Utf8Path,
+    ctx: &ApplyCtx<'_>,
+    mode: EffectiveDirMode,
+) -> Result<()> {
     for (staged, kind) in paths::scan_staged(dst) {
         if ctx.dry_run {
             info!("[dry-run] finish interrupted {kind:?} staging: {staged}");
             continue;
+        }
+        // A failed installation can leave staging beside an unrelated target.
+        // Prove the live path resolves to source before consuming any recovery
+        // tree. If the process died before linking, install the link first.
+        match std::fs::symlink_metadata(dst) {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                if !src.is_dir() {
+                    anyhow::bail!("cannot recover {staged}: source directory {src} is missing");
+                }
+                link_staged_dir(src, dst, &staged, mode)?;
+            }
+            Ok(_) => {
+                if !same_file::is_same_file(src, dst).with_context(|| {
+                    format!("verify {dst} links to {src}; recovery tree retained at {staged}")
+                })? {
+                    anyhow::bail!(
+                        "cannot recover {staged}: {dst} does not link to {src}; \
+                         target, source, and recovery tree left unchanged"
+                    );
+                }
+            }
+            Err(e) => {
+                return Err(anyhow::Error::new(e).context(format!(
+                    "stat {dst} before recovery; recovery tree retained at {staged}"
+                )));
+            }
         }
         match kind {
             paths::StagedKind::Absorb => {
@@ -1381,29 +1440,16 @@ pub(crate) fn absorb_target_dir_into_source(
     info!("absorb dir: {dst} → {src}");
     backup_existing(src, ctx.backup_root, /* is_dir */ true)?;
 
-    let staged = match stage_aside(dst, paths::StagedKind::Absorb) {
-        Ok(Some(staged)) => staged,
+    let staged = match stage_aside(dst, paths::StagedKind::Absorb)
+        .with_context(|| staging_failure_message(dst))?
+    {
+        Some(staged) => staged,
         // Target vanished under us between classify and now — there is
         // nothing left to absorb, so just expose source.
-        Ok(None) => return link::link_dir(src, dst, mode).map_err(Into::into),
-        Err(e) => {
-            warn!("cannot stage {dst} aside ({e:#}) — falling back to in-place teardown");
-            merge_dir_target_into_source(dst, src, ctx)?;
-            if ctx.quit_requested.get() {
-                warn!(
-                    "absorb dir interrupted by user quit: {dst} \
-                     — leaving target tree intact; source backup at {}",
-                    ctx.backup_root
-                );
-                return Ok(());
-            }
-            remove_dir_link_or_real(dst)?;
-            link::link_dir(src, dst, mode)?;
-            return Ok(());
-        }
+        None => return link::link_dir(src, dst, mode).map_err(Into::into),
     };
 
-    link::link_dir(src, dst, mode)?;
+    link_staged_dir(src, dst, &staged, mode)?;
     merge_dir_target_into_source(&staged, src, ctx)?;
 
     // If the user picked `[q]uit` at a prompt during the merge, put the
@@ -1439,17 +1485,14 @@ fn overwrite_source_dir_into_target(
 ) -> Result<()> {
     info!("overwrite dir: {src} → {dst}");
     backup_existing(dst, ctx.backup_root, /* is_dir */ true)?;
-    match stage_aside(dst, paths::StagedKind::Discard) {
-        Ok(Some(staged)) => {
-            link::link_dir(src, dst, mode)?;
+    match stage_aside(dst, paths::StagedKind::Discard)
+        .with_context(|| staging_failure_message(dst))?
+    {
+        Some(staged) => {
+            link_staged_dir(src, dst, &staged, mode)?;
             remove_staged(&staged);
         }
-        Ok(None) => link::link_dir(src, dst, mode)?,
-        Err(e) => {
-            warn!("cannot stage {dst} aside ({e:#}) — falling back to in-place teardown");
-            remove_dir_link_or_real(dst)?;
-            link::link_dir(src, dst, mode)?;
-        }
+        None => link::link_dir(src, dst, mode)?,
     }
     Ok(())
 }
@@ -1513,3 +1556,6 @@ fn backup_existing(target: &Utf8Path, backup_root: &Utf8Path, is_dir: bool) -> R
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod staging_tests;

--- a/src/cmd/apply/staging_tests.rs
+++ b/src/cmd/apply/staging_tests.rs
@@ -1,0 +1,243 @@
+use super::*;
+use tempfile::TempDir;
+
+fn with_ctx(test: impl FnOnce(&Utf8Path, &ApplyCtx<'_>)) {
+    let tmp = TempDir::new().unwrap();
+    let root = Utf8Path::from_path(tmp.path()).unwrap();
+    let config = Config::default();
+    let plan = LinkPlan::default();
+    let backup_root = root.join("backup");
+    let ctx = ApplyCtx {
+        config: &config,
+        plan: &plan,
+        file_mode: resolve_file_mode(config.mount.file_mode),
+        dir_mode: resolve_dir_mode(config.mount.dir_mode),
+        backup_root: &backup_root,
+        dry_run: false,
+        sticky_anomaly: Cell::new(None),
+        quit_requested: Cell::new(false),
+        source_clean: true,
+        unresolved: RefCell::new(Vec::new()),
+    };
+    test(root, &ctx);
+}
+
+#[cfg(windows)]
+fn check_locked_target(overwrite: bool) {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    with_ctx(|root, ctx| {
+        let src = root.join("source");
+        let dst = root.join("target");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::create_dir_all(dst.join("nested")).unwrap();
+        std::fs::write(src.join("source-only"), "source").unwrap();
+        std::fs::write(dst.join("config.toml"), "original settings").unwrap();
+        std::fs::write(dst.join("nested/keep"), "original data").unwrap();
+
+        // A directory handle without FILE_SHARE_DELETE denies staging while
+        // leaving its children deletable: the old fallback destroyed them.
+        let handle = std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(0x1 | 0x2) // FILE_SHARE_READ | FILE_SHARE_WRITE
+            .custom_flags(0x0200_0000) // FILE_FLAG_BACKUP_SEMANTICS
+            .open(&dst)
+            .unwrap();
+        let result = if overwrite {
+            overwrite_source_dir_into_target(&src, &dst, ctx, ctx.dir_mode)
+        } else {
+            absorb_target_dir_into_source(&src, &dst, ctx, ctx.dir_mode)
+        };
+        let error = format!("{:#}", result.unwrap_err());
+        assert!(error.contains("target left unchanged"), "{error}");
+        assert!(error.contains("Close applications"), "{error}");
+        assert!(
+            !std::fs::symlink_metadata(&dst)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(
+            std::fs::read_to_string(dst.join("config.toml")).unwrap(),
+            "original settings"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dst.join("nested/keep")).unwrap(),
+            "original data"
+        );
+        assert_eq!(
+            std::fs::read_to_string(src.join("source-only")).unwrap(),
+            "source"
+        );
+        assert!(
+            !src.join("config.toml").exists(),
+            "failed staging must not merge"
+        );
+        assert!(
+            !src.join("nested").exists(),
+            "failed staging must not merge"
+        );
+        assert!(paths::scan_staged(&dst).is_empty());
+
+        drop(handle);
+        if overwrite {
+            overwrite_source_dir_into_target(&src, &dst, ctx, ctx.dir_mode).unwrap();
+        } else {
+            absorb_target_dir_into_source(&src, &dst, ctx, ctx.dir_mode).unwrap();
+            assert_eq!(
+                std::fs::read_to_string(dst.join("nested/keep")).unwrap(),
+                "original data"
+            );
+        }
+        assert_eq!(
+            absorb::classify(&src, &dst).unwrap(),
+            absorb::AbsorbDecision::InSync
+        );
+        assert!(paths::scan_staged(&dst).is_empty());
+    });
+}
+
+#[test]
+#[cfg(windows)]
+fn absorb_preserves_locked_target_without_merging() {
+    check_locked_target(false);
+}
+
+#[test]
+#[cfg(windows)]
+fn overwrite_preserves_locked_target() {
+    check_locked_target(true);
+}
+
+fn check_failed_link(overwrite: bool) {
+    with_ctx(|root, ctx| {
+        let dst = root.join("target");
+        std::fs::create_dir_all(dst.join("nested")).unwrap();
+        std::fs::write(dst.join("nested/keep"), "original data").unwrap();
+        // NUL makes link creation fail on every OS without needing privileges
+        // or changing global process state. The target can still be staged.
+        let src = root.join("invalid\0source");
+        let result = if overwrite {
+            overwrite_source_dir_into_target(&src, &dst, ctx, EffectiveDirMode::Symlink)
+        } else {
+            absorb_target_dir_into_source(&src, &dst, ctx, EffectiveDirMode::Symlink)
+        };
+        let error = format!("{:#}", result.unwrap_err());
+        assert!(error.contains("original target restored"), "{error}");
+        assert!(
+            !std::fs::symlink_metadata(&dst)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(
+            std::fs::read_to_string(dst.join("nested/keep")).unwrap(),
+            "original data"
+        );
+        assert!(paths::scan_staged(&dst).is_empty());
+    });
+}
+
+#[test]
+fn absorb_restores_target_when_link_creation_fails() {
+    check_failed_link(false);
+}
+
+#[test]
+fn overwrite_restores_target_when_link_creation_fails() {
+    check_failed_link(true);
+}
+
+#[test]
+fn failed_link_retains_staging_when_destination_is_occupied() {
+    with_ctx(|root, ctx| {
+        let src = root.join("source");
+        let dst = root.join("target");
+        let staged =
+            paths::staged_path(&dst, paths::StagedKind::Absorb, "20260101_000000000").unwrap();
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::create_dir_all(&staged).unwrap();
+        std::fs::write(staged.join("keep"), "original data").unwrap();
+        std::fs::write(&dst, "new occupant").unwrap();
+
+        let error = format!(
+            "{:#}",
+            link_staged_dir(&src, &dst, &staged, ctx.dir_mode).unwrap_err()
+        );
+        assert!(error.contains("original target retained at"), "{error}");
+        assert!(error.contains(staged.as_str()), "{error}");
+        assert_eq!(std::fs::read_to_string(&dst).unwrap(), "new occupant");
+        assert_eq!(
+            std::fs::read_to_string(staged.join("keep")).unwrap(),
+            "original data"
+        );
+    });
+}
+
+#[test]
+fn rollback_never_replaces_an_existing_empty_directory() {
+    with_ctx(|root, _ctx| {
+        let staged = root.join("staged");
+        let dst = root.join("target");
+        std::fs::create_dir_all(&staged).unwrap();
+        std::fs::create_dir_all(&dst).unwrap();
+        std::fs::write(staged.join("keep"), "original data").unwrap();
+        let before = same_file::Handle::from_path(&dst).unwrap();
+
+        assert!(link::rename_dir_noreplace(&staged, &dst).is_err());
+        assert_eq!(before, same_file::Handle::from_path(&dst).unwrap());
+        assert_eq!(std::fs::read_dir(&dst).unwrap().count(), 0);
+        assert_eq!(
+            std::fs::read_to_string(staged.join("keep")).unwrap(),
+            "original data"
+        );
+        drop(before);
+
+        std::fs::remove_dir(&dst).unwrap();
+        link::rename_dir_noreplace(&staged, &dst).unwrap();
+        assert!(!staged.exists());
+        assert_eq!(
+            std::fs::read_to_string(dst.join("keep")).unwrap(),
+            "original data"
+        );
+    });
+}
+
+#[test]
+fn retry_preserves_blocked_recovery_until_the_link_can_be_installed() {
+    for kind in [paths::StagedKind::Absorb, paths::StagedKind::Discard] {
+        with_ctx(|root, ctx| {
+            let src = root.join("source");
+            let dst = root.join("target");
+            let staged = paths::staged_path(&dst, kind, "20260101_000000000").unwrap();
+            std::fs::create_dir_all(&src).unwrap();
+            std::fs::create_dir_all(&staged).unwrap();
+            std::fs::write(src.join("source-only"), "source").unwrap();
+            std::fs::write(staged.join("keep"), "original data").unwrap();
+            std::fs::write(&dst, "new occupant").unwrap();
+            assert!(link_staged_dir(&src, &dst, &staged, ctx.dir_mode).is_err());
+
+            let error = format!(
+                "{:#}",
+                link_dir_with_backup(&src, &dst, ctx, ctx.dir_mode).unwrap_err()
+            );
+            assert!(error.contains("does not link to"), "{error}");
+            assert_eq!(std::fs::read_to_string(&dst).unwrap(), "new occupant");
+            assert_eq!(
+                std::fs::read_to_string(staged.join("keep")).unwrap(),
+                "original data"
+            );
+            assert_eq!(
+                std::fs::read_to_string(src.join("source-only")).unwrap(),
+                "source"
+            );
+            assert!(!src.join("keep").exists());
+
+            std::fs::remove_file(&dst).unwrap();
+            link_dir_with_backup(&src, &dst, ctx, ctx.dir_mode).unwrap();
+            assert!(same_file::is_same_file(&src, &dst).unwrap());
+            assert!(!staged.exists());
+            assert_eq!(src.join("keep").exists(), kind == paths::StagedKind::Absorb);
+        });
+    }
+}

--- a/src/link.rs
+++ b/src/link.rs
@@ -74,6 +74,52 @@ pub fn link_dir(src: &Utf8Path, dst: &Utf8Path, mode: EffectiveDirMode) -> Resul
     Ok(())
 }
 
+/// Rename a directory atomically without replacing any destination, including
+/// an empty directory created by another process during rollback.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn rename_dir_noreplace(src: &Utf8Path, dst: &Utf8Path) -> std::io::Result<()> {
+    use rustix::fs::{CWD, RenameFlags, renameat_with};
+    renameat_with(
+        CWD,
+        src.as_std_path(),
+        CWD,
+        dst.as_std_path(),
+        RenameFlags::NOREPLACE,
+    )
+    .map_err(Into::into)
+}
+
+#[cfg(windows)]
+pub(crate) fn rename_dir_noreplace(src: &Utf8Path, dst: &Utf8Path) -> std::io::Result<()> {
+    use windows_sys::Win32::Storage::FileSystem::MoveFileExW;
+    fn wide(path: &Utf8Path) -> std::io::Result<Vec<u16>> {
+        if path.as_str().contains('\0') {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "path contains NUL",
+            ));
+        }
+        Ok(path.as_str().encode_utf16().chain(Some(0)).collect())
+    }
+    let src = wide(src)?;
+    let dst = wide(dst)?;
+    // SAFETY: both buffers are valid NUL-terminated UTF-16 for this call.
+    // No MOVEFILE_REPLACE_EXISTING flag: a concurrent destination must survive.
+    if unsafe { MoveFileExW(src.as_ptr(), dst.as_ptr(), 0) } != 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+pub(crate) fn rename_dir_noreplace(_src: &Utf8Path, _dst: &Utf8Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "atomic no-replace directory rename is unavailable on this platform",
+    ))
+}
+
 /// Remove a yui-managed link. No-op if the path doesn't exist. Refuses to
 /// recursively delete a regular directory with contents.
 pub fn unlink(dst: &Utf8Path) -> Result<()> {


### PR DESCRIPTION
When a Windows handle prevents directory staging, yui currently falls back to recursively deleting the live target before creating its replacement link. A failed removal can leave an active configuration directory partially deleted. Absorb and overwrite now abort staging failures, preserving the live target and avoiding a source merge.

A link failure after staging restores the original directory with an atomic no-replace rename. If rollback is blocked, yui preserves the staging tree and reports its path. Recovery on later runs must verify or install the source link before merging or deleting staging; an unrelated target blocks recovery without changing either tree. The README and agent guidance document these guarantees.

Closes #280.

Validation:
- Four regression cases failed against the original implementation; all seven final regression tests pass.
- Windows handle tests verify unchanged original files, no source merge, and successful retry after releasing the handle for absorb and overwrite.
- Tests also cover link failures, occupied rollback destinations (including empty directories), and safe retries for both absorb and discard staging.
- All 263 unit tests, formatting, clippy with warnings denied, doc tests, and locked dependency checks passed locally.
- EditorConfig passed for every `jj file list` entry. In a non-colocated jj workspace, pass tracked files explicitly to avoid scanning ignored vendored `apm_modules`; the rest of the gate passed with `cargo make --skip-tasks '^editorconfig-check$' check`.
- Magi run `20260907-011545-8a5e` reviewed commit `66c48ab`: both reviewers completed without timeout and reported no findings. Its regression verification and full `cargo make check` gate passed. CodeRabbit verified both follow-up fixes; both review threads are resolved. All three OS CI matrices passed.
