### PR TITLE
chore: release v0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "yui-cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yui-cli"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Target-as-truth dotfiles manager: edit your live configs, source repo updates automatically via hardlink/junction/symlink."


### PR DESCRIPTION
Release the directory-relink data-preservation fix from #281 (#280).

Bump `yui-cli` from 0.14.0 to 0.14.1 and synchronize Cargo.lock. No other changes. Merging triggers the automatic tag, cross-platform release builds, and crates.io publication.

Validation: all 263 unit tests, formatting, clippy, doc tests, locked dependency checks, and EditorConfig for all tracked files passed locally. Version-only release PR; the code change already passed magi review, CodeRabbit follow-up review, and all three OS CI matrices in #281.
